### PR TITLE
Fix MultiplierGate decomposition result width

### DIFF
--- a/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
@@ -198,4 +198,4 @@ class MultiplierGate(Gate):
         # This particular decomposition does not use any ancilla qubits.
         # Note that the transpiler may choose a different decomposition
         # based on the number of ancilla qubits available.
-        self.definition = multiplier_qft_r17(self.num_state_qubits)
+        self.definition = multiplier_qft_r17(self.num_state_qubits, self.num_result_qubits)

--- a/releasenotes/notes/fix-multipliergate-result-width-8a7d23e4b5a9c1f0.yaml
+++ b/releasenotes/notes/fix-multipliergate-result-width-8a7d23e4b5a9c1f0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed :class:`.MultiplierGate` so that its synthesized definition preserves
+    the configured result-register width. Previously, decomposing a multiplier
+    gate with a reduced result width could produce a definition with too many
+    qubits.

--- a/test/python/circuit/library/test_multipliers.py
+++ b/test/python/circuit/library/test_multipliers.py
@@ -154,6 +154,14 @@ class TestMultiplier(QiskitTestCase):
             with self.assertWarns(DeprecationWarning):
                 _ = multiplier(num_state_qubits, num_result_qubits)
 
+    def test_multiplier_gate_decompose_with_reduced_result_register(self):
+        """Test decompose respects a multiplier gate's configured result width."""
+        multiplier = MultiplierGate(1, 1)
+        circuit = QuantumCircuit(multiplier.num_qubits)
+        circuit.append(multiplier, range(multiplier.num_qubits))
+
+        self.assertEqual(circuit.decompose().num_qubits, multiplier.num_qubits)
+
     def test_modular_cumulative_multiplier_custom_adder(self):
         """Test an error is raised when a custom adder is used with modular cumulative multiplier."""
         with self.assertRaises(NotImplementedError):

--- a/test/python/circuit/library/test_multipliers.py
+++ b/test/python/circuit/library/test_multipliers.py
@@ -157,10 +157,8 @@ class TestMultiplier(QiskitTestCase):
     def test_multiplier_gate_decompose_with_reduced_result_register(self):
         """Test decompose respects a multiplier gate's configured result width."""
         multiplier = MultiplierGate(1, 1)
-        circuit = QuantumCircuit(multiplier.num_qubits)
-        circuit.append(multiplier, range(multiplier.num_qubits))
 
-        self.assertEqual(circuit.decompose().num_qubits, multiplier.num_qubits)
+        self.assertEqual(multiplier.definition.num_qubits, multiplier.num_qubits)
 
     def test_modular_cumulative_multiplier_custom_adder(self):
         """Test an error is raised when a custom adder is used with modular cumulative multiplier."""


### PR DESCRIPTION
### Summary
- pass `MultiplierGate.num_result_qubits` through to the QFT multiplier definition
- simplify the regression test assertion
- add a release note for the reduced result-width fix

Fixes #16168

### AI usage
This PR was prepared with assistance from an AI coding tool and reviewed/edited before submission.

### Verification
- `python3 -m pytest test/python/circuit/library/test_multipliers.py -q` *(blocked locally: missing `ddt` test dependency)*
- `git diff --check`