### PR TITLE
Fix redundant unit numerator in pi_check pi fractions

### DIFF
--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -137,7 +137,14 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
         if frac[0].shape[0]:
             numer = int(frac[1][0]) + 1
             denom = int(frac[0][0]) + 1
-            if output == "latex":
+            if numer == 1:
+                if output == "latex":
+                    str_out = f"\\frac{{{neg_str}{pi}}}{{{denom}}}"
+                elif output == "qasm":
+                    str_out = f"{neg_str}{pi}/{denom}"
+                else:
+                    str_out = f"{neg_str}{pi}/{denom}"
+            elif output == "latex":
                 str_out = f"\\frac{{{neg_str}{numer}{pi}}}{{{denom}}}"
             elif output == "qasm":
                 str_out = f"{neg_str}{numer}*{pi}/{denom}"

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -122,13 +122,16 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
         # Fourth check is for fractions for 1*pi in the numer and any
         # number in the denom.
         val = np.pi / single_inpt
-        if abs(abs(val) - abs(round(val))) < eps:
-            val = int(abs(round(val)))
-            if output == "latex":
-                str_out = f"\\frac{{{neg_str}{pi}}}{{{val}}}"
-            else:
-                str_out = f"{neg_str}{pi}/{val}"
-            return str_out
+        denom = int(abs(round(val)))
+        if denom >= 1:
+            reciprocal_close = abs(abs(val) - denom) < eps
+            angle_close = abs(abs(single_inpt) - np.pi / denom) < eps
+            if reciprocal_close or (angle_close and denom <= MAX_FRAC):
+                if output == "latex":
+                    str_out = f"\\frac{{{neg_str}{pi}}}{{{denom}}}"
+                else:
+                    str_out = f"{neg_str}{pi}/{denom}"
+                return str_out
 
         # Fifth check is for fractions where the numer > 1*pi and numer
         # is up to MAX_FRAC*pi and denom is up to MAX_FRAC and all
@@ -137,14 +140,7 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
         if frac[0].shape[0]:
             numer = int(frac[1][0]) + 1
             denom = int(frac[0][0]) + 1
-            if numer == 1:
-                if output == "latex":
-                    str_out = f"\\frac{{{neg_str}{pi}}}{{{denom}}}"
-                elif output == "qasm":
-                    str_out = f"{neg_str}{pi}/{denom}"
-                else:
-                    str_out = f"{neg_str}{pi}/{denom}"
-            elif output == "latex":
+            if output == "latex":
                 str_out = f"\\frac{{{neg_str}{numer}{pi}}}{{{denom}}}"
             elif output == "qasm":
                 str_out = f"{neg_str}{numer}*{pi}/{denom}"

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -20,7 +20,7 @@ from qiskit.exceptions import QiskitError
 MAX_FRAC = 16
 # Max denominator k for pi/k in the fourth check (2-digit denominators).
 # The different threshold compared to MAX_FRAC is historic, since previous versions
-# of Qiskit used a slightly different, inconsistent check that led to higher fractions 
+# of Qiskit used a slightly different, inconsistent check that led to higher fractions
 # being detected.
 MAX_PI_FRAC = 99
 N, D = np.meshgrid(np.arange(1, MAX_FRAC + 1), np.arange(1, MAX_FRAC + 1))

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -18,6 +18,8 @@ from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.exceptions import QiskitError
 
 MAX_FRAC = 16
+# Max denominator k for pi/k in the fourth check (2-digit denominators; see pi_check).
+MAX_PI_FRAC = 99
 N, D = np.meshgrid(np.arange(1, MAX_FRAC + 1), np.arange(1, MAX_FRAC + 1))
 FRAC_MESH = N / D * np.pi
 RECIP_MESH = N / D / np.pi
@@ -124,9 +126,8 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
         val = np.pi / single_inpt
         denom = int(abs(round(val)))
         if denom >= 1:
-            reciprocal_close = abs(abs(val) - denom) < eps
             angle_close = abs(abs(single_inpt) - np.pi / denom) < eps
-            if reciprocal_close or (angle_close and denom <= MAX_FRAC):
+            if angle_close and denom <= MAX_PI_FRAC:
                 if output == "latex":
                     str_out = f"\\frac{{{neg_str}{pi}}}{{{denom}}}"
                 else:

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -18,7 +18,10 @@ from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.exceptions import QiskitError
 
 MAX_FRAC = 16
-# Max denominator k for pi/k in the fourth check (2-digit denominators; see pi_check).
+# Max denominator k for pi/k in the fourth check (2-digit denominators).
+# The different threshold compared to MAX_FRAC is historic, since previous versions
+# of Qiskit used a slightly different, inconsistent check that led to higher fractions 
+# being detected.
 MAX_PI_FRAC = 99
 N, D = np.meshgrid(np.arange(1, MAX_FRAC + 1), np.arange(1, MAX_FRAC + 1))
 FRAC_MESH = N / D * np.pi

--- a/releasenotes/notes/fix-pi-check-unit-numerator-pi-fraction-16170.yaml
+++ b/releasenotes/notes/fix-pi-check-unit-numerator-pi-fraction-16170.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    ``pi_check`` and circuit visualization no longer print a redundant leading ``1`` for
+    angles within tolerance of :math:`\pi/k` for integer :math:`k` (for example ``1π/2``
+    is now ``π/2``), including ``latex``, ``mpl``, and ``qasm`` output modes.
+
+    Fixes `#16170 <https://github.com/Qiskit/qiskit/issues/16170>`__.

--- a/test/python/circuit/test_tools.py
+++ b/test/python/circuit/test_tools.py
@@ -95,6 +95,15 @@ class TestPiCheck(QiskitTestCase):
         result = pi_check(input_number)
         self.assertEqual(result, expected_string)
 
+    def test_near_pi_over_k_no_redundant_coefficient(self):
+        """Floats near π/k format like π/k, not 1π/k — #16170"""
+        a = 1.5707963276708181
+        self.assertEqual(pi_check(a), "π/2")
+        self.assertEqual(pi_check(a, output="latex"), "\\frac{\\pi}{2}")
+        self.assertEqual(pi_check(a, output="mpl"), "$\\pi$/2")
+        self.assertEqual(pi_check(a, output="qasm"), "pi/2")
+        self.assertEqual(pi_check(-a), "-π/2")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #16170

### The issue

For some floats slightly off from values like π/2, `pi_check` formatted them as `1π/2` instead of `π/2` in circuit text output (and other `pi_check` output modes).

### What was changed

The fourth check for π/k now uses the same angle tolerance as the mesh logic below (`|x − π/k| < eps`), with `MAX_PI_FRAC = 99` for denominators under 100. That covers the issue float and keeps `text`, `latex`, `mpl`, and `qasm` consistent.

Added a regression test using `1.5707963276708181` from the issue, plus negative and other output modes.

### How this was verified

Ran all 42 tests in `test/python/circuit/test_tools.py` locally on Python 3.13 with an editable install.

### Release notes

Added a Reno fragment under `fixes` for the user-visible string change.

### AI/LLM disclosure

- [x] I didn’t use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Gemini 3 PRO
- [ ] I used the following tool to generate or modify code: