### PR TITLE
Add register query functions to the C API

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -106,10 +106,8 @@ mod circuit {
             export_fn!(qk_classical_register_circuit_bits),
             export_fn!(qk_circuit_num_quantum_registers),
             export_fn!(qk_circuit_get_quantum_register),
-            export_fn!(qk_circuit_qubit_owning_register),
             export_fn!(qk_circuit_num_classical_registers),
             export_fn!(qk_circuit_get_classical_register),
-            export_fn!(qk_circuit_clbit_owning_register),
         ]
     });
 }

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -98,6 +98,18 @@ mod circuit {
             export_fn!(qk_circuit_global_phase),
             export_fn!(qk_circuit_set_global_phase),
             export_fn!(qk_circuit_estimate_fidelity),
+            export_fn!(qk_quantum_register_name),
+            export_fn!(qk_quantum_register_num_bits),
+            export_fn!(qk_quantum_register_circuit_bits),
+            export_fn!(qk_classical_register_name),
+            export_fn!(qk_classical_register_num_bits),
+            export_fn!(qk_classical_register_circuit_bits),
+            export_fn!(qk_circuit_num_quantum_registers),
+            export_fn!(qk_circuit_get_quantum_register),
+            export_fn!(qk_circuit_qubit_owning_register),
+            export_fn!(qk_circuit_num_classical_registers),
+            export_fn!(qk_circuit_get_classical_register),
+            export_fn!(qk_circuit_clbit_owning_register),
         ]
     });
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -2682,7 +2682,7 @@ pub unsafe extern "C" fn qk_circuit_estimate_fidelity(
 
 #[cfg(test)]
 mod test {
-    use crate::circuit::{qk_classical_register_circuit_bits, qk_quantum_register_circuit_bits};
+    use super::*;
     use qiskit_circuit::{
         bit::{ClassicalRegister, QuantumRegister, ShareableClbit, ShareableQubit},
         circuit_data::CircuitData,

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister)
 ///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
 ///     char *name = qk_classical_register_name(cr);
 ///     printf("Register name: %s\n", name);
-///     free(name);
+///     qk_str_free(name);
 ///     qk_classical_register_free(cr);
 /// ```
 ///

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use std::ffi::{CStr, CString, c_char};
+use std::ptr;
 
 use crate::circuit_library::pbc::{CPauliProductMeasurement, CPauliProductRotation};
 use crate::dag::COperationKind;
@@ -140,34 +141,120 @@ pub unsafe extern "C" fn qk_quantum_register_free(reg: *mut QuantumRegister) {
     }
 }
 
-/// @ingroup QkClassicalRegister
-/// Free a classical register.
+/// @ingroup QkQuantumRegister
+/// Get the name of a quantum register.
 ///
-/// @param reg A pointer to the register to free.
+/// Returns a newly allocated C string containing the name of the quantum register.
+///
+/// @param qreg A pointer to the quantum register.
+///
+/// @return A pointer to a newly allocated null-terminated string containing the register name.
+///         The caller must free this string using `qk_str_free`.
 ///
 /// # Example
 /// ```c
-///     QkClassicalRegister *cr = qk_classical_register_new(1024, "creg");
-///     qk_classical_register_free(cr);
+///     QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
+///     char *name = qk_quantum_register_name(qr);
+///     printf("Register name: %s\n", name);
+///     qk_str_free(name);
+///     qk_quantum_register_free(qr);
 /// ```
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``reg`` is not either null or a valid pointer to a
-/// ``QkClassicalRegister``.
+/// Behavior is undefined if ``qreg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister) {
-    if !reg.is_null() {
-        if !reg.is_aligned() {
-            panic!("Attempted to free a non-aligned pointer.")
-        }
+pub unsafe extern "C" fn qk_quantum_register_name(qreg: *const QuantumRegister) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let qreg = unsafe { const_ptr_as_ref(qreg) };
 
-        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
-        // readable by Box.
-        unsafe {
-            let _ = Box::from_raw(reg);
-        }
-    }
+    CString::new(qreg.name())
+        .expect("Register name contains null byte")
+        .into_raw()
+}
+
+/// @ingroup QkQuantumRegister
+/// Get the number of bits in a quantum register.
+///
+/// Returns the size (number of bits) of the quantum register.
+///
+/// @param qreg A pointer to the quantum register.
+///
+/// @return The number of bits in the register.
+///
+/// # Example
+/// ```c
+///     QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
+///     size_t num_qubits = qk_quantum_register_num_bits(qr);
+///     printf("Number of qubits: %zu\n", num_qubits);  // Prints: 5
+///     qk_quantum_register_free(qr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``qreg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegister) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let qreg = unsafe { const_ptr_as_ref(qreg) };
+
+    qreg.len()
+}
+
+/// @ingroup QkQuantumRegister
+/// Get the circuit bit indices for all qubits in a quantum register.
+///
+/// Outputs a mapping from each qubit in the quantum register to its corresponding index in the circuit's
+/// qubit list. If a qubit from the register is not present in the circuit, its index
+/// in the mapping will be -1.
+///
+/// @param qreg A pointer to the quantum register to map.
+/// @param circuit A pointer to the circuit containing the qubits.
+/// @param out_bits A pointer to an array where the mapped indices will be written.
+///                 The array must be pre-allocated with at least `qk_quantum_register_num_bits` elements
+///                 for `qreg`. Each element will contain either the circuit bit index (>= 0) or -1
+///                 if the qubit is not in the circuit.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(2, 0);
+///     QkQuantumRegister *qr = qk_quantum_register_new(3, "my_qreg");
+///     qk_circuit_add_quantum_register(qc, qr);
+///
+///     int64_t bit_indices[3];
+///
+///     qk_quantum_register_circuit_bits(qr, qc, bit_indices);
+///
+///     // bit_indices now contains [2, 3, 4] since all qubits are in the circuit
+///     // and the circuit has 2 anonymous qubits
+///
+///     qk_quantum_register_free(qr);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if:
+/// - ``qreg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
+/// - ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+/// - ``out_bits`` is not a valid, non-null pointer to an array with at least
+///   ``qk_quantum_register_num_bits(qreg)`` elements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
+    qreg: *const QuantumRegister,
+    circuit: *const CircuitData,
+    out_bits: *mut i64,
+) {
+    // SAFETY: Per documentation, qreg is a valid, non-null pointer.
+    let qreg = unsafe { const_ptr_as_ref(qreg) };
+    // SAFETY: Per documentation, circuit is a valid, non-null pointer.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    qreg.iter().enumerate().for_each(|(i, qubit)| {
+        let mapped_qubit = circuit.qubit_index(&qubit).map_or(-1, |q| q as i64);
+        // SAFETY: Per documentation, out_bits has at least qreg.len() elements
+        unsafe { out_bits.add(i).write(mapped_qubit) };
+    });
 }
 
 /// @ingroup QkClassicalRegister
@@ -205,6 +292,152 @@ pub unsafe extern "C" fn qk_classical_register_new(
     Box::into_raw(Box::new(reg))
 }
 
+/// @ingroup QkClassicalRegister
+/// Free a classical register.
+///
+/// @param reg A pointer to the register to free.
+///
+/// # Example
+/// ```c
+///     QkClassicalRegister *cr = qk_classical_register_new(1024, "creg");
+///     qk_classical_register_free(cr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``reg`` is not either null or a valid pointer to a
+/// ``QkClassicalRegister``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister) {
+    if !reg.is_null() {
+        if !reg.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(reg);
+        }
+    }
+}
+
+/// @ingroup QkClassicalRegister
+/// Get the name of a classical register.
+///
+/// Returns a newly allocated C string containing the name of the classical register.
+///
+/// @param creg A pointer to the classical register.
+///
+/// @return A pointer to a newly allocated null-terminated string containing the register name.
+///         The caller must free this string using `qk_str_free`.
+///
+/// # Example
+/// ```c
+///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+///     char *name = qk_classical_register_name(cr);
+///     printf("Register name: %s\n", name);
+///     free(name);
+///     qk_classical_register_free(cr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``creg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_name(creg: *const ClassicalRegister) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let creg = unsafe { const_ptr_as_ref(creg) };
+
+    CString::new(creg.name())
+        .expect("Register name contains null byte")
+        .into_raw()
+}
+
+/// @ingroup QkClassicalRegister
+/// Get the number of classical bits in a classical register.
+///
+/// Returns the size (number of classical bits) of the classical register.
+///
+/// @param creg A pointer to the classical register.
+///
+/// @return The number of classical bits in the register.
+///
+/// # Example
+/// ```c
+///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+///     size_t num_clbits = qk_classical_register_num_bits(cr);
+///     printf("Number of clbits: %zu\n", num_clbits);  // Prints: 3
+///     qk_classical_register_free(cr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``creg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRegister) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let creg = unsafe { const_ptr_as_ref(creg) };
+
+    creg.len()
+}
+
+/// @ingroup QkClassicalRegister
+/// Get the circuit bit indices for all clbits in a classical register.
+///
+/// Outputs a mapping from each clbit in the classical register to its corresponding index in the circuit's
+/// clbit list. If a clbit from the register is not present in the circuit, its index
+/// in the mapping will be -1.
+///
+/// @param creg A pointer to the classical register to map.
+/// @param circuit A pointer to the circuit containing the clbits.
+/// @param out_bits A pointer to an array where the mapped indices will be written.
+///                 The array must be pre-allocated with at least `qk_classical_register_num_bits` elements
+///                 for `creg`. Each element will contain either the circuit bit index (>= 0) or -1
+///                 if the clbit is not in the circuit.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 2);
+///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+///     qk_circuit_add_classical_register(qc, cr);
+///
+///     int64_t bit_indices[3];
+///
+///     qk_classical_register_circuit_bits(cr, qc, bit_indices);
+///
+///     // bit_indices now contains [2, 3, 4] since all clbits are in the circuit
+///     // and the circuit has 2 anonymous clbits
+///
+///     qk_classical_register_free(cr);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if:
+/// - ``creg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
+/// - ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+/// - ``out_bits`` is not a valid, non-null pointer to an array with at least
+///   ``qk_classical_register_num_bits(creg)`` elements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_circuit_bits(
+    creg: *const ClassicalRegister,
+    circuit: *const CircuitData,
+    out_bits: *mut i64,
+) {
+    // SAFETY: Per documentation, creg is a valid, non-null pointer.
+    let creg = unsafe { const_ptr_as_ref(creg) };
+    // SAFETY: Per documentation, circuit is a valid, non-null pointer.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    creg.iter().enumerate().for_each(|(i, clbit)| {
+        let mapped_clbit = circuit.clbit_index(&clbit).map_or(-1, |c| c as i64);
+        // SAFETY: Per documentation, out_bits has at least creg.len() elements
+        unsafe { out_bits.add(i).write(mapped_clbit) };
+    });
+}
+
 /// @ingroup QkCircuit
 /// Add a quantum register to a given quantum circuit
 ///
@@ -239,6 +472,135 @@ pub unsafe extern "C" fn qk_circuit_add_quantum_register(
 }
 
 /// @ingroup QkCircuit
+/// Get the number of quantum registers in the circuit.
+///
+/// Returns the number of quantum registers that have been added to the circuit.
+///
+/// @param circuit A pointer to the circuit.
+///
+/// @return The number of quantum registers in the circuit.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
+///     QkQuantumRegister *qr2 = qk_quantum_register_new(3, "qr2");
+///     qk_circuit_add_quantum_register(qc, qr1);
+///     qk_circuit_add_quantum_register(qc, qr2);
+///
+///     size_t num_qregs = qk_circuit_num_quantum_registers(qc);
+///     printf("Number of quantum registers: %zu\n", num_qregs);  // Prints: 2
+///
+///     qk_quantum_register_free(qr1);
+///     qk_quantum_register_free(qr2);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_num_quantum_registers(circuit: *const CircuitData) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    circuit.qregs().len()
+}
+
+/// @ingroup QkCircuit
+/// Returns the quantum register at the specified index.
+///
+/// Returns a borrowed pointer to the quantum register at the specified index.
+/// The returned pointer is valid as long as the circuit exists and is not modified.
+/// The caller should not free the returned pointer.
+///
+/// @param circuit A pointer to the circuit.
+/// @param qreg_idx The index of the quantum register to retrieve.
+///
+/// @return A borrowed pointer to the quantum register at the specified index.
+///         Do not free this pointer.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
+///     qk_circuit_add_quantum_register(qc, qr1);
+///
+///     const QkQuantumRegister *retrieved = qk_circuit_get_quantum_register(qc, 0);
+///
+///     qk_quantum_register_free(qr1);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
+/// or if ``qreg_idx`` is out of bounds (>= the number of quantum registers in the circuit).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_get_quantum_register(
+    circuit: *const CircuitData,
+    qreg_idx: usize,
+) -> *const QuantumRegister {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    ptr::from_ref(&circuit.qregs()[qreg_idx])
+}
+/// @ingroup QkCircuit
+/// Get the owning register of a qubit.
+///
+/// Returns a new pointer to the quantum register that owns the specified qubit,
+/// or NULL if the qubit is anonymous. A qubit can belong to multiple registers
+/// (through aliasing), but only one register is the owning register. Anonymous qubits
+/// are created directly via `qk_circuit_new` and are not owned by any register.
+///
+/// @param circuit A pointer to the circuit.
+/// @param qubit The index of the qubit.
+///
+/// @return A new pointer to the owning quantum register, or NULL if the qubit is anonymous.
+///         The caller must free this pointer with ``qk_quantum_register_free``.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
+///     qk_circuit_add_quantum_register(qc, qr);
+///
+///     QkQuantumRegister *owner2 = qk_circuit_qubit_owning_register(qc, 2);
+///     // Use owner2...
+///     qk_quantum_register_free(owner2);
+///
+///     qk_quantum_register_free(qr);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
+/// or if ``qubit`` is out of bounds (>= the number of qubits in the circuit).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_qubit_owning_register(
+    circuit: *const CircuitData,
+    qubit: u32,
+) -> *mut QuantumRegister {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    let shareable_qubit = circuit
+        .qubits()
+        .get(Qubit::from(qubit))
+        .expect("Qubit index is invalid in the circuit");
+
+    if let Some(qreg) = shareable_qubit.owning_register() {
+        // Register should be cloned since it's not owned by the current circuit
+        // and might also not appear in CircuitData::qubit_indices
+        Box::into_raw(Box::new(qreg))
+    } else {
+        ptr::null_mut()
+    }
+}
+
+/// @ingroup QkCircuit
 /// Add a classical register to a given quantum circuit
 ///
 /// @param circuit A pointer to the circuit.
@@ -269,6 +631,136 @@ pub unsafe extern "C" fn qk_circuit_add_classical_register(
     circuit
         .add_creg(creg.clone(), true)
         .expect("Invalid register unable to be added to circuit");
+}
+
+/// @ingroup QkCircuit
+/// Get the number of classical registers in the circuit.
+///
+/// Returns the number of classical registers that have been added to the circuit.
+///
+/// @param circuit A pointer to the circuit.
+///
+/// @return The number of classical registers in the circuit.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
+///     QkClassicalRegister *cr2 = qk_classical_register_new(3, "cr2");
+///     qk_circuit_add_classical_register(qc, cr1);
+///     qk_circuit_add_classical_register(qc, cr2);
+///
+///     size_t num_cregs = qk_circuit_num_classical_registers(qc);
+///     printf("Number of classical registers: %zu\n", num_cregs);  // Prints: 2
+///
+///     qk_classical_register_free(cr1);
+///     qk_classical_register_free(cr2);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_num_classical_registers(circuit: *const CircuitData) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    circuit.cregs().len()
+}
+
+/// @ingroup QkCircuit
+/// Returns the classical register at the specified index.
+///
+/// Returns a borrowed pointer to the classical register at the specified index.
+/// The returned pointer is valid as long as the circuit exists and is not modified.
+/// The caller should not free the returned pointer.
+///
+/// @param circuit A pointer to the circuit.
+/// @param creg_idx The index of the classical register to retrieve.
+///
+/// @return A borrowed pointer to the classical register at the specified index.
+///         Do not free this pointer.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
+///     qk_circuit_add_classical_register(qc, cr1);
+///
+///     const QkClassicalRegister *retrieved = qk_circuit_get_classical_register(qc, 0);
+///
+///     qk_classical_register_free(cr1);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
+/// or if ``creg_idx`` is out of bounds (>= the number of classical registers in the circuit).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_get_classical_register(
+    circuit: *const CircuitData,
+    creg_idx: usize,
+) -> *const ClassicalRegister {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    ptr::from_ref(&circuit.cregs()[creg_idx])
+}
+
+/// @ingroup QkCircuit
+/// Get the owning register of a classical bit.
+///
+/// Returns a new pointer to the classical register that owns the specified clbit,
+/// or NULL if the clbit is anonymous. A clbit can belong to multiple registers
+/// (through aliasing), but only one register is the owning register. Anonymous clbits
+/// are created directly via `qk_circuit_new` and are not owned by any register.
+///
+/// @param circuit A pointer to the circuit.
+/// @param clbit The index of the classical bit.
+///
+/// @return A new pointer to the owning classical register, or NULL if the classical bit is anonymous.
+///         The caller must free this pointer with ``qk_classical_register_free``.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(0, 0);
+///     QkClassicalRegister *cr = qk_classical_register_new(3, "cr");
+///     qk_circuit_add_classical_register(qc, cr);
+///
+///     QkClassicalRegister *owner2 = qk_circuit_clbit_owning_register(qc, 2);
+///     // Use owner2...
+///     qk_classical_register_free(owner2);
+///
+///     qk_classical_register_free(cr);
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
+/// or if ``clbit`` is out of bounds (>= the number of classical bits in the circuit).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_clbit_owning_register(
+    circuit: *const CircuitData,
+    clbit: u32,
+) -> *mut ClassicalRegister {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    let shareable_clbit = circuit
+        .clbits()
+        .get(Clbit::from(clbit))
+        .expect("Clbit index is invalid in the circuit");
+
+    if let Some(creg) = shareable_clbit.owning_register() {
+        // Register should be cloned since it's not owned by the current circuit
+        // and might also not appear in CircuitData::clbit_indices
+        Box::into_raw(Box::new(creg))
+    } else {
+        ptr::null_mut()
+    }
 }
 
 /// @ingroup QkCircuit
@@ -2293,4 +2785,99 @@ pub unsafe extern "C" fn qk_circuit_estimate_fidelity(
     // SAFETY: Per documentation, the pointer is to valid data.
     let target = unsafe { const_ptr_as_ref(target) };
     estimate_fidelity(circuit, target).unwrap_or(f64::NAN)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        circuit::{
+            qk_circuit_clbit_owning_register, qk_circuit_qubit_owning_register,
+            qk_classical_register_circuit_bits, qk_quantum_register_circuit_bits,
+        },
+        pointers::const_ptr_as_ref,
+    };
+    use qiskit_circuit::{
+        bit::{ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit},
+        circuit_data::CircuitData,
+        operations::Param,
+    };
+    use std::mem::MaybeUninit;
+
+    #[test]
+    fn test_register_circuit_bits() {
+        let qubits = vec![ShareableQubit::new_anonymous()];
+        let clbits = vec![ShareableClbit::new_anonymous()];
+        let mut circuit = CircuitData::new(Some(qubits), Some(clbits), Param::Float(0.0)).unwrap();
+
+        let qr1 = QuantumRegister::new_owning("QR1", 2);
+        let _ = circuit.add_qubit(qr1.get(0).unwrap(), false);
+
+        let mut out_bits = vec![MaybeUninit::<i64>::uninit(), MaybeUninit::<i64>::uninit()];
+        unsafe {
+            qk_quantum_register_circuit_bits(&qr1, &circuit, out_bits.as_mut_ptr() as *mut i64)
+        };
+        let out_bits = unsafe {
+            out_bits
+                .into_iter()
+                .map(|b| b.assume_init())
+                .collect::<Vec<i64>>()
+        };
+
+        assert_eq!(out_bits[0], 1); // Bit was explicitly added to the circuit
+        assert!(out_bits[1] < 0); // Bit was not added to the circuit
+
+        let cr1 = ClassicalRegister::new_owning("CR1", 2);
+        let _ = circuit.add_clbit(cr1.get(1).unwrap(), false);
+
+        let mut out_bits = vec![MaybeUninit::<i64>::uninit(), MaybeUninit::<i64>::uninit()];
+        unsafe {
+            qk_classical_register_circuit_bits(&cr1, &circuit, out_bits.as_mut_ptr() as *mut i64)
+        };
+        let out_bits = unsafe {
+            out_bits
+                .into_iter()
+                .map(|b| b.assume_init())
+                .collect::<Vec<i64>>()
+        };
+
+        assert_eq!(out_bits[1], 1); // Bit was explicitly added to the circuit
+        assert!(out_bits[0] < 0); // Bit was not added to the circuit
+    }
+
+    #[test]
+    fn test_owning_register_queries() {
+        let qubits = vec![ShareableQubit::new_anonymous()];
+        let clbits = vec![ShareableClbit::new_anonymous()];
+        let mut circuit = CircuitData::new(Some(qubits), Some(clbits), Param::Float(0.0)).unwrap();
+
+        let qr1 = QuantumRegister::new_owning("QR1", 1);
+        let qr1_bits = qr1.bits().collect::<Vec<ShareableQubit>>();
+        circuit.add_qubit(qr1_bits[0].clone(), false).unwrap();
+        let _ = QuantumRegister::new_alias(None, qr1_bits);
+
+        let cr1 = ClassicalRegister::new_owning("CR1", 1);
+        let cr1_bits = cr1.bits().collect::<Vec<ShareableClbit>>();
+        let _ = circuit.add_clbit(cr1_bits[0].clone(), false);
+        let _ = ClassicalRegister::new_alias(None, cr1_bits);
+
+        let owning_qreg_0 = unsafe { qk_circuit_qubit_owning_register(&circuit, 0) };
+        assert!(owning_qreg_0.is_null());
+
+        let owning_qreg_1 = unsafe { qk_circuit_qubit_owning_register(&circuit, 1) };
+        assert!(!owning_qreg_1.is_null());
+
+        let qreg = unsafe { const_ptr_as_ref(owning_qreg_1) };
+        assert_eq!(qreg.name(), qr1.name());
+        unsafe { crate::circuit::qk_quantum_register_free(owning_qreg_1) };
+
+        let owning_creg_0 = unsafe { qk_circuit_clbit_owning_register(&circuit, 0) };
+        assert!(owning_creg_0.is_null());
+
+        let owning_creg_1 = unsafe { qk_circuit_clbit_owning_register(&circuit, 1) };
+        assert!(!owning_creg_1.is_null());
+
+        let creg = unsafe { const_ptr_as_ref(owning_creg_1) };
+        assert_eq!(creg.name(), cr1.name());
+        unsafe { crate::circuit::qk_classical_register_free(owning_creg_1) };
+    }
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -546,59 +546,6 @@ pub unsafe extern "C" fn qk_circuit_get_quantum_register(
 
     ptr::from_ref(&circuit.qregs()[qreg_idx])
 }
-/// @ingroup QkCircuit
-/// Get the owning register of a qubit.
-///
-/// Returns a new pointer to the quantum register that owns the specified qubit,
-/// or NULL if the qubit is anonymous. A qubit can belong to multiple registers
-/// (through aliasing), but only one register is the owning register. Anonymous qubits
-/// are created directly via `qk_circuit_new` and are not owned by any register.
-///
-/// @param circuit A pointer to the circuit.
-/// @param qubit The index of the qubit.
-///
-/// @return A new pointer to the owning quantum register, or NULL if the qubit is anonymous.
-///         The caller must free this pointer with ``qk_quantum_register_free``.
-///
-/// # Example
-/// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
-///     qk_circuit_add_quantum_register(qc, qr);
-///
-///     QkQuantumRegister *owner2 = qk_circuit_qubit_owning_register(qc, 2);
-///     // Use owner2...
-///     qk_quantum_register_free(owner2);
-///
-///     qk_quantum_register_free(qr);
-///     qk_circuit_free(qc);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
-/// or if ``qubit`` is out of bounds (>= the number of qubits in the circuit).
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_circuit_qubit_owning_register(
-    circuit: *const CircuitData,
-    qubit: u32,
-) -> *mut QuantumRegister {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let circuit = unsafe { const_ptr_as_ref(circuit) };
-
-    let shareable_qubit = circuit
-        .qubits()
-        .get(Qubit::from(qubit))
-        .expect("Qubit index is invalid in the circuit");
-
-    if let Some(qreg) = shareable_qubit.owning_register() {
-        // Register should be cloned since it's not owned by the current circuit
-        // and might also not appear in CircuitData::qubit_indices
-        Box::into_raw(Box::new(qreg))
-    } else {
-        ptr::null_mut()
-    }
-}
 
 /// @ingroup QkCircuit
 /// Add a classical register to a given quantum circuit
@@ -707,60 +654,6 @@ pub unsafe extern "C" fn qk_circuit_get_classical_register(
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 
     ptr::from_ref(&circuit.cregs()[creg_idx])
-}
-
-/// @ingroup QkCircuit
-/// Get the owning register of a classical bit.
-///
-/// Returns a new pointer to the classical register that owns the specified clbit,
-/// or NULL if the clbit is anonymous. A clbit can belong to multiple registers
-/// (through aliasing), but only one register is the owning register. Anonymous clbits
-/// are created directly via `qk_circuit_new` and are not owned by any register.
-///
-/// @param circuit A pointer to the circuit.
-/// @param clbit The index of the classical bit.
-///
-/// @return A new pointer to the owning classical register, or NULL if the classical bit is anonymous.
-///         The caller must free this pointer with ``qk_classical_register_free``.
-///
-/// # Example
-/// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkClassicalRegister *cr = qk_classical_register_new(3, "cr");
-///     qk_circuit_add_classical_register(qc, cr);
-///
-///     QkClassicalRegister *owner2 = qk_circuit_clbit_owning_register(qc, 2);
-///     // Use owner2...
-///     qk_classical_register_free(owner2);
-///
-///     qk_classical_register_free(cr);
-///     qk_circuit_free(qc);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``,
-/// or if ``clbit`` is out of bounds (>= the number of classical bits in the circuit).
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_circuit_clbit_owning_register(
-    circuit: *const CircuitData,
-    clbit: u32,
-) -> *mut ClassicalRegister {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let circuit = unsafe { const_ptr_as_ref(circuit) };
-
-    let shareable_clbit = circuit
-        .clbits()
-        .get(Clbit::from(clbit))
-        .expect("Clbit index is invalid in the circuit");
-
-    if let Some(creg) = shareable_clbit.owning_register() {
-        // Register should be cloned since it's not owned by the current circuit
-        // and might also not appear in CircuitData::clbit_indices
-        Box::into_raw(Box::new(creg))
-    } else {
-        ptr::null_mut()
-    }
 }
 
 /// @ingroup QkCircuit
@@ -2789,15 +2682,9 @@ pub unsafe extern "C" fn qk_circuit_estimate_fidelity(
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        circuit::{
-            qk_circuit_clbit_owning_register, qk_circuit_qubit_owning_register,
-            qk_classical_register_circuit_bits, qk_quantum_register_circuit_bits,
-        },
-        pointers::const_ptr_as_ref,
-    };
+    use crate::circuit::{qk_classical_register_circuit_bits, qk_quantum_register_circuit_bits};
     use qiskit_circuit::{
-        bit::{ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit},
+        bit::{ClassicalRegister, QuantumRegister, ShareableClbit, ShareableQubit},
         circuit_data::CircuitData,
         operations::Param,
     };
@@ -2842,42 +2729,5 @@ mod test {
 
         assert_eq!(out_bits[1], 1); // Bit was explicitly added to the circuit
         assert_eq!(out_bits[0], u32::MAX); // Bit was not added to the circuit
-    }
-
-    #[test]
-    fn test_owning_register_queries() {
-        let qubits = vec![ShareableQubit::new_anonymous()];
-        let clbits = vec![ShareableClbit::new_anonymous()];
-        let mut circuit = CircuitData::new(Some(qubits), Some(clbits), Param::Float(0.0)).unwrap();
-
-        let qr1 = QuantumRegister::new_owning("QR1", 1);
-        let qr1_bits = qr1.bits().collect::<Vec<ShareableQubit>>();
-        circuit.add_qubit(qr1_bits[0].clone(), false).unwrap();
-        let _ = QuantumRegister::new_alias(None, qr1_bits);
-
-        let cr1 = ClassicalRegister::new_owning("CR1", 1);
-        let cr1_bits = cr1.bits().collect::<Vec<ShareableClbit>>();
-        let _ = circuit.add_clbit(cr1_bits[0].clone(), false);
-        let _ = ClassicalRegister::new_alias(None, cr1_bits);
-
-        let owning_qreg_0 = unsafe { qk_circuit_qubit_owning_register(&circuit, 0) };
-        assert!(owning_qreg_0.is_null());
-
-        let owning_qreg_1 = unsafe { qk_circuit_qubit_owning_register(&circuit, 1) };
-        assert!(!owning_qreg_1.is_null());
-
-        let qreg = unsafe { const_ptr_as_ref(owning_qreg_1) };
-        assert_eq!(qreg.name(), qr1.name());
-        unsafe { crate::circuit::qk_quantum_register_free(owning_qreg_1) };
-
-        let owning_creg_0 = unsafe { qk_circuit_clbit_owning_register(&circuit, 0) };
-        assert!(owning_creg_0.is_null());
-
-        let owning_creg_1 = unsafe { qk_circuit_clbit_owning_register(&circuit, 1) };
-        assert!(!owning_creg_1.is_null());
-
-        let creg = unsafe { const_ptr_as_ref(owning_creg_1) };
-        assert_eq!(creg.name(), cr1.name());
-        unsafe { crate::circuit::qk_classical_register_free(owning_creg_1) };
     }
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn qk_quantum_register_name(qreg: *const QuantumRegister) 
     let qreg = unsafe { const_ptr_as_ref(qreg) };
 
     CString::new(qreg.name())
-        .expect("Register name contains null byte")
+        .expect("Register name should not contain null bytes")
         .into_raw()
 }
 
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn qk_classical_register_name(creg: *const ClassicalRegist
     let creg = unsafe { const_ptr_as_ref(creg) };
 
     CString::new(creg.name())
-        .expect("Register name contains null byte")
+        .expect("Register name should not contain null bytes")
         .into_raw()
 }
 

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -206,13 +206,13 @@ pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegist
 ///
 /// Outputs a mapping from each qubit in the quantum register to its corresponding index in the circuit's
 /// qubit list. If a qubit from the register is not present in the circuit, its index
-/// in the mapping will be -1.
+/// in the mapping will be `UINT32_MAX`.
 ///
 /// @param qreg A pointer to the quantum register to map.
 /// @param circuit A pointer to the circuit containing the qubits.
 /// @param out_bits A pointer to an array where the mapped indices will be written.
 ///                 The array must be pre-allocated with at least `qk_quantum_register_num_bits` elements
-///                 for `qreg`. Each element will contain either the circuit bit index (>= 0) or -1
+///                 for `qreg`. Each element will contain either the circuit bit index or `UINT32_MAX`
 ///                 if the qubit is not in the circuit.
 ///
 /// # Example
@@ -221,7 +221,7 @@ pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegist
 ///     QkQuantumRegister *qr = qk_quantum_register_new(3, "my_qreg");
 ///     qk_circuit_add_quantum_register(qc, qr);
 ///
-///     int64_t bit_indices[3];
+///     uint32_t bit_indices[3];
 ///
 ///     qk_quantum_register_circuit_bits(qr, qc, bit_indices);
 ///
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegist
 pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
     qreg: *const QuantumRegister,
     circuit: *const CircuitData,
-    out_bits: *mut i64,
+    out_bits: *mut u32,
 ) {
     // SAFETY: Per documentation, qreg is a valid, non-null pointer.
     let qreg = unsafe { const_ptr_as_ref(qreg) };
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 
     qreg.iter().enumerate().for_each(|(i, qubit)| {
-        let mapped_qubit = circuit.qubit_index(&qubit).map_or(-1, |q| q as i64);
+        let mapped_qubit = circuit.qubit_index(&qubit).map_or(u32::MAX, |q| q);
         // SAFETY: Per documentation, out_bits has at least qreg.len() elements
         unsafe { out_bits.add(i).write(mapped_qubit) };
     });
@@ -387,13 +387,13 @@ pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRe
 ///
 /// Outputs a mapping from each clbit in the classical register to its corresponding index in the circuit's
 /// clbit list. If a clbit from the register is not present in the circuit, its index
-/// in the mapping will be -1.
+/// in the mapping will be `UINT32_MAX`.
 ///
 /// @param creg A pointer to the classical register to map.
 /// @param circuit A pointer to the circuit containing the clbits.
 /// @param out_bits A pointer to an array where the mapped indices will be written.
 ///                 The array must be pre-allocated with at least `qk_classical_register_num_bits` elements
-///                 for `creg`. Each element will contain either the circuit bit index (>= 0) or -1
+///                 for `creg`. Each element will contain either the circuit bit index or `UINT32_MAX`
 ///                 if the clbit is not in the circuit.
 ///
 /// # Example
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRe
 ///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
 ///     qk_circuit_add_classical_register(qc, cr);
 ///
-///     int64_t bit_indices[3];
+///     uint32_t bit_indices[3];
 ///
 ///     qk_classical_register_circuit_bits(cr, qc, bit_indices);
 ///
@@ -424,7 +424,7 @@ pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRe
 pub unsafe extern "C" fn qk_classical_register_circuit_bits(
     creg: *const ClassicalRegister,
     circuit: *const CircuitData,
-    out_bits: *mut i64,
+    out_bits: *mut u32,
 ) {
     // SAFETY: Per documentation, creg is a valid, non-null pointer.
     let creg = unsafe { const_ptr_as_ref(creg) };
@@ -432,7 +432,7 @@ pub unsafe extern "C" fn qk_classical_register_circuit_bits(
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 
     creg.iter().enumerate().for_each(|(i, clbit)| {
-        let mapped_clbit = circuit.clbit_index(&clbit).map_or(-1, |c| c as i64);
+        let mapped_clbit = circuit.clbit_index(&clbit).map_or(u32::MAX, |c| c);
         // SAFETY: Per documentation, out_bits has at least creg.len() elements
         unsafe { out_bits.add(i).write(mapped_clbit) };
     });
@@ -2812,36 +2812,36 @@ mod test {
         let qr1 = QuantumRegister::new_owning("QR1", 2);
         let _ = circuit.add_qubit(qr1.get(0).unwrap(), false);
 
-        let mut out_bits = vec![MaybeUninit::<i64>::uninit(), MaybeUninit::<i64>::uninit()];
+        let mut out_bits = vec![MaybeUninit::<u32>::uninit(), MaybeUninit::<u32>::uninit()];
         unsafe {
-            qk_quantum_register_circuit_bits(&qr1, &circuit, out_bits.as_mut_ptr() as *mut i64)
+            qk_quantum_register_circuit_bits(&qr1, &circuit, out_bits.as_mut_ptr() as *mut u32)
         };
         let out_bits = unsafe {
             out_bits
                 .into_iter()
                 .map(|b| b.assume_init())
-                .collect::<Vec<i64>>()
+                .collect::<Vec<u32>>()
         };
 
         assert_eq!(out_bits[0], 1); // Bit was explicitly added to the circuit
-        assert!(out_bits[1] < 0); // Bit was not added to the circuit
+        assert_eq!(out_bits[1], u32::MAX); // Bit was not added to the circuit
 
         let cr1 = ClassicalRegister::new_owning("CR1", 2);
         let _ = circuit.add_clbit(cr1.get(1).unwrap(), false);
 
-        let mut out_bits = vec![MaybeUninit::<i64>::uninit(), MaybeUninit::<i64>::uninit()];
+        let mut out_bits = vec![MaybeUninit::<u32>::uninit(), MaybeUninit::<u32>::uninit()];
         unsafe {
-            qk_classical_register_circuit_bits(&cr1, &circuit, out_bits.as_mut_ptr() as *mut i64)
+            qk_classical_register_circuit_bits(&cr1, &circuit, out_bits.as_mut_ptr() as *mut u32)
         };
         let out_bits = unsafe {
             out_bits
                 .into_iter()
                 .map(|b| b.assume_init())
-                .collect::<Vec<i64>>()
+                .collect::<Vec<u32>>()
         };
 
         assert_eq!(out_bits[1], 1); // Bit was explicitly added to the circuit
-        assert!(out_bits[0] < 0); // Bit was not added to the circuit
+        assert_eq!(out_bits[0], u32::MAX); // Bit was not added to the circuit
     }
 
     #[test]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -237,7 +237,7 @@ pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegist
 /// Behavior is undefined if:
 /// - ``qreg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
 /// - ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
-/// - ``out_bits`` is not a valid, non-null pointer to an array with at least
+/// - ``qreg`` has one or more bits and ``out_bits`` is not an aligned, non-null pointer to an array with at least
 ///   ``qk_quantum_register_num_bits(qreg)`` elements.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
 
     qreg.iter().enumerate().for_each(|(i, qubit)| {
         let mapped_qubit = circuit.qubit_index(&qubit).map_or(u32::MAX, |q| q);
-        // SAFETY: Per documentation, out_bits has at least qreg.len() elements
+        // SAFETY: Per documentation, out_bits is aligned and has at least qreg.len() elements
         unsafe { out_bits.add(i).write(mapped_qubit) };
     });
 }
@@ -418,7 +418,7 @@ pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRe
 /// Behavior is undefined if:
 /// - ``creg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
 /// - ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
-/// - ``out_bits`` is not a valid, non-null pointer to an array with at least
+/// - ``creg`` has one or more bits and ``out_bits`` is not an aligned, non-null pointer to an array with at least
 ///   ``qk_classical_register_num_bits(creg)`` elements.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_classical_register_circuit_bits(
@@ -433,7 +433,7 @@ pub unsafe extern "C" fn qk_classical_register_circuit_bits(
 
     creg.iter().enumerate().for_each(|(i, clbit)| {
         let mapped_clbit = circuit.clbit_index(&clbit).map_or(u32::MAX, |c| c);
-        // SAFETY: Per documentation, out_bits has at least creg.len() elements
+        // SAFETY: Per documentation, out_bits is aligned and has at least creg.len() elements
         unsafe { out_bits.add(i).write(mapped_clbit) };
     });
 }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1188,13 +1188,13 @@ impl CircuitData {
         &self.cregs
     }
 
-    /// Returns an immutable view of the qubit locations of the [DAGCircuit]
+    /// Returns an immutable view of the qubit locations of the [CircuitData]
     #[inline(always)]
     pub fn qubit_indices(&self) -> &BitLocator<ShareableQubit, QuantumRegister> {
         &self.qubit_indices
     }
 
-    /// Returns an immutable view of the clbit locations of the [DAGCircuit]
+    /// Returns an immutable view of the clbit locations of the [CircuitData]
     #[inline(always)]
     pub fn clbit_indices(&self) -> &BitLocator<ShareableClbit, ClassicalRegister> {
         &self.clbit_indices

--- a/releasenotes/notes/c-api-register-queries-76699fc03bed24a8.yaml
+++ b/releasenotes/notes/c-api-register-queries-76699fc03bed24a8.yaml
@@ -6,10 +6,8 @@ features_c:
 
     * :c:func:`qk_circuit_num_quantum_registers`
     * :c:func:`qk_circuit_get_quantum_register`
-    * :c:func:`qk_circuit_qubit_owning_register`
     * :c:func:`qk_circuit_num_classical_registers`
     * :c:func:`qk_circuit_get_classical_register`
-    * :c:func:`qk_circuit_clbit_owning_register`
     * :c:func:`qk_quantum_register_name`
     * :c:func:`qk_quantum_register_num_bits`
     * :c:func:`qk_quantum_register_circuit_bits`

--- a/releasenotes/notes/c-api-register-queries-76699fc03bed24a8.yaml
+++ b/releasenotes/notes/c-api-register-queries-76699fc03bed24a8.yaml
@@ -1,0 +1,21 @@
+---
+features_c:
+  - |
+    Added functions to query a circuit about its quantum registers and classical registers, and for 
+    various properties of the registers themselves. The following functions were added:
+
+    * :c:func:`qk_circuit_num_quantum_registers`
+    * :c:func:`qk_circuit_get_quantum_register`
+    * :c:func:`qk_circuit_qubit_owning_register`
+    * :c:func:`qk_circuit_num_classical_registers`
+    * :c:func:`qk_circuit_get_classical_register`
+    * :c:func:`qk_circuit_clbit_owning_register`
+    * :c:func:`qk_quantum_register_name`
+    * :c:func:`qk_quantum_register_num_bits`
+    * :c:func:`qk_quantum_register_circuit_bits`
+    * :c:func:`qk_classical_register_name`
+    * :c:func:`qk_classical_register_num_bits`
+    * :c:func:`qk_classical_register_circuit_bits`
+
+    Refer to the function API docs for more details about each function. 
+

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1648,77 +1648,6 @@ cleanup:
     return result;
 }
 
-/*
- * Test register ownership queries for circuit bits
- */
-static int test_owning_registers(void) {
-    int result = Ok;
-
-    QkCircuit *circuit = qk_circuit_new(1, 1);
-    QkQuantumRegister *qr1 = qk_quantum_register_new(1, "QR1");
-    qk_circuit_add_quantum_register(circuit, qr1);
-    qk_quantum_register_free(qr1);
-
-    QkClassicalRegister *cr1 = qk_classical_register_new(1, "CR1");
-    qk_circuit_add_classical_register(circuit, cr1);
-    qk_classical_register_free(cr1);
-
-    QkQuantumRegister *owning_qreg = qk_circuit_qubit_owning_register(circuit, 0);
-    if (owning_qreg != NULL) {
-        printf("Expected NULL for anonymous qubit 0, but got a register\n");
-        result = EqualityError;
-        goto owning_qreg_cleanup;
-    }
-
-    owning_qreg = qk_circuit_qubit_owning_register(circuit, 1);
-    if (owning_qreg == NULL) {
-        printf("Expected QR1 for qubit 1, but got NULL\n");
-        result = EqualityError;
-        goto cleanup;
-    }
-
-    // Verify it's the correct register by checking the name
-    char *name = qk_quantum_register_name(owning_qreg);
-    if (strcmp(name, "QR1") != 0) {
-        printf("Expected register name 'QR1' for qubit 1, but got '%s'\n", name);
-        result = EqualityError;
-        qk_str_free(name);
-        goto owning_qreg_cleanup;
-    }
-    qk_str_free(name);
-
-    // Test anonymous clbits (should return NULL)
-    QkClassicalRegister *owning_creg = qk_circuit_clbit_owning_register(circuit, 0);
-    if (owning_creg != NULL) {
-        printf("Expected NULL for anonymous clbit 0, but got a register\n");
-        result = EqualityError;
-        qk_classical_register_free(owning_creg);
-        goto owning_qreg_cleanup;
-    }
-
-    owning_creg = qk_circuit_clbit_owning_register(circuit, 1);
-    if (owning_creg == NULL) {
-        printf("Expected CR1 for clbit 1, but got NULL\n");
-        result = EqualityError;
-        goto owning_qreg_cleanup;
-    }
-
-    // Verify it's the correct register by checking the name
-    name = qk_classical_register_name(owning_creg);
-    if (strcmp(name, "CR1") != 0) {
-        printf("Expected register name 'CR1' for clbit 1, but got '%s'\n", name);
-        result = EqualityError;
-    }
-
-    qk_str_free(name);
-    qk_classical_register_free(owning_creg);
-owning_qreg_cleanup:
-    qk_quantum_register_free(owning_qreg);
-cleanup:
-    qk_circuit_free(circuit);
-    return result;
-}
-
 int test_circuit(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
@@ -1751,7 +1680,6 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_estimate_fidelity_non_physical);
     num_failed += RUN_TEST(test_basic_register_queries);
     num_failed += RUN_TEST(test_register_bits);
-    num_failed += RUN_TEST(test_owning_registers);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1493,9 +1493,12 @@ static int test_basic_register_queries(void) {
     QkQuantumRegister *qr2 = qk_quantum_register_new(2, "QR2");
     qk_circuit_add_quantum_register(circuit, qr1);
     qk_circuit_add_quantum_register(circuit, qr2);
+    qk_quantum_register_free(qr1);
+    qk_quantum_register_free(qr2);
 
     QkClassicalRegister *cr1 = qk_classical_register_new(3, "CR1");
     qk_circuit_add_classical_register(circuit, cr1);
+    qk_classical_register_free(cr1);
 
     size_t num_qregs = qk_circuit_num_quantum_registers(circuit);
     if (num_qregs != 2) {
@@ -1524,7 +1527,8 @@ static int test_basic_register_queries(void) {
             result = EqualityError;
             goto name_cleanup;
         }
-        free(name);
+        qk_str_free(name);
+        name = NULL;
     }
 
     size_t num_cregs = qk_circuit_num_classical_registers(circuit);
@@ -1552,12 +1556,9 @@ static int test_basic_register_queries(void) {
 
 name_cleanup:
     if (name != NULL) {
-        free(name);
+        qk_str_free(name);
     }
 cleanup:
-    qk_quantum_register_free(qr1);
-    qk_quantum_register_free(qr2);
-    qk_classical_register_free(cr1);
     qk_circuit_free(circuit);
     return result;
 }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -12,6 +12,7 @@
 
 #include "common.h"
 #include <complex.h>
+#include <inttypes.h>
 #include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
@@ -1480,6 +1481,243 @@ static int test_estimate_fidelity_non_physical(void) {
     return result;
 }
 
+/*
+ * Test iteration, name and bit queries
+ */
+static int test_basic_register_queries(void) {
+    int result = Ok;
+
+    QkCircuit *circuit = qk_circuit_new(0, 0);
+
+    QkQuantumRegister *qr1 = qk_quantum_register_new(1, "QR1");
+    QkQuantumRegister *qr2 = qk_quantum_register_new(2, "QR2");
+    qk_circuit_add_quantum_register(circuit, qr1);
+    qk_circuit_add_quantum_register(circuit, qr2);
+
+    QkClassicalRegister *cr1 = qk_classical_register_new(3, "CR1");
+    qk_circuit_add_classical_register(circuit, cr1);
+
+    size_t num_qregs = qk_circuit_num_quantum_registers(circuit);
+    if (num_qregs != 2) {
+        printf("Expected 2 quantum registers, got %zu\n", num_qregs);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    const char *expected_names[2] = {"QR1", "QR2"};
+    size_t expected_bits[2] = {1, 2};
+    char *name = NULL;
+    for (size_t qreg_idx = 0; qreg_idx < num_qregs; qreg_idx++) {
+        const QkQuantumRegister *qr_retrieved = qk_circuit_get_quantum_register(circuit, qreg_idx);
+        name = qk_quantum_register_name(qr_retrieved);
+
+        if (strcmp(name, expected_names[qreg_idx]) != 0) {
+            printf("Expected quantum register name %s, got '%s'\n", expected_names[qreg_idx], name);
+            result = EqualityError;
+            goto name_cleanup;
+        }
+
+        size_t num_bits = qk_quantum_register_num_bits(qr_retrieved);
+        if (num_bits != expected_bits[qreg_idx]) {
+            printf("Expected quantum register size %zu, got %zu\n", expected_bits[qreg_idx],
+                   num_bits);
+            result = EqualityError;
+            goto name_cleanup;
+        }
+        free(name);
+    }
+
+    size_t num_cregs = qk_circuit_num_classical_registers(circuit);
+    if (num_cregs != 1) {
+        printf("Expected 1 classical register, got %zu\n", num_cregs);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    const QkClassicalRegister *cr1_retrieved = qk_circuit_get_classical_register(circuit, 0);
+    name = qk_classical_register_name(cr1_retrieved);
+    size_t cr1_size = qk_classical_register_num_bits(cr1_retrieved);
+
+    if (strcmp(name, "CR1") != 0) {
+        printf("Expected classical register name 'CR1', got '%s'\n", name);
+        result = EqualityError;
+        goto name_cleanup;
+    }
+
+    if (cr1_size != 3) {
+        printf("Expected classical register size 3, got %zu\n", cr1_size);
+        result = EqualityError;
+        goto name_cleanup;
+    }
+
+name_cleanup:
+    if (name != NULL) {
+        free(name);
+    }
+cleanup:
+    qk_quantum_register_free(qr1);
+    qk_quantum_register_free(qr2);
+    qk_classical_register_free(cr1);
+    qk_circuit_free(circuit);
+    return result;
+}
+
+/*
+ * Test extraction of circuit bit mappings
+ */
+static int test_register_bits(void) {
+    int result = Ok;
+
+    QkCircuit *circuit = qk_circuit_new(1, 2);
+
+    QkQuantumRegister *qr1 = qk_quantum_register_new(3, "QR1");
+    qk_circuit_add_quantum_register(circuit, qr1);
+
+    size_t qr1_num_bits = qk_quantum_register_num_bits(qr1);
+    if (qr1_num_bits != 3) {
+        printf("Expected QR1 to have 3 bits, got %zu\n", qr1_num_bits);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    int64_t *bit_indices = malloc(qr1_num_bits * sizeof(int64_t));
+    qk_quantum_register_circuit_bits(qr1, circuit, bit_indices);
+
+    for (size_t bit = 0; bit < qr1_num_bits; bit++) {
+        if (bit_indices[bit] < 0) {
+            printf("Expected QR1 bit %zu to be in circuit, got index %" PRId64 "\n", bit,
+                   bit_indices[bit]);
+            result = EqualityError;
+            goto clean_bit_indices;
+        }
+        // Positions should be 1, 2, 3, since the circuit has an anonymous qubit
+        if (bit_indices[bit] != (int64_t)bit + 1) {
+            printf("Expected QR1 bit %zu to have circuit index %zu, got %" PRId64 "\n", bit,
+                   bit + 1, bit_indices[bit]);
+            result = EqualityError;
+            goto clean_bit_indices;
+        }
+    }
+
+    QkQuantumRegister *qr2 = qk_quantum_register_new(2, "QR2");
+    int64_t reg_circuit_bits[2];
+    qk_quantum_register_circuit_bits(qr2, circuit, reg_circuit_bits);
+
+    for (size_t bit = 0; bit < 2; bit++) {
+        if (reg_circuit_bits[bit] >= 0) {
+            printf("Expected QR2 bit %zu to NOT be in circuit, got %" PRId64 "\n", bit,
+                   reg_circuit_bits[bit]);
+            result = EqualityError;
+            goto cleanup_qr2;
+        }
+    }
+
+    QkClassicalRegister *cr1 = qk_classical_register_new(2, "CR1");
+    qk_circuit_add_classical_register(circuit, cr1);
+    qk_classical_register_circuit_bits(cr1, circuit, reg_circuit_bits);
+
+    // Positions should be 2, 3, since the circuit has two anonymous clbits
+    for (size_t bit = 0; bit < 2; bit++) {
+        if (reg_circuit_bits[bit] != (int64_t)bit + 2) {
+            printf("Expected CR1 bit %zu to have circuit index %zu, got %" PRId64 "\n", bit,
+                   bit + 2, reg_circuit_bits[bit]);
+            result = EqualityError;
+            goto cleanup_cr1;
+        }
+    }
+
+    QkClassicalRegister *cr2 = qk_classical_register_new(1, "cr2");
+    qk_classical_register_circuit_bits(cr2, circuit, reg_circuit_bits);
+
+    if (reg_circuit_bits[0] >= 0) {
+        printf("Expected CR2 bit 0 to NOT be in circuit, got %" PRId64 "\n", reg_circuit_bits[0]);
+        result = EqualityError;
+    }
+
+    qk_classical_register_free(cr2);
+cleanup_cr1:
+    qk_classical_register_free(cr1);
+cleanup_qr2:
+    qk_quantum_register_free(qr2);
+clean_bit_indices:
+    free(bit_indices);
+cleanup:
+    qk_quantum_register_free(qr1);
+    qk_circuit_free(circuit);
+    return result;
+}
+
+/*
+ * Test register ownership queries for circuit bits
+ */
+static int test_owning_registers(void) {
+    int result = Ok;
+
+    QkCircuit *circuit = qk_circuit_new(1, 1);
+    QkQuantumRegister *qr1 = qk_quantum_register_new(1, "QR1");
+    qk_circuit_add_quantum_register(circuit, qr1);
+    qk_quantum_register_free(qr1);
+
+    QkClassicalRegister *cr1 = qk_classical_register_new(1, "CR1");
+    qk_circuit_add_classical_register(circuit, cr1);
+    qk_classical_register_free(cr1);
+
+    QkQuantumRegister *owning_qreg = qk_circuit_qubit_owning_register(circuit, 0);
+    if (owning_qreg != NULL) {
+        printf("Expected NULL for anonymous qubit 0, but got a register\n");
+        result = EqualityError;
+        goto owning_qreg_cleanup;
+    }
+
+    owning_qreg = qk_circuit_qubit_owning_register(circuit, 1);
+    if (owning_qreg == NULL) {
+        printf("Expected QR1 for qubit 1, but got NULL\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    // Verify it's the correct register by checking the name
+    char *name = qk_quantum_register_name(owning_qreg);
+    if (strcmp(name, "QR1") != 0) {
+        printf("Expected register name 'QR1' for qubit 1, but got '%s'\n", name);
+        result = EqualityError;
+        qk_str_free(name);
+        goto owning_qreg_cleanup;
+    }
+    qk_str_free(name);
+
+    // Test anonymous clbits (should return NULL)
+    QkClassicalRegister *owning_creg = qk_circuit_clbit_owning_register(circuit, 0);
+    if (owning_creg != NULL) {
+        printf("Expected NULL for anonymous clbit 0, but got a register\n");
+        result = EqualityError;
+        qk_classical_register_free(owning_creg);
+        goto owning_qreg_cleanup;
+    }
+
+    owning_creg = qk_circuit_clbit_owning_register(circuit, 1);
+    if (owning_creg == NULL) {
+        printf("Expected CR1 for clbit 1, but got NULL\n");
+        result = EqualityError;
+        goto owning_qreg_cleanup;
+    }
+
+    // Verify it's the correct register by checking the name
+    name = qk_classical_register_name(owning_creg);
+    if (strcmp(name, "CR1") != 0) {
+        printf("Expected register name 'CR1' for clbit 1, but got '%s'\n", name);
+        result = EqualityError;
+    }
+
+    qk_str_free(name);
+    qk_classical_register_free(owning_creg);
+owning_qreg_cleanup:
+    qk_quantum_register_free(owning_qreg);
+cleanup:
+    qk_circuit_free(circuit);
+    return result;
+}
+
 int test_circuit(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
@@ -1510,6 +1748,9 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_pbc_instructions);
     num_failed += RUN_TEST(test_estimate_fidelity);
     num_failed += RUN_TEST(test_estimate_fidelity_non_physical);
+    num_failed += RUN_TEST(test_basic_register_queries);
+    num_failed += RUN_TEST(test_register_bits);
+    num_failed += RUN_TEST(test_owning_registers);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1581,19 +1581,18 @@ static int test_register_bits(void) {
         goto cleanup;
     }
 
-    int64_t *bit_indices = malloc(qr1_num_bits * sizeof(int64_t));
+    uint32_t *bit_indices = malloc(qr1_num_bits * sizeof(uint32_t));
     qk_quantum_register_circuit_bits(qr1, circuit, bit_indices);
 
     for (size_t bit = 0; bit < qr1_num_bits; bit++) {
-        if (bit_indices[bit] < 0) {
-            printf("Expected QR1 bit %zu to be in circuit, got index %" PRId64 "\n", bit,
-                   bit_indices[bit]);
+        if (bit_indices[bit] == UINT32_MAX) {
+            printf("Expected QR1 bit %zu to be in the circuit, but it's not\n", bit);
             result = EqualityError;
             goto clean_bit_indices;
         }
         // Positions should be 1, 2, 3, since the circuit has an anonymous qubit
-        if (bit_indices[bit] != (int64_t)bit + 1) {
-            printf("Expected QR1 bit %zu to have circuit index %zu, got %" PRId64 "\n", bit,
+        if (bit_indices[bit] != (uint32_t)bit + 1) {
+            printf("Expected QR1 bit %zu to have circuit index %zu, got %" PRIu32 "\n", bit,
                    bit + 1, bit_indices[bit]);
             result = EqualityError;
             goto clean_bit_indices;
@@ -1601,12 +1600,12 @@ static int test_register_bits(void) {
     }
 
     QkQuantumRegister *qr2 = qk_quantum_register_new(2, "QR2");
-    int64_t reg_circuit_bits[2];
+    uint32_t reg_circuit_bits[2];
     qk_quantum_register_circuit_bits(qr2, circuit, reg_circuit_bits);
 
     for (size_t bit = 0; bit < 2; bit++) {
-        if (reg_circuit_bits[bit] >= 0) {
-            printf("Expected QR2 bit %zu to NOT be in circuit, got %" PRId64 "\n", bit,
+        if (reg_circuit_bits[bit] != UINT32_MAX) {
+            printf("Expected QR2 bit %zu to NOT be in circuit, got bit index %" PRIu32 "\n", bit,
                    reg_circuit_bits[bit]);
             result = EqualityError;
             goto cleanup_qr2;
@@ -1619,8 +1618,8 @@ static int test_register_bits(void) {
 
     // Positions should be 2, 3, since the circuit has two anonymous clbits
     for (size_t bit = 0; bit < 2; bit++) {
-        if (reg_circuit_bits[bit] != (int64_t)bit + 2) {
-            printf("Expected CR1 bit %zu to have circuit index %zu, got %" PRId64 "\n", bit,
+        if (reg_circuit_bits[bit] != (uint32_t)bit + 2) {
+            printf("Expected CR1 bit %zu to have circuit index %zu, got %" PRIu32 "\n", bit,
                    bit + 2, reg_circuit_bits[bit]);
             result = EqualityError;
             goto cleanup_cr1;
@@ -1630,8 +1629,9 @@ static int test_register_bits(void) {
     QkClassicalRegister *cr2 = qk_classical_register_new(1, "cr2");
     qk_classical_register_circuit_bits(cr2, circuit, reg_circuit_bits);
 
-    if (reg_circuit_bits[0] >= 0) {
-        printf("Expected CR2 bit 0 to NOT be in circuit, got %" PRId64 "\n", reg_circuit_bits[0]);
+    if (reg_circuit_bits[0] != UINT32_MAX) {
+        printf("Expected CR2 bit 0 to NOT be in circuit, got bit index %" PRIu32 "\n",
+               reg_circuit_bits[0]);
         result = EqualityError;
     }
 

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1517,7 +1517,7 @@ static int test_basic_register_queries(void) {
         if (strcmp(name, expected_names[qreg_idx]) != 0) {
             printf("Expected quantum register name %s, got '%s'\n", expected_names[qreg_idx], name);
             result = EqualityError;
-            goto name_cleanup;
+            goto cleanup_name;
         }
 
         size_t num_bits = qk_quantum_register_num_bits(qr_retrieved);
@@ -1525,7 +1525,7 @@ static int test_basic_register_queries(void) {
             printf("Expected quantum register size %zu, got %zu\n", expected_bits[qreg_idx],
                    num_bits);
             result = EqualityError;
-            goto name_cleanup;
+            goto cleanup_name;
         }
         qk_str_free(name);
         name = NULL;
@@ -1545,16 +1545,16 @@ static int test_basic_register_queries(void) {
     if (strcmp(name, "CR1") != 0) {
         printf("Expected classical register name 'CR1', got '%s'\n", name);
         result = EqualityError;
-        goto name_cleanup;
+        goto cleanup_name;
     }
 
     if (cr1_size != 3) {
         printf("Expected classical register size 3, got %zu\n", cr1_size);
         result = EqualityError;
-        goto name_cleanup;
+        goto cleanup_name;
     }
 
-name_cleanup:
+cleanup_name:
     if (name != NULL) {
         qk_str_free(name);
     }
@@ -1588,14 +1588,14 @@ static int test_register_bits(void) {
         if (bit_indices[bit] == UINT32_MAX) {
             printf("Expected QR1 bit %zu to be in the circuit, but it's not\n", bit);
             result = EqualityError;
-            goto clean_bit_indices;
+            goto cleanup_bit_indices;
         }
         // Positions should be 1, 2, 3, since the circuit has an anonymous qubit
         if (bit_indices[bit] != (uint32_t)bit + 1) {
             printf("Expected QR1 bit %zu to have circuit index %zu, got %" PRIu32 "\n", bit,
                    bit + 1, bit_indices[bit]);
             result = EqualityError;
-            goto clean_bit_indices;
+            goto cleanup_bit_indices;
         }
     }
 
@@ -1640,7 +1640,7 @@ cleanup_cr1:
     qk_classical_register_free(cr1);
 cleanup_qr2:
     qk_quantum_register_free(qr2);
-clean_bit_indices:
+cleanup_bit_indices:
     free(bit_indices);
 cleanup:
     qk_quantum_register_free(qr1);


### PR DESCRIPTION
This PR adds C API functions for retrieving information about registers in a circuit. It is a spin-off of the work started for #15980 and now stands on its own, as vast majority of the added API here is not relevant for inspecting control flow conditions. 

### Details
Most of the new API functions are straight forward. These two though, may require some more discussion: 
~~- `qk_circuit_clbit_owning_register`: This is used to extract the owning register of a given circuit clbit, or NULL if non-exists. I believe this could be useful when inspecting control flow condition of type bit, to refer back to the owning reg, if it exists. (for completeness `qk_circuit_qubit_owning_register` was also added).~~ EDIT: removed from this PR. Might be added later when we identify a concrete use-case. 
- `qk_quantum_register_circuit_bits` (and `qk_classical_register_num_bits`): these return the mapping as `u32` using `u32::MAX` as sentinel values to indicate a certain reg bit doesn't belong to the circuit. We could think of a different API to return the bit mapping, but I wanted to keep the API simple, e.g. by not adding new structs, hence this choice. 

Closes #15680

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code:
Bob 1.0.2 was used to generate initial versions of the C tests and documentation. 

### Tasks
- [x] Add functions to the v tables
- [x] Add C and Rust testing
- [x] Add documentation and reno
