### PR TITLE
Document that `rtol` has no effect in `SparsePauliOp.simplify`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -468,8 +468,13 @@ class SparsePauliOp(LinearOp):
         Args:
             atol (float): Optional. Absolute tolerance for checking if
                           coefficients are zero (Default: 1e-8).
-            rtol (float): Optional. relative tolerance for checking if
-                          coefficients are zero (Default: 1e-5).
+            rtol (float): Optional. Accepted for API compatibility but has no
+                          effect on the result. The zero check is performed
+                          with ``numpy.isclose(coeff, 0, atol=atol, rtol=rtol)``,
+                          which reduces to ``|coeff| <= atol`` because the
+                          relative-tolerance term is multiplied by the
+                          (zero) reference value. Use ``atol`` to control
+                          the threshold (Default: 1e-5).
 
         Returns:
             SparsePauliOp: the simplified SparsePauliOp operator.


### PR DESCRIPTION
### Summary

Updates the docstring of `SparsePauliOp.simplify` to state plainly that the `rtol`
argument has no effect on the result. The argument is kept for API compatibility.

Fixes #13383

### Problem

`SparsePauliOp.simplify(atol, rtol)` documents `rtol` as the *"relative tolerance
for checking if coefficients are zero"*, but the parameter does nothing. The zero
check is performed with `numpy.isclose(coeff, 0, atol=atol, rtol=rtol)`, which
expands to `|coeff - 0| <= atol + rtol * |0|`. The `rtol * |reference|` term is
always zero against a zero reference, so only `atol` controls the threshold.

Both the issue reporter and a maintainer (@jakelishman) confirmed they were
confused by this behavior.

### Root cause

Misleading docstring. The runtime behavior is unavoidable: relative tolerance
against a zero reference is undefined.

### Fix

Documentation only — clarifies that `rtol` is accepted but has no effect, points
out the underlying `numpy.isclose` semantics, and directs readers to `atol`.
The function signature, runtime behavior, and class-level `atol`/`rtol`
defaults are unchanged.

I deliberately did not modify `is_unitary` (where `rtol` *is* meaningful, since
it's compared against `1.0`) or `from_operator` (where `rtol` participates in a
`max(atol, rtol)` expression with different semantics).

### Tests

This is documentation-only with zero behavior change; no new test is added,
matching recent doc-clarification PRs (e.g. #16080, #16105).

### Validation

- `python -m black --check qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py`
  with the project-pinned `black~=25.1` (25.12.0): passed.
- `python -m ruff check qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py`
  with `ruff==0.15.2`: passed.
- `ast.parse` + `ast.get_docstring(simplify)`: docstring is valid Python and
  renders as intended.
- Targeted Python unit tests were not run locally because the Rust
  `_accelerate` extension is not built in my clone, but the change touches no
  runtime code, so this is reported honestly rather than skipped silently.

### Notes / limitations

This deliberately does not alter the behavior of `rtol`. As discussed on the
now-closed PR #15963, redefining `rtol` to anything functional would be a
silent breaking change to a stable public API. Per @jakelishman's comment on
that PR (2026-04-07), *"the solution to #13383 that's available to us within
stability guarantees is just to document/comment that the option is meaningless"* —
this PR implements exactly that.

A follow-up that transitions `SparsePauliOp` to a single `tol` argument (in line
with the newer `SparseObservable`) is out of scope here.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Anthropic Claude Opus 4.7
- [x] I used the following tool to generate or modify code: Anthropic Claude Opus 4.7

I reviewed the closed PR #15963 and @jakelishman's comments before writing this
patch and can defend each line; the only generated code is the seven-line
docstring change in this diff.