### PR TITLE
Improve LieTrotter synthesis for a special Z-only cubic pattern

### DIFF
--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -15,12 +15,110 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp
 import qiskit.quantum_info
 
+from .product_formula import real_or_fail
 from .suzuki_trotter import SuzukiTrotter
+
+
+@dataclass(frozen=True)
+class _SpecialZOnlyCubicMatch:
+    """Canonical representation of the narrow Z-only `{2, 2, 3}` pattern."""
+
+    pivot: int
+    leaf_a: int
+    leaf_b: int
+    coeff_leaf_a_pivot: float | Any
+    coeff_pivot_leaf_b: float | Any
+    coeff_three_body: float | Any
+
+
+def _match_special_z_only_cubic_pattern(operator: object) -> _SpecialZOnlyCubicMatch | None:
+    """Return a match for the narrow Z-only `{2, 2, 3}` cubic pattern if present."""
+    if isinstance(operator, list):
+        return None
+
+    simplify = getattr(operator, "simplify", None)
+    if callable(simplify):
+        operator = simplify()
+
+    to_sparse_list = getattr(operator, "to_sparse_list", None)
+    num_qubits = getattr(operator, "num_qubits", None)
+    if not callable(to_sparse_list) or not isinstance(num_qubits, int):
+        return None
+
+    terms = list(to_sparse_list())
+    if len(terms) != 3:
+        return None
+
+    parsed_terms: list[tuple[tuple[int, ...], float | Any]] = []
+    for pauli, qubits, coeff in terms:
+        if len(pauli) != len(qubits) or set(pauli) != {"Z"}:
+            return None
+
+        try:
+            real_coeff = real_or_fail(coeff)
+        except ValueError:
+            return None
+
+        support = tuple(sorted(int(qubit) for qubit in qubits))
+        parsed_terms.append((support, real_coeff))
+
+    two_local = [(support, coeff) for support, coeff in parsed_terms if len(support) == 2]
+    three_local = [(support, coeff) for support, coeff in parsed_terms if len(support) == 3]
+    if len(two_local) != 2 or len(three_local) != 1:
+        return None
+
+    (support_a, coeff_a), (support_b, coeff_b) = two_local
+    (support_three, coeff_three) = three_local[0]
+    set_a = set(support_a)
+    set_b = set(support_b)
+    shared = set_a & set_b
+    support_union = set_a | set_b
+    if len(shared) != 1 or support_union != set(support_three):
+        return None
+
+    pivot = next(iter(shared))
+    leaf_a, leaf_b = sorted(support_union - {pivot})
+
+    coeff_leaf_a_pivot = coeff_a
+    coeff_pivot_leaf_b = coeff_b
+    if set(support_a) == {pivot, leaf_b} and set(support_b) == {leaf_a, pivot}:
+        coeff_leaf_a_pivot, coeff_pivot_leaf_b = coeff_b, coeff_a
+    elif set(support_a) != {leaf_a, pivot} or set(support_b) != {pivot, leaf_b}:
+        return None
+
+    return _SpecialZOnlyCubicMatch(
+        pivot=pivot,
+        leaf_a=leaf_a,
+        leaf_b=leaf_b,
+        coeff_leaf_a_pivot=coeff_leaf_a_pivot,
+        coeff_pivot_leaf_b=coeff_pivot_leaf_b,
+        coeff_three_body=coeff_three,
+    )
+
+
+def _synthesize_special_z_only_cubic(
+    num_qubits: int, time: Any, match: _SpecialZOnlyCubicMatch
+) -> QuantumCircuit:
+    """Emit the exact `4 CX + 3 RZ` template for the narrow matched pattern."""
+    circuit = QuantumCircuit(num_qubits)
+
+    circuit.cx(match.leaf_a, match.pivot)
+    circuit.rz(2 * match.coeff_leaf_a_pivot * time, match.pivot)
+
+    circuit.cx(match.leaf_b, match.pivot)
+    circuit.rz(2 * match.coeff_three_body * time, match.pivot)
+
+    circuit.cx(match.leaf_a, match.pivot)
+    circuit.rz(2 * match.coeff_pivot_leaf_b * time, match.pivot)
+
+    circuit.cx(match.leaf_b, match.pivot)
+    return circuit
 
 
 class LieTrotter(SuzukiTrotter):
@@ -121,3 +219,19 @@ class LieTrotter(SuzukiTrotter):
             "cx_structure": self._cx_structure,
             "wrap": self._wrap,
         }
+
+    def synthesize(self, evolution):
+        """Synthesize a :class:`.PauliEvolutionGate` with a narrow fast path for `#13285`."""
+        if (
+            self.reps == 1
+            and self._atomic_evolution is None
+            and not self._wrap
+            and not self.insert_barriers
+            and self._cx_structure == "chain"
+            and not isinstance(evolution.operator, list)
+        ):
+            match = _match_special_z_only_cubic_pattern(evolution.operator)
+            if match is not None:
+                return _synthesize_special_z_only_cubic(evolution.num_qubits, evolution.time, match)
+
+        return super().synthesize(evolution)

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -19,11 +19,12 @@ import numpy as np
 import scipy
 from ddt import ddt, data, unpack
 
-from qiskit import transpile
+from qiskit import generate_preset_pass_manager, transpile
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.circuit.library import PauliEvolutionGate, HamiltonianGate, PhaseGate, RZGate
 from qiskit.circuit.library.pauli_evolution import _merge_two_pauli_evolutions
 from qiskit.synthesis import LieTrotter, SuzukiTrotter, MatrixExponential, QDrift
+from qiskit.synthesis.evolution.lie_trotter import _match_special_z_only_cubic_pattern
 from qiskit.synthesis.evolution.product_formula import reorder_paulis
 from qiskit.converters import circuit_to_dag
 from qiskit.quantum_info import Operator, SparsePauliOp, Pauli, Statevector, SparseObservable
@@ -414,6 +415,60 @@ class TestEvolutionGate(QiskitTestCase):
         lie_trotter = PauliEvolutionGate(operator, time, synthesis=LieTrotter())
 
         self.assertSuzukiTrotterIsCorrect(lie_trotter)
+
+    def test_lie_trotter_special_z_only_cubic_issue_case(self):
+        """Test the narrow Z-only cubic fast path from Qiskit/qiskit#13285."""
+        time = Parameter("x")
+        operator = SparsePauliOp(["IZZ", "ZZI", "ZZZ"], coeffs=[1, 2, 3])
+        evolution = PauliEvolutionGate(operator, time, synthesis=LieTrotter())
+
+        self.assertEqual(evolution.definition.count_ops(), {"cx": 4, "rz": 3})
+        self.assertSetEqual({parameter.name for parameter in evolution.definition.parameters}, {"x"})
+
+        circuit = QuantumCircuit(3)
+        circuit.append(evolution, circuit.qubits)
+        pm = generate_preset_pass_manager(optimization_level=3, basis_gates=["cx", "rz"])
+        transpiled = pm.run(circuit)
+        self.assertEqual(transpiled.count_ops().get("cx", 0), 4)
+        self.assertEqual(transpiled.count_ops().get("rz", 0), 3)
+
+        numeric_evolution = PauliEvolutionGate(operator, 0.25, synthesis=LieTrotter())
+        self.assertSuzukiTrotterIsCorrect(numeric_evolution)
+
+    def test_lie_trotter_special_z_only_cubic_permuted_wires(self):
+        """Test wire permutations of the narrow Z-only cubic pattern remain exact."""
+        for pivot, leaf_a, leaf_b in [(0, 1, 2), (1, 0, 2), (2, 0, 1)]:
+            operator = SparsePauliOp.from_sparse_list(
+                [
+                    ("ZZ", [leaf_a, pivot], 1),
+                    ("ZZ", [pivot, leaf_b], 2),
+                    ("ZZZ", [leaf_a, pivot, leaf_b], 3),
+                ],
+                num_qubits=3,
+            )
+            evolution = PauliEvolutionGate(operator, 0.25, synthesis=LieTrotter())
+            self.assertEqual(evolution.definition.count_ops(), {"cx": 4, "rz": 3})
+            self.assertSuzukiTrotterIsCorrect(evolution)
+
+    def test_lie_trotter_special_z_only_cubic_matcher_negatives(self):
+        """Test the special matcher rejects malformed and out-of-scope operators."""
+        negatives = [
+            SparsePauliOp(["IZZ", "IZZ", "ZZZ"], coeffs=[1, 2, 3]),
+            SparsePauliOp(["IZZ", "IIX", "ZZZ"], coeffs=[1, 2, 3]),
+            SparsePauliOp(["IZZ", "IIZ", "ZZZ"], coeffs=[1, 2, 3]),
+            SparsePauliOp(["IZZ", "ZII", "ZZZ"], coeffs=[1, 2, 3]),
+            SparsePauliOp(["IZZ", "ZZI", "ZZZ", "ZII"], coeffs=[1, 2, 3, 4]),
+        ]
+
+        for operator in negatives:
+            self.assertIsNone(_match_special_z_only_cubic_pattern(operator))
+
+        grouped = [
+            SparsePauliOp(["IZZ", "ZZI"], coeffs=[1, 2]),
+            SparsePauliOp(["ZZZ"], coeffs=[3]),
+        ]
+        evolution = PauliEvolutionGate(grouped, 0.5, synthesis=LieTrotter())
+        self.assertSuzukiTrotterIsCorrect(evolution)
 
     def test_lie_trotter_reordered_manual(self):
         """Test the evolution circuit of Lie Trotter against a manually constructed circuit."""


### PR DESCRIPTION
Why
This addresses Qiskit/qiskit#13285 with a deliberately narrow LieTrotter fast path for the structural Z-only cubic pattern shown in the issue: two ZZ terms sharing one pivot qubit plus the corresponding ZZZ term over the union.

What changed
- add a structural matcher for a single Z-only `{2, 2, 3}` SparsePauliOp pattern
- add an exact `4 CX + 3 RZ` LieTrotter synthesis template for that match
- keep fallback behavior unchanged for block lists and out-of-scope operators
- add targeted tests for the canonical issue case, wire permutations, parameter preservation, and conservative negatives

Why this approach
The existing product-formula path flattens the operator into separate Pauli evolutions before this structure can be exploited. A narrow fast path in `LieTrotter.synthesize()` preserves the joint pattern long enough to emit the exact circuit shown in the issue, while staying conservative outside that scope.

How to review
- start in `qiskit/synthesis/evolution/lie_trotter.py`
- review the guard conditions around the fast path in `LieTrotter.synthesize()`
- review the matcher `_match_special_z_only_cubic_pattern`
- review the exact synthesis template `_synthesize_special_z_only_cubic`
- review the new tests in `test/python/circuit/library/test_evolution_gate.py`

Validation
- reproduce the issue case with `SparsePauliOp(["IZZ", "ZZI", "ZZZ"], coeffs=[1, 2, 3])`
- verify `PauliEvolutionGate(..., synthesis=LieTrotter())` now decomposes to `4 cx` and `3 rz`
- verify the transpiled circuit under `generate_preset_pass_manager(optimization_level=3, basis_gates=["cx", "rz"])` stays at `4 cx` and `3 rz`
- verify exactness for numeric instances and wire permutations
- verify out-of-scope cases still follow the fallback path

Testing
- `python -m pytest -q test/python/circuit/library/test_evolution_gate.py -k 'special_z_only_cubic or lie_trotter_two_qubit_correct_order or cnot_chain_options'`
- direct reproduction script for the canonical issue case in the local editable environment

Closes #13285

AI assistance disclosure
GPT-5 Codex was used for implementation planning and test design. The final code and tests were manually reviewed and validated before submission.
