### PR TITLE
Bump MSRV to 1.87 and nalgebra to the 0.34 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,7 +1419,41 @@ checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
+ "nalgebra-macros 0.2.2",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros 0.3.0",
  "num-complex",
  "num-rational",
  "num-traits",
@@ -1324,6 +1466,17 @@ name = "nalgebra-macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1585,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
 dependencies = [
  "libc",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-complex",
  "num-integer",
@@ -2003,7 +2156,7 @@ dependencies = [
  "approx",
  "hashbrown 0.15.5",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-bigint",
  "num-complex",
@@ -2047,7 +2200,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.15.5",
  "indexmap",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-complex",
  "pyo3",
@@ -2080,7 +2233,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "nom",
  "nom-language",
@@ -2107,7 +2260,7 @@ version = "2.5.0-dev"
 dependencies = [
  "hashbrown 0.15.5",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-complex",
  "numpy",
@@ -2206,7 +2359,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "ndarray-einsum",
  "num-complex",
@@ -2236,7 +2389,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-complex",
  "num-traits",
@@ -2269,7 +2422,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "itertools 0.14.0",
- "nalgebra",
+ "nalgebra 0.34.2",
  "ndarray",
  "num-complex",
  "numpy",
@@ -2535,7 +2688,7 @@ dependencies = [
  "dashu-int",
  "env_logger",
  "log",
- "nalgebra",
+ "nalgebra 0.33.3",
  "num",
  "num-traits",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "2.5.0-dev"
 edition = "2024"
-rust-version = "1.85"  # Keep in sync with README.md, rust-toolchain.toml, and tools/install_rust_msrv.sh
+rust-version = "1.87"  # Keep in sync with README.md, rust-toolchain.toml, and tools/install_rust_msrv.sh
 license = "Apache-2.0"
 
 # Shared dependencies that can be inherited.  This just helps a little with
@@ -20,7 +20,7 @@ indexmap.version = "2.10.0"
 hashbrown.version = "0.15.5"
 num-bigint = "0.4"
 num-complex = "0.4"
-nalgebra = "0.33"
+nalgebra = "0.34"
 faer = "0.24"
 numpy = "0.28"
 ndarray = "0.16"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/qiskit.svg)](https://pypi.org/project/qiskit/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
-[![Minimum rustc 1.85](https://img.shields.io/badge/rustc-1.85+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.87](https://img.shields.io/badge/rustc-1.87+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Downloads](https://static.pepy.tech/badge/qiskit)](https://pepy.tech/project/qiskit)<!--- long-description-skip-end -->
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2583252.svg)](https://doi.org/10.5281/zenodo.2583252)
 

--- a/crates/circuit_library/src/entanglement.rs
+++ b/crates/circuit_library/src/entanglement.rs
@@ -87,7 +87,7 @@ fn shift_circular_alternating(
     let shifted = circular(num_qubits, block_size)
         .skip(split as usize)
         .chain(circular(num_qubits, block_size).take(split as usize));
-    if offset % 2 == 0 {
+    if offset.is_multiple_of(2) {
         Box::new(shifted)
     } else {
         // if the offset is odd, reverse the indices inside the qubit block (e.g. turn CX

--- a/crates/circuit_library/src/pauli_feature_map.rs
+++ b/crates/circuit_library/src/pauli_feature_map.rs
@@ -201,7 +201,7 @@ fn _default_reduce(parameters: Vec<Param>) -> Param {
         let acc = parameters.iter().fold(Param::Float(1.0), |acc, param| {
             multiply_params(acc, add_param(param, -PI))
         });
-        if parameters.len() % 2 == 0 {
+        if parameters.len().is_multiple_of(2) {
             acc
         } else {
             multiply_param(&acc, -1.0) // take care of parity

--- a/crates/circuit_library/src/suzuki_trotter.rs
+++ b/crates/circuit_library/src/suzuki_trotter.rs
@@ -36,7 +36,7 @@ pub fn suzuki_trotter_evolution(
     preserve_order: bool,
     insert_barriers: bool,
 ) -> Result<CircuitData, EvolutionError> {
-    if order > 1 && order % 2 != 0 || order == 0 {
+    if order > 1 && !order.is_multiple_of(2) || order == 0 {
         return Err(EvolutionError::OrderSymmetry(order));
     }
 

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -383,7 +383,10 @@ impl MatrixCompressedPaulis {
                 // Technically this discards part of the storable data, but in practice, a dense
                 // operator with more than 32 qubits needs in the region of 1 ZiB memory.  We still use
                 // `u64` to help sparse-matrix construction, though.
-                let coeff = if (i_row as u32 & z_like as u32).count_ones() % 2 == 0 {
+                let coeff = if (i_row as u32 & z_like as u32)
+                    .count_ones()
+                    .is_multiple_of(2)
+                {
                     coeff
                 } else {
                     -coeff

--- a/crates/quantum_info/src/unitary_compose.rs
+++ b/crates/quantum_info/src/unitary_compose.rs
@@ -87,7 +87,7 @@ fn _einsum_matmul(
 ) -> Result<Array<Complex64, IxDyn>, &'static str> {
     let rank = tensor.ndim();
     let rank_mat = mat.ndim();
-    if rank_mat % 2 != 0 {
+    if !rank_mat.is_multiple_of(2) {
         return Err("Contracted matrix must have an even number of indices.");
     }
     // Get einsum indices for tensor

--- a/crates/synthesis/src/linear/pmh.rs
+++ b/crates/synthesis/src/linear/pmh.rs
@@ -31,7 +31,7 @@ fn _index(transpose: bool, i: usize, j: usize) -> (usize, usize) {
 
 fn _ceil_fraction(numerator: usize, denominator: usize) -> usize {
     let mut fraction = numerator / denominator;
-    if numerator % denominator > 0 {
+    if !numerator.is_multiple_of(denominator) {
         fraction += 1;
     }
     fraction

--- a/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
@@ -150,7 +150,7 @@ fn _update_phase_schedule(
                     (k != i)
                         && (k != j)
                         && (order_comp[min(k, j)] < order_comp[i])
-                        && (phase_schedule[[min(k, j), max(k, j)]] % 4 != 0)
+                        && !phase_schedule[[min(k, j), max(k, j)]].is_multiple_of(4)
                 })
                 .collect();
 

--- a/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
@@ -76,13 +76,13 @@ fn _create_patterns(n: usize) -> HashMap<(usize, usize), (usize, usize)> {
         return HashMap::from_iter((0..n).map(|i| ((0, i), (i, i))));
     }
 
-    let (pat1, pat2) = if n % 2 == 0 {
+    let (pat1, pat2) = if n.is_multiple_of(2) {
         (_even_pattern1(n), _even_pattern2(n))
     } else {
         (_odd_pattern1(n), _odd_pattern2(n))
     };
 
-    let ind = if n % 2 == 0 {
+    let ind = if n.is_multiple_of(2) {
         (2 * n - 4) / 2
     } else {
         (2 * n - 4) / 2 - 1
@@ -157,7 +157,7 @@ pub(super) fn synth_cz_depth_line_mr_inner(matrix: ArrayView2<bool>) -> (usize, 
         s_gates = Array1::<usize>::zeros(num_qubits);
     }
 
-    if num_qubits % 2 == 0 {
+    if num_qubits.is_multiple_of(2) {
         let i = num_qubits / 2;
 
         for j in 0..num_qubits {

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -685,7 +685,7 @@ fn synth_relative_mcx_n_dirty(num_controls: usize) -> Result<CircuitData, Circui
 ///
 /// A quantum circuit with :math:`n+1` qubits.
 fn increment_1_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
-    if n % 2 == 0 {
+    if n.is_multiple_of(2) {
         return Err(QiskitError::new_err(
             "increment_1_dirty_large requires an odd number of qubits.",
         ));
@@ -905,7 +905,7 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
         // The construction described in Fig.8 of the paper works for all values of n and is better than the one
         // in Fig.7 when n<23.
 
-        if (n % 2 == 0) && (n >= 23) {
+        if n.is_multiple_of(2) && (n >= 23) {
             // This implements C^{n-1}(V) in Fig.7.
 
             // These implement U^{n-1}_{+1} and U^{n-1}_{-1} (last qubit is ancilla)

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -171,7 +171,7 @@ pub(crate) fn _append_reverse_permutation_lnn_kms(gates: &mut LnnGatesVec, num_q
         _append_cx_stage2(gates, num_qubits);
     });
 
-    if num_qubits % 2 == 0 {
+    if num_qubits.is_multiple_of(2) {
         _append_cx_stage1(gates, num_qubits);
     }
 }

--- a/releasenotes/notes/msrv-187-fe3d9818f5c4103d.yaml
+++ b/releasenotes/notes/msrv-187-fe3d9818f5c4103d.yaml
@@ -1,0 +1,8 @@
+---
+build:
+  - The minimum supported Rust version (MSRV) for building Qiskit from source
+    has been increased from 1.85 to 1.87. Rust 1.87 was required to update
+    to the latest versions of our upstream dependencies. Specifically
+    `nalgebra <https://github.com/dimforge/nalgebra>`__ latest release require
+    Rust 1.87.
+

--- a/releasenotes/notes/msrv-187-fe3d9818f5c4103d.yaml
+++ b/releasenotes/notes/msrv-187-fe3d9818f5c4103d.yaml
@@ -2,7 +2,7 @@
 build:
   - The minimum supported Rust version (MSRV) for building Qiskit from source
     has been increased from 1.85 to 1.87. Rust 1.87 was required to update
-    to the latest versions of our upstream dependencies. Specifically
-    `nalgebra <https://github.com/dimforge/nalgebra>`__ latest release require
+    to the latest versions of our upstream dependencies. Specifically,
+    `nalgebra 0.34 <https://github.com/dimforge/nalgebra>`__ requires
     Rust 1.87.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Keep in sync with Cargo.toml's `rust-version`.
-channel = "1.85"
+channel = "1.87"
 components = [
   "cargo",
   "clippy",

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -3,7 +3,7 @@ if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.85
+    rustup default 1.87
     rustup component add llvm-tools
     rustup uninstall stable
 fi


### PR DESCRIPTION
This commit updates nalgebra to the latest release 0.34 and also increases our MSRV to the minimum version compatible with that nalgebra release 1.87. Nalgebra 0.34 was release in July of 2025 and we didn't upgrade at the time because we had just increased our msrv to 1.85 and bumping it again would have been overly onerous. But since we're now using nalgebra more in critical code paths (2q decomposition) it makes sense to make this change now especially since rust 1.87 is over 1 year old now (being release in March 2025).

The rust code changes made in this are to fix clippy warnings due to new clippy rules being enabled with the higher msrv of 1.87.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
