### PR TITLE
`DensePauli` class in Rust

### DIFF
--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -359,7 +359,9 @@ impl Clifford {
                     self.tableau[qbit + num_qubits][i + num_qubits]
                         ^ self.tableau[qbit][i + num_qubits],
                 ),
-                _ => unreachable!("The case "),
+                _ => unreachable!(
+                    "The case that both pauli_z and pauli_x are false has already been handled."
+                ),
             };
             z.set(i, z_bit);
             x.set(i, x_bit);

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -374,9 +374,9 @@ impl Clifford {
         let evolved_pauli_phase =
             (pauli_y_count + 2 * (phase_sign as u8) + 3 * ((pauli_x & pauli_z) as u8)) & 3;
         DensePauli {
-            pauli_x: x,
             pauli_z: z,
-            xz_phase: evolved_pauli_phase,
+            pauli_x: x,
+            zx_phase: evolved_pauli_phase,
         }
     }
 }

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -321,8 +321,7 @@ impl Clifford {
         (phase, z, x, indices)
     }
 
-    /// Evolve a Pauli with a single non-identity term (either X, Y, or Z on qubit `qbit`)
-    /// by the given Clifford.
+    /// Evolve a Pauli with at most one non-identity term (on qubit `qbit`) by the given Clifford.
     /// The non-identity Pauli term is represented as a pair `(pauli_z, pauli_x)` of boolean values.
     ///
     /// Return the evolved Pauli as (dense) Pauli.
@@ -333,6 +332,10 @@ impl Clifford {
         qbit: usize,
     ) -> DensePauli {
         let num_qubits = self.num_qubits;
+        if !pauli_z && !pauli_x {
+            // C^\dagger I C = I.
+            return DensePauli::identity(num_qubits);
+        }
         let mut z = FixedBitSet::with_capacity(num_qubits);
         let mut x = FixedBitSet::with_capacity(num_qubits);
         let mut pauli_indices = Vec::<usize>::with_capacity(2 * num_qubits);
@@ -356,7 +359,7 @@ impl Clifford {
                     self.tableau[qbit + num_qubits][i + num_qubits]
                         ^ self.tableau[qbit][i + num_qubits],
                 ),
-                _ => unreachable!("This is only called for RX/RZ/RY gates."),
+                _ => unreachable!("The case "),
             };
             z.set(i, z_bit);
             x.set(i, x_bit);

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -14,6 +14,8 @@ use std::fmt;
 use fixedbitset::FixedBitSet;
 use ndarray::{Array2, ArrayView2};
 
+use crate::dense_pauli::DensePauli;
+
 /// Symplectic matrix.
 pub struct SymplecticMatrix {
     /// Number of qubits.
@@ -288,15 +290,16 @@ impl Clifford {
         );
     }
 
-    /// Evolving the single-qubit Pauli-Z with Z on qubit qbit.
-    /// Returns the evolved Pauli in the a sparse ZX format: (sign, z, x, indices).
+    /// Evolving a Pauli with a single non-identity Z-term on qubit `qbit` by the given Clifford.
+    ///
+    /// Return the evolved Pauli in a sparse ZX format: (sign, z, x, indices).
     pub fn get_inverse_z(&self, qbit: usize) -> (bool, Vec<bool>, Vec<bool>, Vec<u32>) {
         let mut z = Vec::with_capacity(self.num_qubits);
         let mut x = Vec::with_capacity(self.num_qubits);
         let mut indices = Vec::with_capacity(self.num_qubits);
         let mut pauli_indices = Vec::<usize>::with_capacity(2 * self.num_qubits);
         // Compute the y-count to avoid recomputing it later
-        let mut pauli_y_count: u32 = 0;
+        let mut pauli_y_count: u8 = 0;
         for i in 0..self.num_qubits {
             let z_bit = self.tableau[qbit][i];
             let x_bit = self.tableau[qbit][i + self.num_qubits];
@@ -310,34 +313,97 @@ impl Clifford {
                 if z_bit {
                     pauli_indices.push(i + self.num_qubits);
                 }
-                pauli_y_count += (x_bit && z_bit) as u32;
+                pauli_y_count += (x_bit && z_bit) as u8;
             }
         }
         let phase = compute_phase_product_pauli(self, &pauli_indices, pauli_y_count);
 
         (phase, z, x, indices)
     }
+
+    /// Evolve a Pauli with a single non-identity term (either X, Y, or Z on qubit `qbit`)
+    /// by the given Clifford.
+    /// The non-identity Pauli term is represented as a pair `(pauli_z, pauli_x)` of boolean values.
+    ///
+    /// Return the evolved Pauli as (dense) Pauli.
+    pub fn evolve_single_qubit_pauli_dense(
+        &self,
+        pauli_z: bool,
+        pauli_x: bool,
+        qbit: usize,
+    ) -> DensePauli {
+        let num_qubits = self.num_qubits;
+        let mut z = FixedBitSet::with_capacity(num_qubits);
+        let mut x = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_indices = Vec::<usize>::with_capacity(2 * num_qubits);
+        // Compute the y-count to avoid recomputing it later
+        let mut pauli_y_count: u8 = 0;
+        for i in 0..num_qubits {
+            let (z_bit, x_bit) = match (pauli_z, pauli_x) {
+                (true, false) => (
+                    // pauli Z
+                    self.tableau[qbit][i],
+                    self.tableau[qbit][i + num_qubits],
+                ),
+                (false, true) => (
+                    // pauli X
+                    self.tableau[qbit + num_qubits][i],
+                    self.tableau[qbit + num_qubits][i + num_qubits],
+                ),
+                (true, true) => (
+                    // pauli Y
+                    self.tableau[qbit + num_qubits][i] ^ self.tableau[qbit][i],
+                    self.tableau[qbit + num_qubits][i + num_qubits]
+                        ^ self.tableau[qbit][i + num_qubits],
+                ),
+                _ => unreachable!("This is only called for RX/RZ/RY gates."),
+            };
+            z.set(i, z_bit);
+            x.set(i, x_bit);
+
+            if x_bit {
+                pauli_indices.push(i);
+            }
+            if z_bit {
+                pauli_indices.push(i + num_qubits);
+            }
+            pauli_y_count += (x_bit & z_bit) as u8;
+        }
+
+        let phase_sign = compute_phase_product_pauli(self, &pauli_indices, pauli_y_count);
+        let evolved_pauli_phase =
+            (pauli_y_count + 2 * (phase_sign as u8) + 3 * ((pauli_x & pauli_z) as u8)) & 3;
+        DensePauli {
+            pauli_x: x,
+            pauli_z: z,
+            xz_phase: evolved_pauli_phase,
+        }
+    }
 }
 
-/// Computes the sign (either +1 or -1) when conjugating a Pauli by a Clifford
+/// Compute the sign (either +1 or -1) when conjugating a Pauli by a Clifford.
+/// The Pauli is represented using a sparse vector of indices.
+/// For efficiency, the number of Y-terms in the Pauli is already available.
 fn compute_phase_product_pauli(
     clifford: &Clifford,
     pauli_indices: &[usize],
-    pauli_y_count: u32,
+    pauli_y_count: u8,
 ) -> bool {
+    let num_qubits = clifford.num_qubits;
+
     let phase = pauli_indices.iter().fold(false, |acc, &pauli_index| {
-        acc ^ (clifford.tableau[2 * clifford.num_qubits][pauli_index])
+        acc ^ (clifford.tableau[2 * num_qubits][pauli_index])
     });
 
-    let mut ifact: u8 = pauli_y_count as u8 % 4;
-
-    for j in 0..clifford.num_qubits {
+    let mut ifact: u8 = pauli_y_count;
+    for j in 0..num_qubits {
         let mut x = false;
         let mut z = false;
+        let x1_column = &clifford.tableau[j];
+        let z1_column = &clifford.tableau[j + num_qubits];
         for &pauli_index in pauli_indices.iter() {
-            let x1: bool = clifford.tableau[j][pauli_index];
-            let z1: bool = clifford.tableau[j + clifford.num_qubits][pauli_index];
-
+            let x1: bool = x1_column[pauli_index];
+            let z1: bool = z1_column[pauli_index];
             match (x1, z1, x, z) {
                 (false, true, true, true)
                 | (true, false, false, true)
@@ -353,10 +419,9 @@ fn compute_phase_product_pauli(
             };
             x ^= x1;
             z ^= z1;
-            ifact %= 4;
         }
     }
-    (((ifact % 4) >> 1) != 0) ^ phase
+    (((ifact & 3) >> 1) != 0) ^ phase
 }
 
 impl fmt::Debug for Clifford {

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -14,6 +14,7 @@ use crate::clifford::Clifford;
 use fixedbitset::FixedBitSet;
 use rand::{RngExt, SeedableRng};
 use rand_pcg::Pcg64Mcg;
+use thiserror::Error;
 
 /// A dense Pauli operator class.
 #[derive(Clone, Debug, PartialEq)]
@@ -25,6 +26,15 @@ pub struct DensePauli {
     /// xz-phase
     pub xz_phase: u8,
 }
+
+#[derive(Error, Debug)]
+pub enum DensePauliError {
+    #[error("`DensePauli::commute` requires both Paulis to have the same length")]
+    DifferentLengthsCommute,
+    #[error("`DensePauli::compose` requires both Paulis to have the same length")]
+    DifferentLengthsCompose,
+}
+
 
 impl DensePauli {
     /// Return the identity Pauli operator on ``num_qubits`` qubits.
@@ -290,13 +300,15 @@ impl DensePauli {
         (pauli_x_sparse, pauli_z_sparse, out_indices, phase)
     }
 
-    /// Return whether two Paulis commute.
+    /// Return `true` if `self` and `other` commute.
     ///
-    /// Panics
+    /// This method **does not check** that the two Paulis act on the same
+    /// number of qubits. Calling it with mismatched lengths results in an
+    /// **undefined logical behavior**.
     ///
-    /// This function will panic if the two Paulis are of different length.
-    pub fn commutes(&self, other: &DensePauli) -> bool {
-        debug_assert!(self.num_qubits() == other.num_qubits());
+    /// See [`DensePauli::commutes`] for a safe version that validates input
+    /// lengths.
+    pub fn commutes_unchecked(&self, other: &DensePauli) -> bool {
         let num_qubits = self.num_qubits();
         let mut parity = false;
         for i in 0..num_qubits {
@@ -304,6 +316,29 @@ impl DensePauli {
         }
         !parity
     }
+
+    /// Return `true` if `self` and `other` commute.
+    ///
+    /// This method checks that both Paulis act on the same number of qubits.
+    /// If they do not, an error is returned.
+    /// 
+    /// See [`DensePauli::commutes_unchecked`] for a faster version without
+    /// input validation.
+    /// 
+    /// # Errors
+    ///
+    /// Returns [`DensePauliError::DifferentLengthsCommute`] if the two Paulis
+    /// have different lengths.
+    pub fn commutes(&self, other: &DensePauli) -> Result<bool, DensePauliError> {
+        if self.num_qubits() != other.num_qubits() {
+            return Err(DensePauliError::DifferentLengthsCommute)
+        }
+        Ok(self.commutes_unchecked(other))
+    }
+
+
+
+
 
     /// Compose ``self`` and ``other``, returning the result as a new Pauli.
     ///
@@ -339,7 +374,7 @@ impl DensePauli {
     /// Panics
     ///
     /// This function will panic if the two Paulis are of different length.
-    pub fn compose_with(&mut self, other: &DensePauli) {
+    pub fn compose_with_unchecked(&mut self, other: &DensePauli) {
         debug_assert!(self.num_qubits() == other.num_qubits());
         let num_qubits = self.num_qubits();
         self.xz_phase += other.xz_phase;
@@ -353,7 +388,41 @@ impl DensePauli {
         self.pauli_z ^= &other.pauli_z;
         self.xz_phase &= 3u8;
     }
+
+    pub fn compose_with3(&mut self, other: &DensePauli) {
+        debug_assert!(self.num_qubits() == other.num_qubits());
+        self.pauli_x ^= &other.pauli_x;
+        self.pauli_z ^= &other.pauli_z;
+
+        let num_qubits = self.num_qubits();
+        self.xz_phase += other.xz_phase;
+        for i in 0..num_qubits {
+            if self.pauli_x[i] & other.pauli_z[i] {
+                self.xz_phase += 2;
+            }
+        }
+
+        self.xz_phase &= 3u8;
+
+    }
+
+
+
+
+     pub fn compose_with(&mut self, other: &DensePauli) -> Result<(), DensePauliError> {
+        
+        if self.num_qubits() != other.num_qubits() {
+            return Err(DensePauliError::DifferentLengthsCompose);
+        }
+        self.compose_with_unchecked(other);
+
+        Ok(())
+    }
 }
+
+
+
+
 
 /// Evolve a Pauli :math:`P` by a Clifford :math:`C`, using the Heisenberg picture,
 /// namely compute :math:`C^\dagger P C`.
@@ -383,7 +452,7 @@ pub fn evolve_pauli_by_clifford(pauli: &DensePauli, cliff: &Clifford) -> DensePa
             let evolved_pauli = cliff.evolve_single_qubit_pauli_dense(pz, px, qbit);
 
             // compose the ouput evolved dense paulies
-            out_pauli.compose_with(&evolved_pauli);
+            out_pauli.compose_with_unchecked(&evolved_pauli);
         }
     }
 
@@ -394,6 +463,8 @@ pub fn evolve_pauli_by_clifford(pauli: &DensePauli, cliff: &Clifford) -> DensePa
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use fixedbitset::FixedBitSet;
 
     use crate::clifford::Clifford;
@@ -455,8 +526,8 @@ mod tests {
     fn assert_commute(p_label: &str, q_label: &str, expected: bool) {
         let p = DensePauli::from_label(p_label);
         let q = DensePauli::from_label(q_label);
-        let computed_pq = p.commutes(&q);
-        let computed_qp = p.commutes(&q);
+        let computed_pq = p.commutes_unchecked(&q);
+        let computed_qp = p.commutes_unchecked(&q);
         assert_eq!(computed_pq, expected);
         assert_eq!(computed_qp, expected);
     }
@@ -498,11 +569,11 @@ mod tests {
     #[test]
     fn test_compose_with() {
         let mut p = DensePauli::identity(3);
-        p.compose_with(&DensePauli::from_label("iXYZ"));
+        p.compose_with_unchecked(&DensePauli::from_label("iXYZ"));
         assert_eq!(p, DensePauli::from_label("iXYZ"));
-        p.compose_with(&DensePauli::from_label("ZII"));
+        p.compose_with_unchecked(&DensePauli::from_label("ZII"));
         assert_eq!(p, DensePauli::from_label("-YYZ"));
-        p.compose_with(&DensePauli::from_label("-YYZ"));
+        p.compose_with_unchecked(&DensePauli::from_label("-YYZ"));
         assert_eq!(p, DensePauli::from_label("III"));
     }
 
@@ -607,4 +678,73 @@ mod tests {
         assert_evolve("-iXY", &cliff, "-iIY");
         assert_evolve("II", &cliff, "II");
     }
+
+
+    #[test]
+    fn test_timings() {
+        // for nq in (0..10).chain([100, 1000, 10000, 100000]) {
+        //     let paulis: Vec<DensePauli> = (0..=10000).map(|i| DensePauli::from_random(nq, i as u64)).collect();
+
+
+
+        //     let start = Instant::now();
+        //     for _ in 0..100 {
+        //         for i in 0..10000 {
+        //              let _ = paulis[i].commutes(&paulis[i+1]).unwrap();
+
+        //         }
+        //     }
+        //     let duration = start.elapsed();
+
+
+        //     let start = Instant::now();
+        //     for _ in 0..100 {
+        //         for i in 0..10000 {
+        //             let _ = paulis[i].commutes_unchecked(&paulis[i+1]);
+        //         }
+        //     }
+        //     let duration2 = start.elapsed();
+
+        //     println!("nq = {:?}, commutation1 {:?}, commutation2 {:?}", nq, duration, duration2);
+        // }
+
+        for nq in (0..10).chain([100, 1000, 10000]) {
+            let paulis: Vec<DensePauli> = (0..10000).map(|i| DensePauli::from_random(nq, i as u64)).collect();
+
+            let start = Instant::now();
+            for _ in 0..100 {
+                let mut p = DensePauli::identity(nq);
+                for i in 0..10000 {
+                    p.compose_with_unchecked(&paulis[i]);
+                }
+            }
+            let duration = start.elapsed();
+
+
+            let start = Instant::now();
+            for _ in 0..100 {
+                let mut p = DensePauli::identity(nq);
+                for i in 0..10000 {
+                    p.compose_with(&paulis[i]).unwrap();
+                }
+            }
+            let duration2 = start.elapsed();
+
+
+
+            let start = Instant::now();
+            for _ in 0..100 {
+                let mut p = DensePauli::identity(nq);
+                for i in 0..10000 {
+                    p.compose_with3(&paulis[i]);
+                }
+            }
+            let duration3 = start.elapsed();
+
+            println!("nq = {:?}, composition1 {:?}, composition2 {:?}, composition3 {:?}", nq, duration, duration2, duration3);
+        }
+    }
+
 }
+
+

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -35,15 +35,13 @@ pub struct DensePauli {
 #[derive(Error, Debug)]
 pub enum DensePauliError {
     #[error(
-        "`DensePauli::from_sparse_bool` requires `z`, `x` and `incices` to have the same length"
+        "`DensePauli::from_sparse_bool` requires `z`, `x` and `indices` to have the same length"
     )]
     InvalidSparseInput,
-    #[error("`DensePauli::from_label` requires a valid label")]
-    InvalidLabel,
-    #[error("`DensePauli::commute` requires both Paulis to have the same length")]
-    DifferentLengthsCommute,
-    #[error("`DensePauli::compose` requires both Paulis to have the same length")]
-    DifferentLengthsCompose,
+    #[error("Invalid Pauli label: {0}")]
+    InvalidLabel(String),
+    #[error("Both Paulis are required to have the same length")]
+    DifferentLengths,
     #[error(
         "Evolving `DensePauli` under a `Clifford` requires both to have the same number of qubits."
     )]
@@ -136,11 +134,11 @@ impl DensePauli {
         let mut zx_phase = 0u8;
         if let Some(r) = s.strip_prefix('-') {
             s = r;
-            zx_phase += 2;
+            zx_phase = (zx_phase + 2) & 3;
         }
         if let Some(r) = s.strip_prefix('i') {
             s = r;
-            zx_phase += 1;
+            zx_phase = (zx_phase + 1) & 3;
         }
 
         let num_qubits = s.len();
@@ -164,10 +162,10 @@ impl DensePauli {
                 'Y' => {
                     pauli_z.set(i, true);
                     pauli_x.set(i, true);
-                    zx_phase = zx_phase.wrapping_add(1) & 3;
+                    zx_phase = (zx_phase + 1) & 3;
                 }
                 _ => {
-                    return Err(DensePauliError::InvalidLabel);
+                    return Err(DensePauliError::InvalidLabel(label.to_string()));
                 }
             }
         }
@@ -335,20 +333,20 @@ impl DensePauli {
     ///
     /// # Errors
     ///
-    /// Returns [`DensePauliError::DifferentLengthsCommute`] if the two Paulis
+    /// Returns [`DensePauliError::DifferentLengths`] if the two Paulis
     /// have different lengths.
     #[inline(always)]
     pub fn commutes(&self, other: &DensePauli) -> Result<bool, DensePauliError> {
         if self.num_qubits() != other.num_qubits() {
-            return Err(DensePauliError::DifferentLengthsCommute);
+            return Err(DensePauliError::DifferentLengths);
         }
         Ok(self.commutes_unchecked(other))
     }
 
     /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
     ///
-    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
-    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    /// Computing ``self.compose_with_unchecked(other)`` is equivalent to
+    /// computing ``other * self``.
     ///
     /// This method **does not check** that the two Paulis act on the same
     /// number of qubits. Calling it with mismatched lengths results in an
@@ -358,47 +356,42 @@ impl DensePauli {
     /// lengths.
     #[inline(always)]
     pub fn compose_with_unchecked(&mut self, other: &DensePauli) {
-        // note: on my MacOS this function is surprisingly *slower* than compose_with,
-        // so best to always call compose_with method instead of this one.
         let num_qubits = self.num_qubits();
-        self.zx_phase += other.zx_phase;
+        self.zx_phase = (self.zx_phase + other.zx_phase) & 3;
         for i in 0..num_qubits {
             if self.pauli_x[i] & other.pauli_z[i] {
-                self.zx_phase += 2;
+                self.zx_phase = (self.zx_phase + 2) & 3;
             }
         }
-
         self.pauli_z ^= &other.pauli_z;
         self.pauli_x ^= &other.pauli_x;
-        self.zx_phase &= 3u8;
     }
 
     /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
     ///
-    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
-    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    /// Computing ``self.compose_with(other)`` is equivalent to computing
+    /// ``other * self``.
     ///
     /// This method checks that both Paulis act on the same number of qubits.
     /// If they do not, an error is returned.
     ///
     /// # Errors
     ///
-    /// Returns [`DensePauliError::DifferentLengthsCompose`] if the two Paulis
+    /// Returns [`DensePauliError::DifferentLengths`] if the two Paulis
     /// have different lengths.
     #[inline(always)]
     pub fn compose_with(&mut self, other: &DensePauli) -> Result<(), DensePauliError> {
         if self.num_qubits() != other.num_qubits() {
-            return Err(DensePauliError::DifferentLengthsCompose);
+            return Err(DensePauliError::DifferentLengths);
         }
         self.compose_with_unchecked(other);
-
         Ok(())
     }
 
     /// Compose ``self`` and ``other``, returning the result in a new Pauli.
     ///
-    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
-    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    /// Computing ``self.compose_unchecked(other)`` is equivalent to computing
+    /// ``other * self``.
     ///
     /// This method **does not check** that the two Paulis act on the same
     /// number of qubits. Calling it with mismatched lengths results in an
@@ -408,11 +401,11 @@ impl DensePauli {
     /// lengths.
     #[inline(always)]
     pub fn compose_unchecked(&self, other: &DensePauli) -> DensePauli {
-        let mut zx_phase = self.zx_phase + other.zx_phase;
+        let mut zx_phase = (self.zx_phase + other.zx_phase) & 3;
         let num_qubits = self.num_qubits();
         for i in 0..num_qubits {
             if self.pauli_x[i] && other.pauli_z[i] {
-                zx_phase += 2;
+                zx_phase = (zx_phase + 2) & 3;
             }
         }
 
@@ -421,26 +414,25 @@ impl DensePauli {
         DensePauli {
             pauli_z,
             pauli_x,
-            zx_phase: zx_phase & 3u8,
+            zx_phase,
         }
     }
 
     /// Compose ``self`` and ``other``, returning the result in a new Pauli.
     ///
-    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
-    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    /// Computing ``self.compose(other)`` is equivalent to computing ``other * self``.
     ///
     /// This method checks that both Paulis act on the same number of qubits.
     /// If they do not, an error is returned.
     ///
     /// # Errors
     ///
-    /// Returns [`DensePauliError::DifferentLengthsCompose`] if the two Paulis
+    /// Returns [`DensePauliError::DifferentLengths`] if the two Paulis
     /// have different lengths.
     #[inline(always)]
     pub fn compose(&self, other: &DensePauli) -> Result<DensePauli, DensePauliError> {
         if self.num_qubits() != other.num_qubits() {
-            return Err(DensePauliError::DifferentLengthsCommute);
+            return Err(DensePauliError::DifferentLengths);
         }
         Ok(self.compose_unchecked(other))
     }
@@ -483,8 +475,7 @@ pub fn evolve_pauli_by_clifford(
         }
     }
 
-    out_pauli.zx_phase += pauli.zx_phase;
-    out_pauli.zx_phase &= 3;
+    out_pauli.zx_phase = (out_pauli.zx_phase + pauli.zx_phase) & 3;
     Ok(out_pauli)
 }
 
@@ -493,7 +484,7 @@ mod tests {
     use fixedbitset::FixedBitSet;
 
     use crate::clifford::Clifford;
-    use crate::dense_pauli::{DensePauli, evolve_pauli_by_clifford};
+    use crate::dense_pauli::{DensePauli, DensePauliError, evolve_pauli_by_clifford};
 
     fn pauli_from_label(label: &str) -> DensePauli {
         DensePauli::from_label(label).unwrap()
@@ -550,6 +541,12 @@ mod tests {
 
         let pauli_label = pauli.to_label();
         assert_eq!(pauli_label, String::from("-iXZ"));
+    }
+
+    #[test]
+    fn test_invalid_label() {
+        let result = DensePauli::from_label("XI-Z");
+        assert!(matches!(result, Err(DensePauliError::InvalidLabel(_))));
     }
 
     /// Assert that commuting two Paulis P and Q gives the expected result.

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -19,16 +19,22 @@ use thiserror::Error;
 /// A dense Pauli operator class.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DensePauli {
-    /// x-component
-    pub pauli_x: FixedBitSet,
     /// z-component
     pub pauli_z: FixedBitSet,
-    /// xz-phase
-    pub xz_phase: u8,
+    /// x-component
+    pub pauli_x: FixedBitSet,
+    /// zx-phase
+    pub zx_phase: u8,
 }
 
 #[derive(Error, Debug)]
 pub enum DensePauliError {
+    #[error(
+        "`DensePauli::from_sparse_bool` requires `z`, `x` and `incices` to have the same length"
+    )]
+    InvalidSparseInput,
+    #[error("`DensePauli::from_label` requires a valid label")]
+    InvalidLabel,
     #[error("`DensePauli::commute` requires both Paulis to have the same length")]
     DifferentLengthsCommute,
     #[error("`DensePauli::compose` requires both Paulis to have the same length")]
@@ -42,13 +48,13 @@ pub enum DensePauliError {
 impl DensePauli {
     /// Return the identity Pauli operator on ``num_qubits`` qubits.
     pub fn identity(num_qubits: usize) -> Self {
-        let pauli_x = FixedBitSet::with_capacity(num_qubits);
         let pauli_z = FixedBitSet::with_capacity(num_qubits);
-        let xz_phase = 0u8;
+        let pauli_x = FixedBitSet::with_capacity(num_qubits);
+        let zx_phase = 0u8;
         DensePauli {
-            pauli_x,
             pauli_z,
-            xz_phase,
+            pauli_x,
+            zx_phase,
         }
     }
 
@@ -62,51 +68,46 @@ impl DensePauli {
     /// * `indices`: Qubit indices corresponding to `x` and `z`.
     /// * `phase`: The phase of the Pauli operator, encoded modulo 4.
     /// * `is_group_phase`: If `true`, `phase` is interpreted as a group phase
-    ///   and is converted to the internal XZ-phase representation.
+    ///   and is converted to the internal ZX-phase representation.
     ///
-    /// # Panics:
+    /// # Errors
     ///
-    /// This function will panic if `x`, `z` or `indices` do not all have the same
-    /// length.
+    /// Returns [`DensePauliError::InvalidSparseInput`] if
+    /// `z`, `x` or `indices` do not all have the same length.
     pub fn from_sparse_bool(
         num_qubits: usize,
-        x: &[bool],
         z: &[bool],
+        x: &[bool],
         indices: &[u32],
         phase: u8,
         is_group_phase: bool,
-    ) -> Self {
-        debug_assert!(
-            x.len() == indices.len(),
-            "x and indices must have the same length"
-        );
-        debug_assert!(
-            z.len() == indices.len(),
-            "z and indices must have the same length"
-        );
+    ) -> Result<Self, DensePauliError> {
+        if (z.len() != indices.len()) || (x.len() != indices.len()) {
+            return Err(DensePauliError::InvalidSparseInput);
+        }
 
-        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
         let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
         let mut num_ys = 0;
 
         for (i, &q) in indices.iter().enumerate() {
-            pauli_x.set(q as usize, x[i]);
             pauli_z.set(q as usize, z[i]);
+            pauli_x.set(q as usize, x[i]);
             if x[i] & z[i] {
                 num_ys += 1;
             }
         }
 
-        let xz_phase = if is_group_phase {
+        let zx_phase = if is_group_phase {
             (phase + num_ys) & 3
         } else {
             phase
         };
-        DensePauli {
-            pauli_x,
+        Ok(DensePauli {
             pauli_z,
-            xz_phase,
-        }
+            pauli_x,
+            zx_phase,
+        })
     }
 
     /// Construct a dense Pauli operator from a string label.
@@ -116,61 +117,61 @@ impl DensePauli {
     /// * `label`: A Pauli label string consisting of an optional minus sign, followed by
     ///   an optional `i` factor, followed by a sequence of `'I'`, `'X'`, `'Y'`, or `'Z'` characters.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if the label is invalid.
+    /// Returns [`DensePauliError::InvalidLabel`] if the label is invalid.
     ///
     /// .. note::
     ///
     ///     In Qiskit convention, the label is represented right-to-left,
     ///     for example "-iXIZY" is interpreted as `'X'` on qubit `3`, followed by `'I'` on qubit `2`,
     ///     followed by `'Z'` on qubit `1`, and finally by `'Y'` on qubit `0`.
-    pub fn from_label(label: &str) -> Self {
+    pub fn from_label(label: &str) -> Result<Self, DensePauliError> {
         let mut s = label;
-        let mut xz_phase = 0u8;
+        let mut zx_phase = 0u8;
         if let Some(r) = s.strip_prefix('-') {
             s = r;
-            xz_phase += 2;
+            zx_phase += 2;
         }
         if let Some(r) = s.strip_prefix('i') {
             s = r;
-            xz_phase += 1;
+            zx_phase += 1;
         }
 
         let num_qubits = s.len();
-        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
         let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
 
         for (i, c) in s.chars().rev().enumerate() {
             match c {
                 'I' => {
-                    pauli_x.set(i, false);
                     pauli_z.set(i, false);
+                    pauli_x.set(i, false);
                 }
                 'X' => {
-                    pauli_x.set(i, true);
                     pauli_z.set(i, false);
+                    pauli_x.set(i, true);
                 }
                 'Z' => {
-                    pauli_x.set(i, false);
                     pauli_z.set(i, true);
+                    pauli_x.set(i, false);
                 }
                 'Y' => {
-                    pauli_x.set(i, true);
                     pauli_z.set(i, true);
-                    xz_phase = xz_phase.wrapping_add(1) & 3;
+                    pauli_x.set(i, true);
+                    zx_phase = zx_phase.wrapping_add(1) & 3;
                 }
                 _ => {
-                    panic!("Incorrect label");
+                    return Err(DensePauliError::InvalidLabel);
                 }
             }
         }
 
-        DensePauli {
-            pauli_x,
+        Ok(DensePauli {
             pauli_z,
-            xz_phase,
-        }
+            pauli_x,
+            zx_phase,
+        })
     }
 
     /// Construct a random dense Pauli operator on ``num_qubits`` qubits.
@@ -181,23 +182,23 @@ impl DensePauli {
     /// * `seed`: Random seed used for generation.
     pub fn from_random(num_qubits: usize, seed: u64) -> Self {
         let mut rng = Pcg64Mcg::seed_from_u64(seed);
-        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
         let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
 
-        for i in 0..num_qubits {
-            let val = rng.random_bool(0.5);
-            pauli_x.set(i, val);
-        }
         for i in 0..num_qubits {
             let val = rng.random_bool(0.5);
             pauli_z.set(i, val);
         }
-        let xz_phase = rng.random::<u8>() & 3;
+        for i in 0..num_qubits {
+            let val = rng.random_bool(0.5);
+            pauli_x.set(i, val);
+        }
+        let zx_phase = rng.random::<u8>() & 3;
 
         DensePauli {
-            pauli_x,
             pauli_z,
-            xz_phase,
+            pauli_x,
+            zx_phase,
         }
     }
 
@@ -229,16 +230,16 @@ impl DensePauli {
         let mut s: String = Default::default();
         let n = self.num_qubits();
 
-        let mut group_phase = self.xz_phase;
+        let mut group_phase = self.zx_phase;
         for i in (0..n).rev() {
-            match (self.pauli_x[i], self.pauli_z[i]) {
+            match (self.pauli_z[i], self.pauli_x[i]) {
                 (false, false) => {
                     s.push('I');
                 }
-                (false, true) => {
+                (true, false) => {
                     s.push('Z');
                 }
-                (true, false) => {
+                (false, true) => {
                     s.push('X');
                 }
                 (true, true) => {
@@ -275,7 +276,7 @@ impl DensePauli {
     /// # Arguments
     ///
     /// * `is_group_phase`: If `true`, the returned phase is a group phase. Otherwise,
-    ///   it is the XZ-phase.
+    ///   it is the ZX-phase.
     ///
     /// # Returns
     ///
@@ -283,24 +284,24 @@ impl DensePauli {
     /// are sorted.
     pub fn to_sparse_bool(&self, is_group_phase: bool) -> (Vec<bool>, Vec<bool>, Vec<u32>, u8) {
         let num_qubits = self.num_qubits();
-        let mut pauli_x_sparse: Vec<bool> = Vec::with_capacity(num_qubits);
         let mut pauli_z_sparse: Vec<bool> = Vec::with_capacity(num_qubits);
+        let mut pauli_x_sparse: Vec<bool> = Vec::with_capacity(num_qubits);
         let mut out_indices: Vec<u32> = Vec::with_capacity(num_qubits);
 
         for i in 0..num_qubits {
             if self.pauli_x[i] || self.pauli_z[i] {
-                pauli_x_sparse.push(self.pauli_x[i]);
                 pauli_z_sparse.push(self.pauli_z[i]);
+                pauli_x_sparse.push(self.pauli_x[i]);
                 out_indices.push(i as u32);
             }
         }
         let phase = if is_group_phase {
-            self.xz_phase.wrapping_sub(self.count_y()) & 3
+            self.zx_phase.wrapping_sub(self.count_y()) & 3
         } else {
-            self.xz_phase
+            self.zx_phase
         };
 
-        (pauli_x_sparse, pauli_z_sparse, out_indices, phase)
+        (pauli_z_sparse, pauli_x_sparse, out_indices, phase)
     }
 
     /// Return `true` if `self` and `other` commute.
@@ -357,16 +358,16 @@ impl DensePauli {
         // note: on my MacOS this function is surprisingly *slower* than compose_with,
         // so best to always call compose_with method instead of this one.
         let num_qubits = self.num_qubits();
-        self.xz_phase += other.xz_phase;
+        self.zx_phase += other.zx_phase;
         for i in 0..num_qubits {
             if self.pauli_x[i] & other.pauli_z[i] {
-                self.xz_phase += 2;
+                self.zx_phase += 2;
             }
         }
 
-        self.pauli_x ^= &other.pauli_x;
         self.pauli_z ^= &other.pauli_z;
-        self.xz_phase &= 3u8;
+        self.pauli_x ^= &other.pauli_x;
+        self.zx_phase &= 3u8;
     }
 
     /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
@@ -404,19 +405,20 @@ impl DensePauli {
     /// lengths.
     #[inline(always)]
     pub fn compose_unchecked(&self, other: &DensePauli) -> DensePauli {
-        let mut xz_phase = self.xz_phase + other.xz_phase;
+        let mut zx_phase = self.zx_phase + other.zx_phase;
         let num_qubits = self.num_qubits();
         for i in 0..num_qubits {
             if self.pauli_x[i] && other.pauli_z[i] {
-                xz_phase += 2;
+                zx_phase += 2;
             }
         }
-        let pauli_x = &self.pauli_x ^ &other.pauli_x;
+
         let pauli_z = &self.pauli_z ^ &other.pauli_z;
+        let pauli_x = &self.pauli_x ^ &other.pauli_x;
         DensePauli {
-            pauli_x,
             pauli_z,
-            xz_phase: xz_phase & 3u8,
+            pauli_x,
+            zx_phase: zx_phase & 3u8,
         }
     }
 
@@ -478,8 +480,8 @@ pub fn evolve_pauli_by_clifford(
         }
     }
 
-    out_pauli.xz_phase += pauli.xz_phase;
-    out_pauli.xz_phase &= 3;
+    out_pauli.zx_phase += pauli.zx_phase;
+    out_pauli.zx_phase &= 3;
     Ok(out_pauli)
 }
 
@@ -490,6 +492,10 @@ mod tests {
     use crate::clifford::Clifford;
     use crate::dense_pauli::{DensePauli, evolve_pauli_by_clifford};
 
+    fn pauli_from_label(label: &str) -> DensePauli {
+        DensePauli::from_label(label).unwrap()
+    }
+
     #[test]
     fn test_identity() {
         let num_qubits = 3;
@@ -498,26 +504,27 @@ mod tests {
         assert_eq!(pauli.count_y(), 0);
         assert_eq!(pauli.pauli_x, FixedBitSet::with_capacity(num_qubits));
         assert_eq!(pauli.pauli_z, FixedBitSet::with_capacity(num_qubits));
-        assert_eq!(pauli.xz_phase, 0);
+        assert_eq!(pauli.zx_phase, 0);
     }
 
     #[test]
     fn test_from_sparse_bool_and_back() {
         let pauli =
-            DensePauli::from_sparse_bool(3, &[true, false], &[true, true], &[1, 2], 2, true);
+            DensePauli::from_sparse_bool(3, &[true, true], &[true, false], &[1, 2], 2, true)
+                .unwrap();
         let mut expected_x = FixedBitSet::with_capacity(3);
         expected_x.set(1, true);
         let mut expected_z = FixedBitSet::with_capacity(3);
         expected_z.set(1, true);
         expected_z.set(2, true);
-        let expected_xz_phase = 3;
+        let expected_zx_phase = 3;
         assert_eq!(pauli.num_qubits(), 3);
         assert_eq!(pauli.count_y(), 1);
         assert_eq!(pauli.pauli_x, expected_x);
         assert_eq!(pauli.pauli_z, expected_z);
-        assert_eq!(pauli.xz_phase, expected_xz_phase);
+        assert_eq!(pauli.zx_phase, expected_zx_phase);
 
-        let (x, z, indices, phase) = pauli.to_sparse_bool(true);
+        let (z, x, indices, phase) = pauli.to_sparse_bool(true);
         assert_eq!(x, vec![true, false]);
         assert_eq!(z, vec![true, true]);
         assert_eq!(indices, vec![1, 2]);
@@ -526,17 +533,17 @@ mod tests {
 
     #[test]
     fn test_from_label_and_back() {
-        let pauli = DensePauli::from_label("-iXZ");
+        let pauli = pauli_from_label("-iXZ");
         let mut expected_x = FixedBitSet::with_capacity(2);
         expected_x.set(1, true);
         let mut expected_z = FixedBitSet::with_capacity(2);
         expected_z.set(0, true);
-        let expected_xz_phase = 3;
+        let expected_zx_phase = 3;
         assert_eq!(pauli.num_qubits(), 2);
         assert_eq!(pauli.count_y(), 0);
         assert_eq!(pauli.pauli_x, expected_x);
         assert_eq!(pauli.pauli_z, expected_z);
-        assert_eq!(pauli.xz_phase, expected_xz_phase);
+        assert_eq!(pauli.zx_phase, expected_zx_phase);
 
         let pauli_label = pauli.to_label();
         assert_eq!(pauli_label, String::from("-iXZ"));
@@ -544,8 +551,8 @@ mod tests {
 
     /// Assert that commuting two Paulis P and Q gives the expected result.
     fn assert_commute(p_label: &str, q_label: &str, expected: bool) {
-        let p = DensePauli::from_label(p_label);
-        let q = DensePauli::from_label(q_label);
+        let p = pauli_from_label(p_label);
+        let q = pauli_from_label(q_label);
         let computed_pq = p.commutes_unchecked(&q);
         let computed_qp = p.commutes_unchecked(&q);
         assert_eq!(computed_pq, expected);
@@ -564,9 +571,9 @@ mod tests {
 
     /// Assert that multiplying Paulis P and Q gives the expected result.
     fn assert_multiply(p_label: &str, q_label: &str, expected_label: &str) {
-        let p = DensePauli::from_label(p_label);
-        let q = DensePauli::from_label(q_label);
-        let expected = DensePauli::from_label(expected_label);
+        let p = pauli_from_label(p_label);
+        let q = pauli_from_label(q_label);
+        let expected = pauli_from_label(expected_label);
         let computed = q.compose_unchecked(&p);
         assert_eq!(computed, expected);
     }
@@ -589,19 +596,19 @@ mod tests {
     #[test]
     fn test_compose_with() {
         let mut p = DensePauli::identity(3);
-        p.compose_with_unchecked(&DensePauli::from_label("iXYZ"));
-        assert_eq!(p, DensePauli::from_label("iXYZ"));
-        p.compose_with_unchecked(&DensePauli::from_label("ZII"));
-        assert_eq!(p, DensePauli::from_label("-YYZ"));
-        p.compose_with_unchecked(&DensePauli::from_label("-YYZ"));
-        assert_eq!(p, DensePauli::from_label("III"));
+        p.compose_with_unchecked(&pauli_from_label("iXYZ"));
+        assert_eq!(p, pauli_from_label("iXYZ"));
+        p.compose_with_unchecked(&pauli_from_label("ZII"));
+        assert_eq!(p, pauli_from_label("-YYZ"));
+        p.compose_with_unchecked(&pauli_from_label("-YYZ"));
+        assert_eq!(p, pauli_from_label("III"));
     }
 
     /// Assert that evolving P under Cliff gives the expected result.
     fn assert_evolve(p_label: &str, cliff: &Clifford, expected_label: &str) {
-        let p = DensePauli::from_label(p_label);
+        let p = pauli_from_label(p_label);
         let computed = evolve_pauli_by_clifford(&p, cliff).unwrap();
-        let expected = DensePauli::from_label(expected_label);
+        let expected = pauli_from_label(expected_label);
         assert_eq!(computed, expected);
     }
 

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -17,6 +17,11 @@ use rand_pcg::Pcg64Mcg;
 use thiserror::Error;
 
 /// A dense Pauli operator class.
+///
+/// The `zx_phase` is a common bookkeeping convention that allows for faster Pauli
+/// commutation and composition checks. This `zx_phase` and the group phase
+/// (that is, the actual algebraic coefficient :math:`i^q` in front of the operator)
+/// are related as `zx phase = (group phase + number of Y-terms) modulo 4`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DensePauli {
     /// z-component
@@ -261,7 +266,7 @@ impl DensePauli {
                 s = String::from("-i") + &s;
             }
             _ => {
-                panic!("we should never get this")
+                unreachable!("The group phase is always kept reduced modulo 4.")
             }
         }
 

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -1,0 +1,610 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::clifford::Clifford;
+use fixedbitset::FixedBitSet;
+use rand::{RngExt, SeedableRng};
+use rand_pcg::Pcg64Mcg;
+
+/// A dense Pauli operator class.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DensePauli {
+    /// x-component
+    pub pauli_x: FixedBitSet,
+    /// z-component
+    pub pauli_z: FixedBitSet,
+    /// xz-phase
+    pub xz_phase: u8,
+}
+
+impl DensePauli {
+    /// Return the identity Pauli operator on ``num_qubits`` qubits.
+    pub fn identity(num_qubits: usize) -> Self {
+        let pauli_x = FixedBitSet::with_capacity(num_qubits);
+        let pauli_z = FixedBitSet::with_capacity(num_qubits);
+        let xz_phase = 0u8;
+        DensePauli {
+            pauli_x,
+            pauli_z,
+            xz_phase,
+        }
+    }
+
+    /// Construct a dense Pauli operator from a sparse boolean representation.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_qubits`: Number of qubits.
+    /// * `x`: Boolean slice representing x-terms.
+    /// * `z`: Boolean slice representing z-terms.
+    /// * `indices`: Qubit indices corresponding to `x` and `z`.
+    /// * `phase`: The phase of the Pauli operator, encoded modulo 4.
+    /// * `is_group_phase`: If `true`, `phase` is interpreted as a group phase
+    ///   and is converted to the internal XZ-phase representation.
+    ///
+    /// # Panics:
+    ///
+    /// This function will panic if `x`, `z` or `indices` do not all have the same
+    /// length.
+    pub fn from_sparse_bool(
+        num_qubits: usize,
+        x: &[bool],
+        z: &[bool],
+        indices: &[u32],
+        phase: u8,
+        is_group_phase: bool,
+    ) -> Self {
+        debug_assert!(
+            x.len() == indices.len(),
+            "x and indices must have the same length"
+        );
+        debug_assert!(
+            z.len() == indices.len(),
+            "z and indices must have the same length"
+        );
+
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+        let mut num_ys = 0;
+
+        for (i, &q) in indices.iter().enumerate() {
+            pauli_x.set(q as usize, x[i]);
+            pauli_z.set(q as usize, z[i]);
+            if x[i] & z[i] {
+                num_ys += 1;
+            }
+        }
+
+        let xz_phase = if is_group_phase {
+            (phase + num_ys) & 3
+        } else {
+            phase
+        };
+        DensePauli {
+            pauli_x,
+            pauli_z,
+            xz_phase,
+        }
+    }
+
+    /// Construct a dense Pauli operator from a string label.
+    ///
+    /// # Arguments
+    ///
+    /// * `label`: A Pauli label string consisting of an optional minus sign, followed by
+    ///   an optional `i` factor, followed by a sequence of `'I'`, `'X'`, `'Y'`, or `'Z'` characters.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the label is invalid.
+    ///
+    /// .. note::
+    ///
+    ///     Unlike Python-space Qiskit convention, the label is represented left-to-right,
+    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `0`, followed by `'I'` on qubit `1`,
+    ///     and so on.
+    pub fn from_label(label: &str) -> Self {
+        let mut s = label;
+        let mut xz_phase = 0u8;
+        if let Some(r) = s.strip_prefix('-') {
+            s = r;
+            xz_phase += 2;
+        }
+        if let Some(r) = s.strip_prefix('i') {
+            s = r;
+            xz_phase += 1;
+        }
+
+        let num_qubits = s.len();
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+
+        for (i, c) in s.chars().enumerate() {
+            match c {
+                'I' => {
+                    pauli_x.set(i, false);
+                    pauli_z.set(i, false);
+                }
+                'X' => {
+                    pauli_x.set(i, true);
+                    pauli_z.set(i, false);
+                }
+                'Z' => {
+                    pauli_x.set(i, false);
+                    pauli_z.set(i, true);
+                }
+                'Y' => {
+                    pauli_x.set(i, true);
+                    pauli_z.set(i, true);
+                    xz_phase = xz_phase.wrapping_add(1) & 3;
+                }
+                _ => {
+                    panic!("Incorrect label");
+                }
+            }
+        }
+
+        DensePauli {
+            pauli_x,
+            pauli_z,
+            xz_phase,
+        }
+    }
+
+    /// Construct a random dense Pauli operator on ``num_qubits`` qubits.
+    ///     
+    /// # Arguments
+    ///
+    /// * `num_qubits`: Number of qubits.
+    /// * `seed`: Random seed used for generation.
+    pub fn from_random(num_qubits: usize, seed: u64) -> Self {
+        let mut rng = Pcg64Mcg::seed_from_u64(seed);
+        let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
+        let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
+
+        for i in 0..num_qubits {
+            let val = rng.random_bool(0.5);
+            pauli_x.set(i, val);
+        }
+        for i in 0..num_qubits {
+            let val = rng.random_bool(0.5);
+            pauli_z.set(i, val);
+        }
+        let xz_phase = rng.random::<u8>() & 3;
+
+        DensePauli {
+            pauli_x,
+            pauli_z,
+            xz_phase,
+        }
+    }
+
+    /// Return the number of qubits in the Pauli.
+    pub fn num_qubits(&self) -> usize {
+        self.pauli_z.len()
+    }
+
+    /// Return the number of Y-terms in the Pauli.
+    pub fn count_y(&self) -> u8 {
+        let num_qubits = self.num_qubits();
+        let mut cnt_y = 0;
+        for i in 0..num_qubits {
+            if self.pauli_x[i] & self.pauli_z[i] {
+                cnt_y += 1;
+            }
+        }
+        cnt_y
+    }
+
+    /// Construct a string representation for the Pauli operator.
+    ///
+    /// .. note::
+    ///
+    ///     Unlike Python-space Qiskit convention, the label is represented left-to-right,
+    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `0`, followed by `'I'` on qubit `1`,
+    ///     and so on.
+    pub fn to_label(&self) -> String {
+        let mut s: String = Default::default();
+        let n = self.num_qubits();
+
+        let mut group_phase = self.xz_phase;
+        for i in 0..n {
+            match (self.pauli_x[i], self.pauli_z[i]) {
+                (false, false) => {
+                    s.push('I');
+                }
+                (false, true) => {
+                    s.push('Z');
+                }
+                (true, false) => {
+                    s.push('X');
+                }
+                (true, true) => {
+                    s.push('Y');
+                    group_phase = group_phase.wrapping_sub(1) & 3;
+                }
+            }
+        }
+
+        match group_phase {
+            0 => {
+                s = String::from("") + &s;
+            }
+            1 => {
+                s = String::from("i") + &s;
+            }
+            2 => {
+                s = String::from("-") + &s;
+            }
+            3 => {
+                s = String::from("-i") + &s;
+            }
+            _ => {
+                panic!("we should never get this")
+            }
+        }
+
+        s
+    }
+
+    /// Convert a dense Pauli operator to a sparse boolean representation,
+    /// removing identity ('I') terms.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_group_phase`: If `true`, the returned phase is a group phase. Otherwise,
+    ///   it is the XZ-phase.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing x-terms, z-terms, qubits indices and phase. Qubit indices
+    /// are sorted.
+    pub fn to_sparse_bool(&self, is_group_phase: bool) -> (Vec<bool>, Vec<bool>, Vec<u32>, u8) {
+        let num_qubits = self.num_qubits();
+        let mut pauli_x_sparse: Vec<bool> = Vec::with_capacity(num_qubits);
+        let mut pauli_z_sparse: Vec<bool> = Vec::with_capacity(num_qubits);
+        let mut out_indices: Vec<u32> = Vec::with_capacity(num_qubits);
+
+        for i in 0..num_qubits {
+            if self.pauli_x[i] || self.pauli_z[i] {
+                pauli_x_sparse.push(self.pauli_x[i]);
+                pauli_z_sparse.push(self.pauli_z[i]);
+                out_indices.push(i as u32);
+            }
+        }
+        let phase = if is_group_phase {
+            self.xz_phase.wrapping_sub(self.count_y()) & 3
+        } else {
+            self.xz_phase
+        };
+
+        (pauli_x_sparse, pauli_z_sparse, out_indices, phase)
+    }
+
+    /// Return whether two Paulis commute.
+    ///
+    /// Panics
+    ///
+    /// This function will panic if the two Paulis are of different length.
+    pub fn commutes(&self, other: &DensePauli) -> bool {
+        debug_assert!(self.num_qubits() == other.num_qubits());
+        let num_qubits = self.num_qubits();
+        let mut parity = false;
+        for i in 0..num_qubits {
+            parity ^= (self.pauli_z[i] & other.pauli_x[i]) ^ (self.pauli_x[i] & other.pauli_z[i]);
+        }
+        !parity
+    }
+
+    /// Compose ``self`` and ``other``, returning the result as a new Pauli.
+    ///
+    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
+    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    ///
+    /// Panics
+    ///
+    /// This function will panic if the two Paulis are of different length.
+    pub fn compose(&self, other: &DensePauli) -> DensePauli {
+        debug_assert!(self.num_qubits() == other.num_qubits());
+        let mut xz_phase = self.xz_phase + other.xz_phase;
+        let num_qubits = self.num_qubits();
+        for i in 0..num_qubits {
+            if self.pauli_x[i] && other.pauli_z[i] {
+                xz_phase += 2;
+            }
+        }
+        let pauli_x = &self.pauli_x ^ &other.pauli_x;
+        let pauli_z = &self.pauli_z ^ &other.pauli_z;
+        DensePauli {
+            pauli_x,
+            pauli_z,
+            xz_phase: xz_phase & 3u8,
+        }
+    }
+
+    /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
+    ///
+    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
+    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    ///
+    /// Panics
+    ///
+    /// This function will panic if the two Paulis are of different length.
+    pub fn compose_with(&mut self, other: &DensePauli) {
+        debug_assert!(self.num_qubits() == other.num_qubits());
+        let num_qubits = self.num_qubits();
+        self.xz_phase += other.xz_phase;
+        for i in 0..num_qubits {
+            if self.pauli_x[i] & other.pauli_z[i] {
+                self.xz_phase += 2;
+            }
+        }
+
+        self.pauli_x ^= &other.pauli_x;
+        self.pauli_z ^= &other.pauli_z;
+        self.xz_phase &= 3u8;
+    }
+}
+
+/// Evolve a Pauli :math:`P` by a Clifford :math:`C`, using the Heisenberg picture,
+/// namely compute :math:`C^\dagger P C`.
+///
+/// # Arguments
+///
+/// * `pauli`: The pauli to evolve.
+/// * `cliff`: The Clifford to evolve by.
+///
+/// Panics
+///
+/// This function will panic if the Clifford and the Pauli do not have the
+/// same number of qubits.
+pub fn evolve_pauli_by_clifford(pauli: &DensePauli, cliff: &Clifford) -> DensePauli {
+    debug_assert!(pauli.num_qubits() == cliff.num_qubits);
+    let num_qubits = cliff.num_qubits;
+    let mut out_pauli = DensePauli::identity(num_qubits);
+
+    // Decompose pauli as a tensor product of single qubit paulis on each of the qubits.
+    for qbit in 0..num_qubits {
+        // evolve the singe qubit pauli by cliff
+        let pz = pauli.pauli_z[qbit];
+        let px = pauli.pauli_x[qbit];
+
+        if (pz, px) != (false, false) {
+            // single qubit pauli is not I (only X, Y, Z)
+            let evolved_pauli = cliff.evolve_single_qubit_pauli_dense(pz, px, qbit);
+
+            // compose the ouput evolved dense paulies
+            out_pauli.compose_with(&evolved_pauli);
+        }
+    }
+
+    out_pauli.xz_phase += pauli.xz_phase;
+    out_pauli.xz_phase &= 3;
+    out_pauli
+}
+
+#[cfg(test)]
+mod tests {
+    use fixedbitset::FixedBitSet;
+
+    use crate::clifford::Clifford;
+    use crate::dense_pauli::{DensePauli, evolve_pauli_by_clifford};
+
+    #[test]
+    fn test_identity() {
+        let num_qubits = 3;
+        let pauli = DensePauli::identity(num_qubits);
+        assert_eq!(pauli.num_qubits(), 3);
+        assert_eq!(pauli.count_y(), 0);
+        assert_eq!(pauli.pauli_x, FixedBitSet::with_capacity(num_qubits));
+        assert_eq!(pauli.pauli_z, FixedBitSet::with_capacity(num_qubits));
+        assert_eq!(pauli.xz_phase, 0);
+    }
+
+    #[test]
+    fn test_from_sparse_bool_and_back() {
+        let pauli =
+            DensePauli::from_sparse_bool(3, &[true, false], &[true, true], &[1, 2], 2, true);
+        let mut expected_x = FixedBitSet::with_capacity(3);
+        expected_x.set(1, true);
+        let mut expected_z = FixedBitSet::with_capacity(3);
+        expected_z.set(1, true);
+        expected_z.set(2, true);
+        let expected_xz_phase = 3;
+        assert_eq!(pauli.num_qubits(), 3);
+        assert_eq!(pauli.count_y(), 1);
+        assert_eq!(pauli.pauli_x, expected_x);
+        assert_eq!(pauli.pauli_z, expected_z);
+        assert_eq!(pauli.xz_phase, expected_xz_phase);
+
+        let (x, z, indices, phase) = pauli.to_sparse_bool(true);
+        assert_eq!(x, vec![true, false]);
+        assert_eq!(z, vec![true, true]);
+        assert_eq!(indices, vec![1, 2]);
+        assert_eq!(phase, 2);
+    }
+
+    #[test]
+    fn test_from_label_and_back() {
+        let pauli = DensePauli::from_label("-iXZ");
+        let mut expected_x = FixedBitSet::with_capacity(2);
+        expected_x.set(0, true);
+        let mut expected_z = FixedBitSet::with_capacity(2);
+        expected_z.set(1, true);
+        let expected_xz_phase = 3;
+        assert_eq!(pauli.num_qubits(), 2);
+        assert_eq!(pauli.count_y(), 0);
+        assert_eq!(pauli.pauli_x, expected_x);
+        assert_eq!(pauli.pauli_z, expected_z);
+        assert_eq!(pauli.xz_phase, expected_xz_phase);
+
+        let pauli_label = pauli.to_label();
+        assert_eq!(pauli_label, String::from("-iXZ"));
+    }
+
+    /// Assert that commuting two Paulis P and Q gives the expected result.
+    fn assert_commute(p_label: &str, q_label: &str, expected: bool) {
+        let p = DensePauli::from_label(p_label);
+        let q = DensePauli::from_label(q_label);
+        let computed_pq = p.commutes(&q);
+        let computed_qp = p.commutes(&q);
+        assert_eq!(computed_pq, expected);
+        assert_eq!(computed_qp, expected);
+    }
+
+    #[test]
+    fn test_pauli_commute() {
+        assert_commute("XX", "YY", true);
+        assert_commute("XXX", "YYY", false);
+        assert_commute("XZ", "iZY", true);
+        assert_commute("III", "-iXYZ", true);
+        assert_commute("-XIXI", "iIZZI", false);
+        assert_commute("IXYZ", "IYZX", false);
+    }
+
+    /// Assert that multiplying Paulis P and Q gives the expected result.
+    fn assert_multiply(p_label: &str, q_label: &str, expected_label: &str) {
+        let p = DensePauli::from_label(p_label);
+        let q = DensePauli::from_label(q_label);
+        let expected = DensePauli::from_label(expected_label);
+        let computed = q.compose(&p);
+        assert_eq!(computed, expected);
+    }
+
+    #[test]
+    fn test_pauli_multiply() {
+        assert_multiply("X", "Y", "iZ");
+        assert_multiply("Y", "X", "-iZ");
+        assert_multiply("X", "Z", "-iY");
+        assert_multiply("Z", "X", "iY");
+        assert_multiply("Y", "Z", "iX");
+        assert_multiply("Z", "Y", "-iX");
+        assert_multiply("I", "X", "X");
+        assert_multiply("-iX", "iI", "X");
+        assert_multiply("iZ", "iZ", "-I");
+        assert_multiply("XX", "XY", "iIZ");
+        assert_multiply("XY", "XX", "-iIZ");
+    }
+
+    #[test]
+    fn test_compose_with() {
+        let mut p = DensePauli::identity(3);
+        p.compose_with(&DensePauli::from_label("iXYZ"));
+        assert_eq!(p, DensePauli::from_label("iXYZ"));
+        p.compose_with(&DensePauli::from_label("ZII"));
+        assert_eq!(p, DensePauli::from_label("-YYZ"));
+        p.compose_with(&DensePauli::from_label("-YYZ"));
+        assert_eq!(p, DensePauli::from_label("III"));
+    }
+
+    /// Assert that evolving P under Cliff gives the expected result.
+    fn assert_evolve(p_label: &str, cliff: &Clifford, expected_label: &str) {
+        let p = DensePauli::from_label(p_label);
+        let computed = evolve_pauli_by_clifford(&p, cliff);
+        let expected = DensePauli::from_label(expected_label);
+        assert_eq!(computed, expected);
+    }
+
+    #[test]
+    fn test_evolve_1_qubit() {
+        use ndarray::Array2;
+
+        let cliff_s = Clifford::from_array(
+            Array2::from(vec![[true, true, false], [false, true, false]]).view(),
+        );
+        let cliff_h = Clifford::from_array(
+            Array2::from(vec![[false, true, false], [true, false, false]]).view(),
+        );
+        let cliff_sdg = Clifford::from_array(
+            Array2::from(vec![[true, true, true], [false, true, false]]).view(),
+        );
+        let cliff_sx = Clifford::from_array(
+            Array2::from(vec![[true, false, false], [true, true, true]]).view(),
+        );
+        let cliff_sxdg = Clifford::from_array(
+            Array2::from(vec![[true, false, false], [true, true, false]]).view(),
+        );
+
+        assert_evolve("I", &cliff_s, "I");
+        assert_evolve("X", &cliff_s, "-Y");
+        assert_evolve("Z", &cliff_s, "Z");
+        assert_evolve("Y", &cliff_s, "X");
+        assert_evolve("-I", &cliff_s, "-I");
+        assert_evolve("-X", &cliff_s, "Y");
+        assert_evolve("-Z", &cliff_s, "-Z");
+        assert_evolve("-Y", &cliff_s, "-X");
+
+        assert_evolve("I", &cliff_sdg, "I");
+        assert_evolve("X", &cliff_sdg, "Y");
+        assert_evolve("Z", &cliff_sdg, "Z");
+        assert_evolve("Y", &cliff_sdg, "-X");
+        assert_evolve("-I", &cliff_sdg, "-I");
+        assert_evolve("-X", &cliff_sdg, "-Y");
+        assert_evolve("-Z", &cliff_sdg, "-Z");
+        assert_evolve("-Y", &cliff_sdg, "X");
+
+        assert_evolve("I", &cliff_h, "I");
+        assert_evolve("X", &cliff_h, "Z");
+        assert_evolve("Z", &cliff_h, "X");
+        assert_evolve("Y", &cliff_h, "-Y");
+        assert_evolve("-I", &cliff_h, "-I");
+        assert_evolve("-X", &cliff_h, "-Z");
+        assert_evolve("-Z", &cliff_h, "-X");
+        assert_evolve("-Y", &cliff_h, "Y");
+
+        assert_evolve("I", &cliff_sx, "I");
+        assert_evolve("X", &cliff_sx, "X");
+        assert_evolve("Z", &cliff_sx, "Y");
+        assert_evolve("Y", &cliff_sx, "-Z");
+        assert_evolve("-I", &cliff_sx, "-I");
+        assert_evolve("-X", &cliff_sx, "-X");
+        assert_evolve("-Z", &cliff_sx, "-Y");
+        assert_evolve("-Y", &cliff_sx, "Z");
+
+        assert_evolve("I", &cliff_sxdg, "I");
+        assert_evolve("X", &cliff_sxdg, "X");
+        assert_evolve("Z", &cliff_sxdg, "-Y");
+        assert_evolve("Y", &cliff_sxdg, "Z");
+        assert_evolve("-I", &cliff_sxdg, "-I");
+        assert_evolve("-X", &cliff_sxdg, "-X");
+        assert_evolve("-Z", &cliff_sxdg, "Y");
+        assert_evolve("-Y", &cliff_sxdg, "-Z");
+    }
+
+    #[test]
+    fn test_evolve_2_qubits() {
+        use ndarray::Array2;
+
+        // Random Clifford created from Python (with seed=1234).
+        let cliff = Clifford::from_array(
+            Array2::from(vec![
+                [false, true, false, true, false],
+                [false, true, true, true, true],
+                [true, false, true, true, false],
+                [true, false, true, false, true],
+            ])
+            .view(),
+        );
+
+        assert_evolve("XX", &cliff, "-ZX");
+        assert_evolve("YY", &cliff, "-XZ");
+        assert_evolve("YX", &cliff, "-YI");
+        assert_evolve("-YI", &cliff, "IZ");
+        assert_evolve("IZ", &cliff, "-ZZ");
+        assert_evolve("-ZY", &cliff, "IX");
+        assert_evolve("XY", &cliff, "IY");
+        assert_evolve("iXY", &cliff, "iIY");
+        assert_evolve("-XY", &cliff, "-IY");
+        assert_evolve("-iXY", &cliff, "-iIY");
+        assert_evolve("II", &cliff, "II");
+    }
+}

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -33,8 +33,11 @@ pub enum DensePauliError {
     DifferentLengthsCommute,
     #[error("`DensePauli::compose` requires both Paulis to have the same length")]
     DifferentLengthsCompose,
+    #[error(
+        "Evolving `DensePauli` under a `Clifford` requires both to have the same number of qubits."
+    )]
+    DifferentLengthsEvolve,
 }
-
 
 impl DensePauli {
     /// Return the identity Pauli operator on ``num_qubits`` qubits.
@@ -119,9 +122,9 @@ impl DensePauli {
     ///
     /// .. note::
     ///
-    ///     Unlike Python-space Qiskit convention, the label is represented left-to-right,
-    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `0`, followed by `'I'` on qubit `1`,
-    ///     and so on.
+    ///     In Qiskit convention, the label is represented right-to-left,
+    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `3`, followed by `'I'` on qubit `2`,
+    ///     followed by `'Z'` on qubit `1`, and finally by `'Y'` on qubit `0`.
     pub fn from_label(label: &str) -> Self {
         let mut s = label;
         let mut xz_phase = 0u8;
@@ -138,7 +141,7 @@ impl DensePauli {
         let mut pauli_x = FixedBitSet::with_capacity(num_qubits);
         let mut pauli_z = FixedBitSet::with_capacity(num_qubits);
 
-        for (i, c) in s.chars().enumerate() {
+        for (i, c) in s.chars().rev().enumerate() {
             match c {
                 'I' => {
                     pauli_x.set(i, false);
@@ -219,15 +222,15 @@ impl DensePauli {
     ///
     /// .. note::
     ///
-    ///     Unlike Python-space Qiskit convention, the label is represented left-to-right,
-    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `0`, followed by `'I'` on qubit `1`,
-    ///     and so on.
+    ///     In Qiskit convention, the label is represented right-to-left,
+    ///     for example "-iXIZY" is interpreted as `'X'` on qubit `3`, followed by `'I'` on qubit `2`,
+    ///     followed by `'Z'` on qubit `1`, and finally by `'Y'` on qubit `0`.
     pub fn to_label(&self) -> String {
         let mut s: String = Default::default();
         let n = self.num_qubits();
 
         let mut group_phase = self.xz_phase;
-        for i in 0..n {
+        for i in (0..n).rev() {
             match (self.pauli_x[i], self.pauli_z[i]) {
                 (false, false) => {
                     s.push('I');
@@ -308,6 +311,7 @@ impl DensePauli {
     ///
     /// See [`DensePauli::commutes`] for a safe version that validates input
     /// lengths.
+    #[inline(always)]
     pub fn commutes_unchecked(&self, other: &DensePauli) -> bool {
         let num_qubits = self.num_qubits();
         let mut parity = false;
@@ -321,35 +325,85 @@ impl DensePauli {
     ///
     /// This method checks that both Paulis act on the same number of qubits.
     /// If they do not, an error is returned.
-    /// 
+    ///
     /// See [`DensePauli::commutes_unchecked`] for a faster version without
     /// input validation.
-    /// 
+    ///
     /// # Errors
     ///
     /// Returns [`DensePauliError::DifferentLengthsCommute`] if the two Paulis
     /// have different lengths.
+    #[inline(always)]
     pub fn commutes(&self, other: &DensePauli) -> Result<bool, DensePauliError> {
         if self.num_qubits() != other.num_qubits() {
-            return Err(DensePauliError::DifferentLengthsCommute)
+            return Err(DensePauliError::DifferentLengthsCommute);
         }
         Ok(self.commutes_unchecked(other))
     }
 
-
-
-
-
-    /// Compose ``self`` and ``other``, returning the result as a new Pauli.
+    /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
     ///
     /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
     /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
     ///
-    /// Panics
+    /// This method **does not check** that the two Paulis act on the same
+    /// number of qubits. Calling it with mismatched lengths results in an
+    /// **undefined logical behavior**.
     ///
-    /// This function will panic if the two Paulis are of different length.
-    pub fn compose(&self, other: &DensePauli) -> DensePauli {
-        debug_assert!(self.num_qubits() == other.num_qubits());
+    /// See [`DensePauli::compose_with`] for a safe version that validates input
+    /// lengths.
+    #[inline(always)]
+    pub fn compose_with_unchecked(&mut self, other: &DensePauli) {
+        // note: on my MacOS this function is surprisingly *slower* than compose_with,
+        // so best to always call compose_with method instead of this one.
+        let num_qubits = self.num_qubits();
+        self.xz_phase += other.xz_phase;
+        for i in 0..num_qubits {
+            if self.pauli_x[i] & other.pauli_z[i] {
+                self.xz_phase += 2;
+            }
+        }
+
+        self.pauli_x ^= &other.pauli_x;
+        self.pauli_z ^= &other.pauli_z;
+        self.xz_phase &= 3u8;
+    }
+
+    /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
+    ///
+    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
+    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    ///
+    /// This method checks that both Paulis act on the same number of qubits.
+    /// If they do not, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DensePauliError::DifferentLengthsCompose`] if the two Paulis
+    /// have different lengths.
+    #[inline(always)]
+    pub fn compose_with(&mut self, other: &DensePauli) -> Result<(), DensePauliError> {
+        if self.num_qubits() != other.num_qubits() {
+            return Err(DensePauliError::DifferentLengthsCompose);
+        }
+        self.compose_with_unchecked(other);
+
+        Ok(())
+    }
+
+    /// Compose ``self`` and ``other``, returning the result in a new Pauli.
+    ///
+    /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
+    /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
+    ///
+    /// This method **does not check** that the two Paulis act on the same
+    /// number of qubits. Calling it with mismatched lengths results in an
+    /// **undefined logical behavior**.
+    ///
+    /// See [`DensePauli::compose`] for a safe version that validates input
+    /// lengths.
+    #[inline(always)]
+    pub fn compose_unchecked(&self, other: &DensePauli) -> DensePauli {
         let mut xz_phase = self.xz_phase + other.xz_phase;
         let num_qubits = self.num_qubits();
         for i in 0..num_qubits {
@@ -366,63 +420,26 @@ impl DensePauli {
         }
     }
 
-    /// Compose ``self`` and ``other``, modifying the current Pauli in-place.
+    /// Compose ``self`` and ``other``, returning the result in a new Pauli.
     ///
     /// As a transformation, composing two Paulis ``P`` and ``Q`` means first applying
     /// ``P`` and then applying ``Q``. As a Pauli, this is the same as ``P * Q``.
     ///
-    /// Panics
+    /// This method checks that both Paulis act on the same number of qubits.
+    /// If they do not, an error is returned.
     ///
-    /// This function will panic if the two Paulis are of different length.
-    pub fn compose_with_unchecked(&mut self, other: &DensePauli) {
-        debug_assert!(self.num_qubits() == other.num_qubits());
-        let num_qubits = self.num_qubits();
-        self.xz_phase += other.xz_phase;
-        for i in 0..num_qubits {
-            if self.pauli_x[i] & other.pauli_z[i] {
-                self.xz_phase += 2;
-            }
-        }
-
-        self.pauli_x ^= &other.pauli_x;
-        self.pauli_z ^= &other.pauli_z;
-        self.xz_phase &= 3u8;
-    }
-
-    pub fn compose_with3(&mut self, other: &DensePauli) {
-        debug_assert!(self.num_qubits() == other.num_qubits());
-        self.pauli_x ^= &other.pauli_x;
-        self.pauli_z ^= &other.pauli_z;
-
-        let num_qubits = self.num_qubits();
-        self.xz_phase += other.xz_phase;
-        for i in 0..num_qubits {
-            if self.pauli_x[i] & other.pauli_z[i] {
-                self.xz_phase += 2;
-            }
-        }
-
-        self.xz_phase &= 3u8;
-
-    }
-
-
-
-
-     pub fn compose_with(&mut self, other: &DensePauli) -> Result<(), DensePauliError> {
-        
+    /// # Errors
+    ///
+    /// Returns [`DensePauliError::DifferentLengthsCompose`] if the two Paulis
+    /// have different lengths.
+    #[inline(always)]
+    pub fn compose(&self, other: &DensePauli) -> Result<DensePauli, DensePauliError> {
         if self.num_qubits() != other.num_qubits() {
-            return Err(DensePauliError::DifferentLengthsCompose);
+            return Err(DensePauliError::DifferentLengthsCommute);
         }
-        self.compose_with_unchecked(other);
-
-        Ok(())
+        Ok(self.compose_unchecked(other))
     }
 }
-
-
-
-
 
 /// Evolve a Pauli :math:`P` by a Clifford :math:`C`, using the Heisenberg picture,
 /// namely compute :math:`C^\dagger P C`.
@@ -432,12 +449,17 @@ impl DensePauli {
 /// * `pauli`: The pauli to evolve.
 /// * `cliff`: The Clifford to evolve by.
 ///
-/// Panics
+/// # Errors
 ///
-/// This function will panic if the Clifford and the Pauli do not have the
-/// same number of qubits.
-pub fn evolve_pauli_by_clifford(pauli: &DensePauli, cliff: &Clifford) -> DensePauli {
-    debug_assert!(pauli.num_qubits() == cliff.num_qubits);
+/// Returns [`DensePauliError::DifferentLengthsEvolve`] if `pauli` and `clifford`
+/// are not defined for the same number of qubits.
+pub fn evolve_pauli_by_clifford(
+    pauli: &DensePauli,
+    cliff: &Clifford,
+) -> Result<DensePauli, DensePauliError> {
+    if pauli.num_qubits() != cliff.num_qubits {
+        return Err(DensePauliError::DifferentLengthsEvolve);
+    }
     let num_qubits = cliff.num_qubits;
     let mut out_pauli = DensePauli::identity(num_qubits);
 
@@ -458,13 +480,11 @@ pub fn evolve_pauli_by_clifford(pauli: &DensePauli, cliff: &Clifford) -> DensePa
 
     out_pauli.xz_phase += pauli.xz_phase;
     out_pauli.xz_phase &= 3;
-    out_pauli
+    Ok(out_pauli)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
     use fixedbitset::FixedBitSet;
 
     use crate::clifford::Clifford;
@@ -508,9 +528,9 @@ mod tests {
     fn test_from_label_and_back() {
         let pauli = DensePauli::from_label("-iXZ");
         let mut expected_x = FixedBitSet::with_capacity(2);
-        expected_x.set(0, true);
+        expected_x.set(1, true);
         let mut expected_z = FixedBitSet::with_capacity(2);
-        expected_z.set(1, true);
+        expected_z.set(0, true);
         let expected_xz_phase = 3;
         assert_eq!(pauli.num_qubits(), 2);
         assert_eq!(pauli.count_y(), 0);
@@ -547,7 +567,7 @@ mod tests {
         let p = DensePauli::from_label(p_label);
         let q = DensePauli::from_label(q_label);
         let expected = DensePauli::from_label(expected_label);
-        let computed = q.compose(&p);
+        let computed = q.compose_unchecked(&p);
         assert_eq!(computed, expected);
     }
 
@@ -580,7 +600,7 @@ mod tests {
     /// Assert that evolving P under Cliff gives the expected result.
     fn assert_evolve(p_label: &str, cliff: &Clifford, expected_label: &str) {
         let p = DensePauli::from_label(p_label);
-        let computed = evolve_pauli_by_clifford(&p, cliff);
+        let computed = evolve_pauli_by_clifford(&p, cliff).unwrap();
         let expected = DensePauli::from_label(expected_label);
         assert_eq!(computed, expected);
     }
@@ -666,85 +686,16 @@ mod tests {
             .view(),
         );
 
-        assert_evolve("XX", &cliff, "-ZX");
-        assert_evolve("YY", &cliff, "-XZ");
-        assert_evolve("YX", &cliff, "-YI");
-        assert_evolve("-YI", &cliff, "IZ");
-        assert_evolve("IZ", &cliff, "-ZZ");
-        assert_evolve("-ZY", &cliff, "IX");
-        assert_evolve("XY", &cliff, "IY");
-        assert_evolve("iXY", &cliff, "iIY");
-        assert_evolve("-XY", &cliff, "-IY");
-        assert_evolve("-iXY", &cliff, "-iIY");
+        assert_evolve("XX", &cliff, "-XZ");
+        assert_evolve("YY", &cliff, "-ZX");
+        assert_evolve("XY", &cliff, "-IY");
+        assert_evolve("-IY", &cliff, "ZI");
+        assert_evolve("ZI", &cliff, "-ZZ");
+        assert_evolve("-YZ", &cliff, "XI");
+        assert_evolve("YX", &cliff, "YI");
+        assert_evolve("iYX", &cliff, "iYI");
+        assert_evolve("-YX", &cliff, "-YI");
+        assert_evolve("-iYX", &cliff, "-iYI");
         assert_evolve("II", &cliff, "II");
     }
-
-
-    #[test]
-    fn test_timings() {
-        // for nq in (0..10).chain([100, 1000, 10000, 100000]) {
-        //     let paulis: Vec<DensePauli> = (0..=10000).map(|i| DensePauli::from_random(nq, i as u64)).collect();
-
-
-
-        //     let start = Instant::now();
-        //     for _ in 0..100 {
-        //         for i in 0..10000 {
-        //              let _ = paulis[i].commutes(&paulis[i+1]).unwrap();
-
-        //         }
-        //     }
-        //     let duration = start.elapsed();
-
-
-        //     let start = Instant::now();
-        //     for _ in 0..100 {
-        //         for i in 0..10000 {
-        //             let _ = paulis[i].commutes_unchecked(&paulis[i+1]);
-        //         }
-        //     }
-        //     let duration2 = start.elapsed();
-
-        //     println!("nq = {:?}, commutation1 {:?}, commutation2 {:?}", nq, duration, duration2);
-        // }
-
-        for nq in (0..10).chain([100, 1000, 10000]) {
-            let paulis: Vec<DensePauli> = (0..10000).map(|i| DensePauli::from_random(nq, i as u64)).collect();
-
-            let start = Instant::now();
-            for _ in 0..100 {
-                let mut p = DensePauli::identity(nq);
-                for i in 0..10000 {
-                    p.compose_with_unchecked(&paulis[i]);
-                }
-            }
-            let duration = start.elapsed();
-
-
-            let start = Instant::now();
-            for _ in 0..100 {
-                let mut p = DensePauli::identity(nq);
-                for i in 0..10000 {
-                    p.compose_with(&paulis[i]).unwrap();
-                }
-            }
-            let duration2 = start.elapsed();
-
-
-
-            let start = Instant::now();
-            for _ in 0..100 {
-                let mut p = DensePauli::identity(nq);
-                for i in 0..10000 {
-                    p.compose_with3(&paulis[i]);
-                }
-            }
-            let duration3 = start.elapsed();
-
-            println!("nq = {:?}, composition1 {:?}, composition2 {:?}, composition3 {:?}", nq, duration, duration2, duration3);
-        }
-    }
-
 }
-
-

--- a/crates/quantum_info/src/dense_pauli.rs
+++ b/crates/quantum_info/src/dense_pauli.rs
@@ -250,9 +250,7 @@ impl DensePauli {
         }
 
         match group_phase {
-            0 => {
-                s = String::from("") + &s;
-            }
+            0 => {}
             1 => {
                 s = String::from("i") + &s;
             }
@@ -682,7 +680,8 @@ mod tests {
     fn test_evolve_2_qubits() {
         use ndarray::Array2;
 
-        // Random Clifford created from Python (with seed=1234).
+        // The assertions below were generated using the Clifford class in python, where the
+        // Clifford below was generated via ``random_clifford(2, seed=1234)``.
         let cliff = Clifford::from_array(
             Array2::from(vec![
                 [false, true, false, true, false],

--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 pub mod clifford;
+pub mod dense_pauli;
 pub mod pauli_lindblad_map;
 pub mod sparse_observable;
 pub mod sparse_pauli_op;


### PR DESCRIPTION
### Summary

This PR adds a `DensePauli` class in Rust.  

The `DensePauli` class is required for extending the Litinski transform to support Pauli rotations (see #15974), and in fact the current implementation is initially based on the implementation there. The plan is to rebase #15974 on top of this PR when this merges. The `DensePauli` class is also required for the other current work of extending the Rust-based StabilizerTableau (Clifford) simulation to support projective Pauli measurements. It can also eventually become a viable alternative to the Python `Pauli` class, allowing to replace the python Pauli class by the much faster rust Pauli class.

Implementation-wise, `DensePauli` is as follows:
```rust
pub struct DensePauli {
    /// z-component
    pub pauli_z: FixedBitSet,
    /// x-component
    pub pauli_x: FixedBitSet,
    /// zx-phase
    pub zx_phase: u8,
}
```
The Z- and X- Pauli components are stored using `FixedBitSet`, allowing bit-packing and word-level operations, and leading to very fast commutativity and multiplication methods. 

Additionally, this implements a function `evolve_pauli_by_clifford` to evolve a Clifford by a dense Pauli.

Co-authored with Shelly Garion.


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
