### PR TITLE
Fix stable clippy warnings

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -984,12 +984,12 @@ impl CircuitData {
     pub fn pack(&mut self, py: Python, inst: &CircuitInstruction) -> PyResult<PackedInstruction> {
         let qubits = self.qargs_interner.insert_owned(
             self.qubits
-                .map_objects(inst.qubits.extract::<Vec<ShareableQubit>>(py)?.into_iter())?
+                .map_objects(inst.qubits.extract::<Vec<ShareableQubit>>(py)?)?
                 .collect(),
         );
         let clbits = self.cargs_interner.insert_owned(
             self.clbits
-                .map_objects(inst.clbits.extract::<Vec<ShareableClbit>>(py)?.into_iter())?
+                .map_objects(inst.clbits.extract::<Vec<ShareableClbit>>(py)?)?
                 .collect(),
         );
         let params = self.extract_blocks_from_circuit_parameters(inst.params.as_ref());

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6391,8 +6391,7 @@ impl DAGCircuit {
                         op_node
                             .instruction
                             .qubits
-                            .extract::<Vec<ShareableQubit>>(py)?
-                            .into_iter(),
+                            .extract::<Vec<ShareableQubit>>(py)?,
                     )?
                     .collect(),
             );
@@ -6402,8 +6401,7 @@ impl DAGCircuit {
                         op_node
                             .instruction
                             .clbits
-                            .extract::<Vec<ShareableClbit>>(py)?
-                            .into_iter(),
+                            .extract::<Vec<ShareableClbit>>(py)?,
                     )?
                     .collect(),
             );

--- a/crates/synthesis/src/discrete_basis/math.rs
+++ b/crates/synthesis/src/discrete_basis/math.rs
@@ -106,10 +106,8 @@ fn rotation_axis_from_so3(matrix: &Matrix3<f64>, do_checks: bool) -> Matrix3x1<f
                 axis[2] *= -1.;
             }
         }
-        1 => {
-            if matrix[(1, 2)] < 0. {
-                axis[2] *= -1.;
-            }
+        1 if matrix[(1, 2)] < 0. => {
+            axis[2] *= -1.;
         }
         _ => (),
     };


### PR DESCRIPTION
This commit fixes clippy warnings that appear when running clippy from the latest stable Rust release 1.95.0. Fixing this preemptively will avoid errors when we try to bump our MSRV in the future and also fix the error for those of use that insist on testing with the latest stable release of Rust and are seeing clippy complain about this.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
