### PR TITLE
Add C API for inspecting classical expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,7 +2301,9 @@ dependencies = [
  "mimalloc",
  "nalgebra 0.34.2",
  "ndarray",
+ "num-bigint",
  "num-complex",
+ "num-traits",
  "pyo3",
  "qiskit-circuit",
  "qiskit-circuit-library",
@@ -2312,6 +2314,7 @@ dependencies = [
  "rand_pcg 0.10.2",
  "smallvec",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -99,6 +99,21 @@ pub static EXPORT_RENAME: &[(&str, &str)] = &[
     ("DAGCircuit", "Dag"),
     ("SparseObservable", "Obs"),
     ("StandardGate", "Gate"),
+    // Classical expression types
+    ("Expr", "ExprNode"),
+    ("CExprNodeKind", "ExprNodeKind"),
+    ("CBinaryExprInfo", "BinaryExprInfo"),
+    ("CBinaryOpType", "BinaryOpType"),
+    ("CUnaryExprInfo", "UnaryExprInfo"),
+    ("CUnaryOpType", "UnaryOpType"),
+    ("CCastExprInfo", "CastExprInfo"),
+    ("CIndexExprInfo", "IndexExprInfo"),
+    ("CExprType", "ExprType"),
+    ("CExprTypeInfo", "ExprTypeInfo"),
+    ("CDurationType", "DurationType"),
+    ("CDurationInfo", "DurationInfo"),
+    ("CDurationValue", "DurationValue"),
+    ("CValueType", "ValueType"),
 ];
 pub static EXPORT_VERBATIM: &[&str] = &["PyObject"];
 

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -441,7 +441,7 @@ mod classical_expr {
             export_fn!(qk_expr_as_value),
             export_fn!(qk_expr_as_var),
             export_fn!(qk_expr_as_stretch),
-            export_fn!(qk_value_type),
+            export_fn!(qk_value_type_info),
             export_fn!(qk_value_duration_info),
             export_fn!(qk_value_float),
             export_fn!(qk_value_uint),

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -26,7 +26,8 @@ pub static FUNCTIONS_CIRCUIT: ExportedFunctions =
         .add_child(5, &circuit::FUNCTIONS)
         .add_child(105, &dag::FUNCTIONS)
         .add_child(205, &param::FUNCTIONS)
-        .add_child(255, &circuit_library::FUNCTIONS);
+        .add_child(255, &circuit_library::FUNCTIONS)
+        .add_child(305, &classical_expr::FUNCTIONS);
 pub static FUNCTIONS_QI: ExportedFunctions =
     ExportedFunctions::empty().add_child(0, &sparse_observable::FUNCTIONS);
 pub use transpiler::FUNCTIONS as FUNCTIONS_TRANSPILE;
@@ -423,4 +424,31 @@ mod transpiler {
         .add_child(50, &TRANSPILE_STATE)
         .add_child(150, &target::FUNCTIONS)
         .add_child(250, &passes::FUNCTIONS);
+}
+
+mod classical_expr {
+    use crate::impl_::prelude::*;
+    #[cfg(feature = "addr")]
+    use qiskit_cext::classical_expr::*;
+
+    pub static FUNCTIONS: ExportedFunctions = ExportedFunctions::leaves(50, || {
+        vec![
+            export_fn!(qk_expr_node_kind),
+            export_fn!(qk_expr_binary_info),
+            export_fn!(qk_expr_unary_info),
+            export_fn!(qk_expr_cast_info),
+            export_fn!(qk_expr_index_info),
+            export_fn!(qk_expr_as_value),
+            export_fn!(qk_expr_as_var),
+            export_fn!(qk_expr_as_stretch),
+            export_fn!(qk_value_type),
+            export_fn!(qk_value_duration_info),
+            export_fn!(qk_value_float),
+            export_fn!(qk_value_uint),
+            export_fn!(qk_value_bool),
+            export_fn!(qk_var_name),
+            export_fn!(qk_var_type_info),
+            export_fn!(qk_stretch_name),
+        ]
+    });
 }

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -433,7 +433,7 @@ mod classical_expr {
 
     pub static FUNCTIONS: ExportedFunctions = ExportedFunctions::leaves(50, || {
         vec![
-            export_fn!(qk_expr_node_kind),
+            export_fn!(qk_expr_kind),
             export_fn!(qk_expr_binary_info),
             export_fn!(qk_expr_unary_info),
             export_fn!(qk_expr_cast_info),

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -30,6 +30,9 @@ rand.workspace = true
 rand_pcg.workspace = true
 anyhow.workspace = true
 mimalloc = { workspace = true, optional = true}
+uuid.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
 
 [features]
 python_binding = ["dep:pyo3"]

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -61,6 +61,7 @@ impl From<&Expr> for CExprNodeKind {
 
 /// The data types that can be used in classical expressions.
 #[repr(u8)]
+#[derive(Copy, Clone)]
 pub enum CExprType {
     /// Boolean type
     Bool = 0,
@@ -95,6 +96,7 @@ impl From<&Value> for CExprType {
 
 /// The complete representation of the data type used for an expression.
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct CExprTypeInfo {
     /// The expression type
     ty: CExprType,
@@ -102,13 +104,13 @@ pub struct CExprTypeInfo {
     width: u16,
 }
 
-impl CExprTypeInfo {
-    fn to_type(&self) -> Type {
-        match self.ty {
+impl From<CExprTypeInfo> for Type {
+    fn from(value: CExprTypeInfo) -> Type {
+        match value.ty {
             CExprType::Bool => Type::Bool,
             CExprType::Duration => Type::Duration,
             CExprType::Float => Type::Float,
-            CExprType::Uint => Type::Uint(self.width),
+            CExprType::Uint => Type::Uint(value.width),
         }
     }
 }
@@ -158,9 +160,9 @@ impl From<UnaryOp> for CUnaryOpType {
     }
 }
 
-impl CUnaryOpType {
-    fn to_unary_op(&self) -> UnaryOp {
-        match self {
+impl From<CUnaryOpType> for UnaryOp {
+    fn from(value: CUnaryOpType) -> Self {
+        match value {
             CUnaryOpType::BitNot => UnaryOp::BitNot,
             CUnaryOpType::LogicNot => UnaryOp::LogicNot,
             CUnaryOpType::Negate => UnaryOp::Negate,
@@ -186,6 +188,7 @@ pub struct CUnaryExprInfo {
 /// The operation types a binary expression can hold.
 /// Values are one-based to match Python convention.
 #[repr(u8)]
+#[derive(Copy, Clone)]
 pub enum CBinaryOpType {
     /// Bitwise AND operation
     BitAnd = 1,
@@ -247,9 +250,9 @@ impl From<BinaryOp> for CBinaryOpType {
     }
 }
 
-impl CBinaryOpType {
-    fn to_binary_op(&self) -> BinaryOp {
-        match self {
+impl From<CBinaryOpType> for BinaryOp {
+    fn from(value: CBinaryOpType) -> Self {
+        match value {
             CBinaryOpType::BitAnd => BinaryOp::BitAnd,
             CBinaryOpType::BitOr => BinaryOp::BitOr,
             CBinaryOpType::BitXor => BinaryOp::BitXor,
@@ -320,6 +323,7 @@ pub struct CIndexExprInfo {
 
 /// Represents different time units used in duration expressions.
 #[repr(u8)]
+#[derive(Copy, Clone)]
 pub enum CDurationType {
     /// System time units
     Dt = 0,
@@ -352,6 +356,7 @@ impl From<&Duration> for CDurationType {
 ///
 /// This union is part of the `QkDurationInfo` struct and should not be used directly.
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub union CDurationValue {
     /// System time units (active when `ty` in `QkDurationInfo` is `QkDurationType_Dt`)
     dt: i64,
@@ -368,6 +373,7 @@ pub union CDurationValue {
 /// - For all other duration types the duration is stored as a floating-point value in `value.time`.
 ///
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct CDurationInfo {
     /// The duration unit type (discriminant for the union)
     pub ty: CDurationType,
@@ -406,16 +412,16 @@ impl From<&Duration> for CDurationInfo {
     }
 }
 
-impl CDurationInfo {
-    pub fn to_duration(&self) -> Duration {
-        match self.ty {
+impl From<CDurationInfo> for Duration {
+    fn from(value: CDurationInfo) -> Self {
+        match value.ty {
             // SAFETY: Per documentation, ty must correctly discriminate the union.
-            CDurationType::Dt => Duration::dt(unsafe { self.value.dt }),
-            CDurationType::Ps => Duration::ps(unsafe { self.value.time }),
-            CDurationType::Ns => Duration::ns(unsafe { self.value.time }),
-            CDurationType::Us => Duration::us(unsafe { self.value.time }),
-            CDurationType::Ms => Duration::ms(unsafe { self.value.time }),
-            CDurationType::S => Duration::s(unsafe { self.value.time }),
+            CDurationType::Dt => Duration::dt(unsafe { value.value.dt }),
+            CDurationType::Ps => Duration::ps(unsafe { value.value.time }),
+            CDurationType::Ns => Duration::ns(unsafe { value.value.time }),
+            CDurationType::Us => Duration::us(unsafe { value.value.time }),
+            CDurationType::Ms => Duration::ms(unsafe { value.value.time }),
+            CDurationType::S => Duration::s(unsafe { value.value.time }),
         }
     }
 }
@@ -999,7 +1005,7 @@ pub unsafe extern "C" fn inner_test_binary_expr_ops(op: CBinaryOpType) -> *mut E
     });
 
     let expr = Expr::Binary(Box::new(Binary {
-        op: op.to_binary_op(),
+        op: op.into(),
         left: zero.clone(),
         right: zero.clone(),
         ty: Type::Float,
@@ -1020,7 +1026,7 @@ pub unsafe extern "C" fn inner_test_unary_expr_ops(op: CUnaryOpType) -> *mut Exp
     });
 
     let expr = Expr::Unary(Box::new(Unary {
-        op: op.to_unary_op(),
+        op: op.into(),
         operand: zero,
         ty: Type::Float,
         constant: true,
@@ -1037,7 +1043,7 @@ pub unsafe extern "C" fn inner_test_expr_kinds_and_types(
     kind: CExprNodeKind,
     ty: CExprTypeInfo,
 ) -> *mut Expr {
-    let rust_type = ty.to_type();
+    let rust_type = ty.into();
 
     let dummy_value = match &rust_type {
         Type::Bool => Expr::Value(Value::Uint {
@@ -1058,7 +1064,7 @@ pub unsafe extern "C" fn inner_test_expr_kinds_and_types(
     let var = Expr::Var(Var::Standalone {
         uuid: Uuid::new_v4().as_u128(),
         name: "test_var".to_owned(),
-        ty: ty.to_type(),
+        ty: ty.into(),
     });
 
     let index = Expr::Value(Value::Uint {
@@ -1119,7 +1125,7 @@ pub unsafe extern "C" fn inner_test_value(
             raw: BigUint::from(if b { 1u32 } else { 0u32 }),
             ty: Type::Bool,
         },
-        CExprType::Duration => Value::Duration(duration.to_duration()),
+        CExprType::Duration => Value::Duration(duration.into()),
         CExprType::Float => Value::Float {
             raw: f_val,
             ty: Type::Float,

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn qk_expr_kind(expr: *const Expr) -> CExprNodeKind {
 /// @param expr A pointer to a binary expression node.
 ///
 /// @return A ``QkBinaryExprInfo`` structure describing the operator, operands,
-/// result type, and constantness of the expression.
+/// result type, and whether the expression is constant.
 ///
 /// This function panics if ``expr`` does not point to a binary expression node.
 ///
@@ -488,7 +488,7 @@ pub unsafe extern "C" fn qk_expr_binary_info(expr: *const Expr) -> CBinaryExprIn
 /// @param expr A pointer to a unary expression node.
 ///
 /// @return A ``QkUnaryExprInfo`` structure describing the operator, operand,
-/// result type, and constantness of the expression.
+/// result type, and whether the expression is constant.
 ///
 /// This function panics if ``expr`` does not point to a unary expression node.
 ///
@@ -524,7 +524,7 @@ pub unsafe extern "C" fn qk_expr_unary_info(expr: *const Expr) -> CUnaryExprInfo
 /// @param expr A pointer to a cast expression node.
 ///
 /// @return A ``QkCastExprInfo`` structure describing the operand, destination
-/// type, implicitness, and constantness of the expression.
+/// type, whether the cast is implicit, and whether the expression is constant.
 ///
 /// This function panics if ``expr`` does not point to a cast expression node.
 ///
@@ -560,7 +560,7 @@ pub unsafe extern "C" fn qk_expr_cast_info(expr: *const Expr) -> CCastExprInfo {
 /// @param expr A pointer to an index expression node.
 ///
 /// @return A ``QkIndexExprInfo`` structure describing the indexed target,
-/// index expression, result type, and constantness of the expression.
+/// index expression, result type, and whether the expression is constant.
 ///
 /// This function panics if ``expr`` does not point to an index expression node.
 ///

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -685,26 +685,32 @@ pub unsafe extern "C" fn qk_expr_as_stretch(expr: *const Expr) -> *const Stretch
 }
 
 /// @ingroup QkClassicalExpressions
-/// Return the type of a value.
+/// Return the type information of a value.
 ///
 /// @param value A pointer to the `QkValue` to inspect.
 ///
-/// @return The coarse-grained expression type for ``value``.
+/// @return A ``QkExprTypeInfo`` structure containing the value type information.
 ///
 /// # Example
 /// ```c
-/// QkExprType ty = qk_value_type(value);
+/// QkExprTypeInfo type_info = qk_value_type_info(value);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``Value``.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_value_type(value: *const Value) -> CExprType {
+pub unsafe extern "C" fn qk_value_type_info(value: *const Value) -> CExprTypeInfo {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let value = unsafe { const_ptr_as_ref(value) };
 
-    CExprType::from(value)
+    match value {
+        Value::Duration(_) => CExprTypeInfo {
+            ty: CExprType::Duration,
+            width: 0,
+        },
+        Value::Float { ty, .. } | Value::Uint { ty, .. } => CExprTypeInfo::from(ty),
+    }
 }
 
 /// @ingroup QkClassicalExpressions
@@ -878,14 +884,13 @@ pub unsafe extern "C" fn qk_var_name(var: *const Var) -> *mut c_char {
 ///
 /// @param var A pointer to the variable to inspect.
 ///
-/// @return A ``QkExprTypeInfo`` structure containing the variable type and, for
-/// unsigned integers, the declared bit width.
+/// @return A ``QkExprTypeInfo`` structure containing the variable type information.
 ///
 /// This function panics if ``var`` is a bit variable, which is not yet supported by this API.
 ///
 /// # Example
 /// ```c
-/// QkExprTypeInfo info = qk_var_type_info(var);
+/// QkExprTypeInfo type_info = qk_var_type_info(var);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -428,14 +428,14 @@ impl CDurationInfo {
 ///
 /// # Example
 /// ```c
-/// QKExprNodeKind kind = qk_expr_node_kind(expr);
+/// QKExprNodeKind kind = qk_expr_kind(expr);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_expr_node_kind(expr: *const Expr) -> CExprNodeKind {
+pub unsafe extern "C" fn qk_expr_kind(expr: *const Expr) -> CExprNodeKind {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let expr = unsafe { const_ptr_as_ref(expr) };
 

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -16,6 +16,7 @@ use crate::pointers::const_ptr_as_ref;
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 use qiskit_circuit::{
+    bit::{ClassicalRegister, ShareableClbit},
     classical::{
         expr::{Binary, BinaryOp, Cast, Expr, Index, Stretch, Unary, UnaryOp, Value, Var},
         types::Type,
@@ -836,14 +837,16 @@ pub unsafe extern "C" fn qk_value_bool(value: *const Value) -> bool {
 /// @param var A pointer to the variable to inspect.
 ///
 /// @return A null-terminated string containing the variable name, or ``NULL``
-/// if ``var`` refers to a bit variable with no standalone name. The caller owns
-/// the returned string and must free it with ``qk_str_free``.
+/// if ``var`` refers to a non-standalone variable (i.e. based on a classical bit or a classical register).
+/// The caller owns the returned string and must free it with ``qk_str_free``.
 ///
 /// # Example
 /// ```c
 /// char *name = qk_var_name(var);
-/// // Use the name...
-/// qk_str_free(name);
+/// if (name ! = NULL) {
+///     // Use the name...
+///     qk_str_free(name);
+/// }
 /// ```
 ///
 /// # Safety
@@ -856,8 +859,7 @@ pub unsafe extern "C" fn qk_var_name(var: *const Var) -> *mut c_char {
 
     let name = match var {
         Var::Standalone { name, .. } => name.as_str(),
-        Var::Register { register, .. } => register.name(),
-        Var::Bit { .. } => return ptr::null_mut(),
+        Var::Register { .. } | Var::Bit { .. } => return ptr::null_mut(),
     };
 
     CString::new(name)
@@ -891,18 +893,15 @@ pub unsafe extern "C" fn qk_var_type_info(var: *const Var) -> CExprTypeInfo {
     let ty = match var {
         Var::Standalone { ty, .. } => ty,
         Var::Register { ty, .. } => ty,
-        Var::Bit { .. } => panic!("Bit variables are not yet supported by this API"),
-    };
-
-    let width = if let Type::Uint(width) = ty {
-        *width
-    } else {
-        0u16
+        Var::Bit { .. } => &Type::Bool,
     };
 
     CExprTypeInfo {
         ty: CExprType::from(ty),
-        width,
+        width: match ty {
+            Type::Uint(width) => *width,
+            _ => 0,
+        },
     }
 }
 
@@ -1132,6 +1131,27 @@ pub unsafe extern "C" fn inner_test_value(
     };
 
     Box::into_raw(Box::new(Expr::Value(value)))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inned_test_old_style_vars(out_vars: *mut *mut Expr) {
+    let bit_var = Var::Bit {
+        bit: ShareableClbit::new_anonymous(),
+    };
+    let reg_var = Var::Register {
+        register: ClassicalRegister::new_owning("c1", 2),
+        ty: Type::Uint(2),
+    };
+
+    unsafe {
+        out_vars.write(Box::into_raw(Box::new(Expr::Var(bit_var))));
+        out_vars
+            .add(1)
+            .write(Box::into_raw(Box::new(Expr::Var(reg_var))));
+    }
 }
 
 /// cbindgen:qk-vtable-rules=[no-export]

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -348,19 +348,27 @@ impl From<&Duration> for CDurationType {
 }
 
 /// A union to hold either system time units (dt) as an integer or real time as a float.
-/// Part of the `QkDurationInfo` struct.
+///
+/// This union is part of the `QkDurationInfo` struct and should not be used directly.
 #[repr(C)]
 pub union CDurationValue {
-    /// System time units
+    /// System time units (active when `ty` in `QkDurationInfo` is `QkDurationType_Dt`)
     dt: i64,
-    /// Real time value
+    /// Real time value (active for all other duration types)
     time: f64,
 }
 
 /// The complete representation of a duration value.
+///
+/// The `ty` field acts as a discriminant that determines which field of the `value` union is active.
+///
+/// When initialized from C, it is the user's responsibility to ensure that:
+/// - When `ty` is `QkDurationType_Dt`, the duration is stored as an integer in `value.dt`.
+/// - For all other duration types the duration is stored as a floating-point value in `value.time`.
+///
 #[repr(C)]
 pub struct CDurationInfo {
-    /// The duration unit type
+    /// The duration unit type (discriminant for the union)
     pub ty: CDurationType,
     /// The duration value
     pub value: CDurationValue,
@@ -400,6 +408,7 @@ impl From<&Duration> for CDurationInfo {
 impl CDurationInfo {
     pub fn to_duration(&self) -> Duration {
         match self.ty {
+            // SAFETY: Per documentation, ty must correctly discriminate the union.
             CDurationType::Dt => Duration::dt(unsafe { self.value.dt }),
             CDurationType::Ps => Duration::ps(unsafe { self.value.time }),
             CDurationType::Ns => Duration::ns(unsafe { self.value.time }),

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -1,0 +1,1134 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use std::ptr;
+
+use crate::pointers::const_ptr_as_ref;
+use num_bigint::BigUint;
+use num_traits::{ToPrimitive, Zero};
+use qiskit_circuit::{
+    classical::{
+        expr::{Binary, BinaryOp, Cast, Expr, Index, Stretch, Unary, UnaryOp, Value, Var},
+        types::Type,
+    },
+    duration::Duration,
+};
+use std::ffi::{CString, c_char};
+use uuid::Uuid;
+
+/// The different types of expression nodes that can appear in a classical expression tree.
+#[repr(u8)]
+pub enum CExprNodeKind {
+    /// Unary operation expression (e.g., NOT, negation)
+    Unary = 0,
+    /// Binary operation expression (e.g., AND, OR, arithmetic operations)
+    Binary = 1,
+    /// Type cast expression
+    Cast = 2,
+    /// Literal value expression
+    Value = 3,
+    /// Variable reference expression
+    Var = 4,
+    /// Stretch expression (timing-related)
+    Stretch = 5,
+    /// Index/subscript expression
+    Index = 6,
+}
+
+impl From<&Expr> for CExprNodeKind {
+    fn from(value: &Expr) -> Self {
+        match value {
+            Expr::Unary(_) => Self::Unary,
+            Expr::Binary(_) => Self::Binary,
+            Expr::Cast(_) => Self::Cast,
+            Expr::Index(_) => Self::Index,
+            Expr::Stretch(_) => Self::Stretch,
+            Expr::Value(_) => Self::Value,
+            Expr::Var(_) => Self::Var,
+        }
+    }
+}
+
+/// The data types that can be used in classical expressions.
+#[repr(u8)]
+pub enum CExprType {
+    /// Boolean type
+    Bool = 0,
+    /// Duration type
+    Duration = 1,
+    /// Floating-point type
+    Float = 2,
+    /// Unsigned integer type
+    Uint = 3,
+}
+
+impl From<&Type> for CExprType {
+    fn from(value: &Type) -> Self {
+        match value {
+            Type::Bool => Self::Bool,
+            Type::Duration => Self::Duration,
+            Type::Float => Self::Float,
+            Type::Uint(_) => Self::Uint,
+        }
+    }
+}
+
+impl From<&Value> for CExprType {
+    fn from(value: &Value) -> Self {
+        match value {
+            Value::Duration(_) => Self::Duration,
+            Value::Float { ty, .. } => Self::from(ty),
+            Value::Uint { ty, .. } => Self::from(ty),
+        }
+    }
+}
+
+/// The complete representation of the data type used for an expression.
+#[repr(C)]
+pub struct CExprTypeInfo {
+    /// The expression type
+    ty: CExprType,
+    /// Bit width for the Uint expression type
+    width: u16,
+}
+
+impl CExprTypeInfo {
+    fn to_type(&self) -> Type {
+        match self.ty {
+            CExprType::Bool => Type::Bool,
+            CExprType::Duration => Type::Duration,
+            CExprType::Float => Type::Float,
+            CExprType::Uint => Type::Uint(self.width),
+        }
+    }
+}
+
+impl From<&Type> for CExprTypeInfo {
+    fn from(ty: &Type) -> Self {
+        match ty {
+            Type::Bool => CExprTypeInfo {
+                ty: CExprType::Bool,
+                width: 0,
+            },
+            Type::Duration => CExprTypeInfo {
+                ty: CExprType::Duration,
+                width: 0,
+            },
+            Type::Float => CExprTypeInfo {
+                ty: CExprType::Float,
+                width: 0,
+            },
+            Type::Uint(w) => CExprTypeInfo {
+                ty: CExprType::Uint,
+                width: *w,
+            },
+        }
+    }
+}
+
+/// The operation types a unary expression can hold.
+/// Values are one-based to match the Python convention of the classical expression system.
+#[repr(u8)]
+pub enum CUnaryOpType {
+    /// Bitwise NOT operation
+    BitNot = 1,
+    /// Logical NOT operation
+    LogicNot = 2,
+    /// Arithmetic negation
+    Negate = 3,
+}
+
+impl From<UnaryOp> for CUnaryOpType {
+    fn from(value: UnaryOp) -> Self {
+        match value {
+            UnaryOp::BitNot => Self::BitNot,
+            UnaryOp::LogicNot => Self::LogicNot,
+            UnaryOp::Negate => Self::Negate,
+        }
+    }
+}
+
+impl CUnaryOpType {
+    fn to_unary_op(&self) -> UnaryOp {
+        match self {
+            CUnaryOpType::BitNot => UnaryOp::BitNot,
+            CUnaryOpType::LogicNot => UnaryOp::LogicNot,
+            CUnaryOpType::Negate => UnaryOp::Negate,
+        }
+    }
+}
+
+/// Describes a unary expression, including its operator, operand, result type and whether it is constant.
+/// Returned by the `qk_expr_unary_info` function. The `operand` field is a borrowed pointer to the operand
+/// of the unary operation expression.
+#[repr(C)]
+pub struct CUnaryExprInfo {
+    /// The unary operator
+    pub op: CUnaryOpType,
+    /// Borrowed pointer to the operand expression
+    pub operand: *const Expr,
+    /// Result type of the operation
+    pub ty: CExprTypeInfo,
+    /// Whether the expression is constant
+    pub constant: bool,
+}
+
+/// The operation types a binary expression can hold.
+/// Values are one-based to match Python convention.
+#[repr(u8)]
+pub enum CBinaryOpType {
+    /// Bitwise AND operation
+    BitAnd = 1,
+    /// Bitwise OR operation
+    BitOr = 2,
+    /// Bitwise XOR operation
+    BitXor = 3,
+    /// Logical AND operation
+    LogicAnd = 4,
+    /// Logical OR operation
+    LogicOr = 5,
+    /// Equality comparison
+    Equal = 6,
+    /// Inequality comparison
+    NotEqual = 7,
+    /// Less than comparison
+    Less = 8,
+    /// Less than or equal comparison
+    LessEqual = 9,
+    /// Greater than comparison
+    Greater = 10,
+    /// Greater than or equal comparison
+    GreaterEqual = 11,
+    /// Left shift operation
+    ShiftLeft = 12,
+    /// Right shift operation
+    ShiftRight = 13,
+    /// Addition operation
+    Add = 14,
+    /// Subtraction operation
+    Sub = 15,
+    /// Multiplication operation
+    Mul = 16,
+    /// Division operation
+    Div = 17,
+}
+
+impl From<BinaryOp> for CBinaryOpType {
+    fn from(value: BinaryOp) -> Self {
+        match value {
+            BinaryOp::BitAnd => Self::BitAnd,
+            BinaryOp::BitOr => Self::BitOr,
+            BinaryOp::BitXor => Self::BitXor,
+            BinaryOp::LogicAnd => Self::LogicAnd,
+            BinaryOp::LogicOr => Self::LogicOr,
+            BinaryOp::Equal => Self::Equal,
+            BinaryOp::NotEqual => Self::NotEqual,
+            BinaryOp::Less => Self::Less,
+            BinaryOp::LessEqual => Self::LessEqual,
+            BinaryOp::Greater => Self::Greater,
+            BinaryOp::GreaterEqual => Self::GreaterEqual,
+            BinaryOp::ShiftLeft => Self::ShiftLeft,
+            BinaryOp::ShiftRight => Self::ShiftRight,
+            BinaryOp::Add => Self::Add,
+            BinaryOp::Sub => Self::Sub,
+            BinaryOp::Mul => Self::Mul,
+            BinaryOp::Div => Self::Div,
+        }
+    }
+}
+
+impl CBinaryOpType {
+    fn to_binary_op(&self) -> BinaryOp {
+        match self {
+            CBinaryOpType::BitAnd => BinaryOp::BitAnd,
+            CBinaryOpType::BitOr => BinaryOp::BitOr,
+            CBinaryOpType::BitXor => BinaryOp::BitXor,
+            CBinaryOpType::LogicAnd => BinaryOp::LogicAnd,
+            CBinaryOpType::LogicOr => BinaryOp::LogicOr,
+            CBinaryOpType::Equal => BinaryOp::Equal,
+            CBinaryOpType::NotEqual => BinaryOp::NotEqual,
+            CBinaryOpType::Less => BinaryOp::Less,
+            CBinaryOpType::LessEqual => BinaryOp::LessEqual,
+            CBinaryOpType::Greater => BinaryOp::Greater,
+            CBinaryOpType::GreaterEqual => BinaryOp::GreaterEqual,
+            CBinaryOpType::ShiftLeft => BinaryOp::ShiftLeft,
+            CBinaryOpType::ShiftRight => BinaryOp::ShiftRight,
+            CBinaryOpType::Add => BinaryOp::Add,
+            CBinaryOpType::Sub => BinaryOp::Sub,
+            CBinaryOpType::Mul => BinaryOp::Mul,
+            CBinaryOpType::Div => BinaryOp::Div,
+        }
+    }
+}
+
+/// Describes a binary expression, including its operator, operands, result type and whether it is constant.
+/// Returned by the `qk_expr_binary_info` function. The `left` and `right` fields are borrowed pointers to
+/// the operands of the binary operation expression.
+#[repr(C)]
+pub struct CBinaryExprInfo {
+    /// The binary operator
+    pub op: CBinaryOpType,
+    /// Borrowed pointer to the left operand expression
+    pub left: *const Expr,
+    /// Borrowed pointer to the right operand expression
+    pub right: *const Expr,
+    /// Result type of the operation
+    pub ty: CExprTypeInfo,
+    /// Whether the expression is constant
+    pub constant: bool,
+}
+
+/// Describes a cast expression, including the operand, target type, whether it is implicit, and whether it is constant.
+/// Returned by the `qk_expr_cast_info` function. The `operand` field is a borrowed pointer to the operand
+/// of the cast expression.
+#[repr(C)]
+pub struct CCastExprInfo {
+    /// Borrowed pointer to the operand expression being cast
+    pub operand: *const Expr,
+    /// Target type of the cast
+    pub ty: CExprTypeInfo,
+    /// Whether the cast is implicit (automatic) or explicit
+    pub implicit: bool,
+    /// Whether the expression is constant
+    pub constant: bool,
+}
+
+/// Describes an index expression, including the target, index, result type and whether it is constant.
+/// Returned by the `qk_expr_index_info` function. The `target` and `index` fields are borrowed pointers
+/// to the target and index of the index operation expression.
+#[repr(C)]
+pub struct CIndexExprInfo {
+    /// Borrowed pointer to the target expression being indexed
+    pub target: *const Expr,
+    /// Borrowed pointer to the index expression
+    pub index: *const Expr,
+    /// Result type of the indexing operation
+    pub ty: CExprTypeInfo,
+    /// Whether the expression is constant
+    pub constant: bool,
+}
+
+/// Represents different time units used in duration expressions.
+#[repr(u8)]
+pub enum CDurationType {
+    /// System time units
+    Dt = 0,
+    /// Picoseconds
+    Ps = 1,
+    /// Nanoseconds
+    Ns = 2,
+    /// Microseconds
+    Us = 3,
+    /// Milliseconds
+    Ms = 4,
+    /// Seconds
+    S = 5,
+}
+
+impl From<&Duration> for CDurationType {
+    fn from(duration: &Duration) -> Self {
+        match duration {
+            Duration::dt(_) => Self::Dt,
+            Duration::ps(_) => Self::Ps,
+            Duration::ns(_) => Self::Ns,
+            Duration::us(_) => Self::Us,
+            Duration::ms(_) => Self::Ms,
+            Duration::s(_) => Self::S,
+        }
+    }
+}
+
+/// A union to hold either system time units (dt) as an integer or real time as a float.
+/// Part of the `QkDurationInfo` struct.
+#[repr(C)]
+pub union CDurationValue {
+    /// System time units
+    dt: i64,
+    /// Real time value
+    time: f64,
+}
+
+/// The complete representation of a duration value.
+#[repr(C)]
+pub struct CDurationInfo {
+    /// The duration unit type
+    pub ty: CDurationType,
+    /// The duration value
+    pub value: CDurationValue,
+}
+
+impl From<&Duration> for CDurationInfo {
+    fn from(duration: &Duration) -> Self {
+        match duration {
+            Duration::dt(v) => CDurationInfo {
+                ty: CDurationType::Dt,
+                value: CDurationValue { dt: *v },
+            },
+            Duration::ps(v) => CDurationInfo {
+                ty: CDurationType::Ps,
+                value: CDurationValue { time: *v },
+            },
+            Duration::ns(v) => CDurationInfo {
+                ty: CDurationType::Ns,
+                value: CDurationValue { time: *v },
+            },
+            Duration::us(v) => CDurationInfo {
+                ty: CDurationType::Us,
+                value: CDurationValue { time: *v },
+            },
+            Duration::ms(v) => CDurationInfo {
+                ty: CDurationType::Ms,
+                value: CDurationValue { time: *v },
+            },
+            Duration::s(v) => CDurationInfo {
+                ty: CDurationType::S,
+                value: CDurationValue { time: *v },
+            },
+        }
+    }
+}
+
+impl CDurationInfo {
+    pub fn to_duration(&self) -> Duration {
+        match self.ty {
+            CDurationType::Dt => Duration::dt(unsafe { self.value.dt }),
+            CDurationType::Ps => Duration::ps(unsafe { self.value.time }),
+            CDurationType::Ns => Duration::ns(unsafe { self.value.time }),
+            CDurationType::Us => Duration::us(unsafe { self.value.time }),
+            CDurationType::Ms => Duration::ms(unsafe { self.value.time }),
+            CDurationType::S => Duration::s(unsafe { self.value.time }),
+        }
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return the kind of a classical expression node.
+///
+/// @param expr A pointer to the expression node to inspect.
+///
+/// @return The kind enum describing which concrete expression variant ``expr`` contains.
+///
+/// # Example
+/// ```c
+/// QKExprNodeKind kind = qk_expr_node_kind(expr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_node_kind(expr: *const Expr) -> CExprNodeKind {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    CExprNodeKind::from(expr)
+}
+
+/// @ingroup QkClassicalExpressions
+///
+/// Extract information from a binary expression node.
+///
+/// @param expr A pointer to a binary expression node.
+///
+/// @return A ``QkBinaryExprInfo`` structure describing the operator, operands,
+/// result type, and constantness of the expression.
+///
+/// This function panics if ``expr`` does not point to a binary expression node.
+///
+/// # Example
+/// ```c
+/// QkBinaryExprInfo info = qk_expr_binary_info(expr);
+/// const Expr *lhs = info.left;
+/// const Expr *rhs = info.right;
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_binary_info(expr: *const Expr) -> CBinaryExprInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Binary(binary) = expr else {
+        panic!("qk_expr_binary_info called on non-binary expression")
+    };
+
+    CBinaryExprInfo {
+        op: CBinaryOpType::from(binary.op),
+        left: ptr::from_ref(&binary.left),
+        right: ptr::from_ref(&binary.right),
+        ty: CExprTypeInfo::from(&binary.ty),
+        constant: binary.constant,
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract information from a unary expression node.
+///
+/// @param expr A pointer to a unary expression node.
+///
+/// @return A ``QkUnaryExprInfo`` structure describing the operator, operand,
+/// result type, and constantness of the expression.
+///
+/// This function panics if ``expr`` does not point to a unary expression node.
+///
+/// # Example
+/// ```c
+/// QkUnaryExprInfo info = qk_expr_unary_info(expr);
+/// QkUnaryOpType op = info.op;
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_unary_info(expr: *const Expr) -> CUnaryExprInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Unary(unary) = expr else {
+        panic!("qk_expr_unary_info called on non-unary expression")
+    };
+
+    CUnaryExprInfo {
+        op: CUnaryOpType::from(unary.op),
+        operand: ptr::from_ref(&unary.operand),
+        ty: CExprTypeInfo::from(&unary.ty),
+        constant: unary.constant,
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract information from a cast expression node.
+///
+/// @param expr A pointer to a cast expression node.
+///
+/// @return A ``QkCastExprInfo`` structure describing the operand, destination
+/// type, implicitness, and constantness of the expression.
+///
+/// This function panics if ``expr`` does not point to a cast expression node.
+///
+/// # Example
+/// ```c
+/// QkCastExprInfo info = qk_expr_cast_info(expr);
+/// const QkExprNode *operand = info.operand;
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_cast_info(expr: *const Expr) -> CCastExprInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Cast(cast) = expr else {
+        panic!("qk_expr_cast_info called on non-cast expression")
+    };
+
+    CCastExprInfo {
+        operand: ptr::from_ref(&cast.operand),
+        ty: CExprTypeInfo::from(&cast.ty),
+        implicit: cast.implicit,
+        constant: cast.constant,
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract information from an index expression node.
+///
+/// @param expr A pointer to an index expression node.
+///
+/// @return A ``QkIndexExprInfo`` structure describing the indexed target,
+/// index expression, result type, and constantness of the expression.
+///
+/// This function panics if ``expr`` does not point to an index expression node.
+///
+/// # Example
+/// ```c
+/// QkIndexExprInfo info = qk_expr_index_info(expr);
+/// const Expr *target = info.target;
+/// const Expr *index = info.index;
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_index_info(expr: *const Expr) -> CIndexExprInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Index(index) = expr else {
+        panic!("qk_expr_index_info called on non-index expression")
+    };
+
+    CIndexExprInfo {
+        target: ptr::from_ref(&index.target),
+        index: ptr::from_ref(&index.index),
+        ty: CExprTypeInfo::from(&index.ty),
+        constant: index.constant,
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return a view into the underlying value of the expression node.
+///
+/// @param expr A pointer to a value expression node.
+///
+/// @return A pointer to the ``QkValue`` stored inside ``expr``.
+///
+/// This function panics if ``expr`` does not point to a value expression node.
+///
+/// # Example
+/// ```c
+/// const QkValue *value = qk_expr_as_value(expr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_value(expr: *const Expr) -> *const Value {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Value(val) = expr else {
+        panic!("qk_expr_as_value called on non-value expression")
+    };
+
+    ptr::from_ref(val)
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return a view into the underlying variable of the expression node.
+///
+/// @param expr A pointer to a variable expression node.
+///
+/// @return A pointer to the ``QkVar`` stored inside ``expr``.
+///
+/// This function panics if ``expr`` does not point to a variable expression node.
+///
+/// # Example
+/// ```c
+/// const QkVar *var = qk_expr_as_var(expr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_var(expr: *const Expr) -> *const Var {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Var(var) = expr else {
+        panic!("qk_expr_as_var called on non-variable expression")
+    };
+
+    ptr::from_ref(var)
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return a view into the underlying stretch of the expression node.
+///
+/// @param expr A pointer to a stretch expression node.
+///
+/// @return A pointer to the ``QkStretch`` stored inside ``expr``.
+///
+/// This function panics if ``expr`` does not point to a stretch expression node.
+///
+/// # Example
+/// ```c
+/// const QkStretch *stretch = qk_expr_as_stretch(expr);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``expr`` is not a valid, non-null pointer to a ``QkExprNode``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_stretch(expr: *const Expr) -> *const Stretch {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Stretch(stretch) = expr else {
+        panic!("qk_expr_as_stretch called on non-stretch expression")
+    };
+
+    ptr::from_ref(stretch)
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return the type of a value.
+///
+/// @param value A pointer to the `QkValue` to inspect.
+///
+/// @return The coarse-grained expression type for ``value``.
+///
+/// # Example
+/// ```c
+/// QkExprType ty = qk_value_type(value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``Value``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_type(value: *const Value) -> CExprType {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    CExprType::from(value)
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract structured information from a duration value.
+///
+/// @param value A pointer to a duration value.
+///
+/// @return A ``QkDurationInfo`` structure containing the duration unit and raw value.
+///
+/// This function panics if ``value`` does not point to a duration value.
+///
+/// # Example
+/// ```c
+/// QkDurationInfo info = qk_value_duration_info(value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_duration_info(value: *const Value) -> CDurationInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Duration(duration) = value else {
+        panic!("qk_value_duration_info called on non-duration value")
+    };
+
+    CDurationInfo::from(duration)
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract the floating-point value from a ``QkValue``.
+///
+/// @param value A pointer to a float value.
+///
+/// @return The ``double`` value stored in ``value``.
+///
+/// This function panics if ``value`` does not point to a float value.
+///
+/// # Example
+/// ```c
+/// double raw = qk_value_float(value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_float(value: *const Value) -> f64 {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Float {
+        raw,
+        ty: Type::Float,
+    } = value
+    else {
+        panic!("qk_value_float called on non-float value")
+    };
+
+    *raw
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract the unsigned integer value from a ``QkValue`` of type ``QkExprType::Uint``.
+///
+/// @param value A pointer to a uint value.
+///
+/// @return The integer value converted to ``uint64_t``.
+///
+/// This function panics if ``value`` does not point to a ``QkExprType::Uint`` value or if the
+/// stored integer does not fit in ``uint64_t``.
+///
+/// # Example
+/// ```c
+/// uint64_t raw = qk_value_uint(value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_uint(value: *const Value) -> u64 {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Uint {
+        raw,
+        ty: Type::Uint(_),
+    } = value
+    else {
+        panic!("qk_value_uint called on non-uint value")
+    };
+
+    raw.to_u64()
+        .expect("Integer value too large to fit in uint64_t")
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract the value from a ``QkValue`` of type ``QkExprType::Bool``.
+///
+/// @param value A pointer to a bool value.
+///
+/// @return ``true`` if the stored integer representation is nonzero, otherwise ``false``.
+///
+/// This function panics if ``value`` does not point to a bool value.
+///
+/// # Example
+/// ```c
+/// bool raw = qk_value_bool(value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_bool(value: *const Value) -> bool {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Uint {
+        raw,
+        ty: Type::Bool,
+    } = value
+    else {
+        panic!("qk_value_bool called on non-bool value")
+    };
+
+    !raw.is_zero()
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return the name of a variable as a newly allocated C string.
+///
+/// @param var A pointer to the variable to inspect.
+///
+/// @return A null-terminated string containing the variable name, or ``NULL``
+/// if ``var`` refers to a bit variable with no standalone name. The caller owns
+/// the returned string and must free it with ``qk_str_free``.
+///
+/// # Example
+/// ```c
+/// char *name = qk_var_name(var);
+/// // Use the name...
+/// qk_str_free(name);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``var`` is not a valid, non-null pointer to a ``QkVar``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_name(var: *const Var) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let var = unsafe { const_ptr_as_ref(var) };
+
+    let name = match var {
+        Var::Standalone { name, .. } => name.as_str(),
+        Var::Register { register, .. } => register.name(),
+        Var::Bit { .. } => return ptr::null_mut(),
+    };
+
+    CString::new(name)
+        .expect("Var should have a valid name")
+        .into_raw()
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return full type information for a variable.
+///
+/// @param var A pointer to the variable to inspect.
+///
+/// @return A ``QkExprTypeInfo`` structure containing the variable type and, for
+/// unsigned integers, the declared bit width.
+///
+/// This function panics if ``var`` is a bit variable, which is not yet supported by this API.
+///
+/// # Example
+/// ```c
+/// QkExprTypeInfo info = qk_var_type_info(var);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``var`` is not a valid, non-null pointer to a ``QkVar``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_type_info(var: *const Var) -> CExprTypeInfo {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let var = unsafe { const_ptr_as_ref(var) };
+
+    let ty = match var {
+        Var::Standalone { ty, .. } => ty,
+        Var::Register { ty, .. } => ty,
+        Var::Bit { .. } => panic!("Bit variables are not yet supported by this API"),
+    };
+
+    let width = if let Type::Uint(width) = ty {
+        *width
+    } else {
+        0u16
+    };
+
+    CExprTypeInfo {
+        ty: CExprType::from(ty),
+        width,
+    }
+}
+
+/// @ingroup QkClassicalExpressions
+/// Return the name of a stretch.
+///
+/// @param stretch A pointer to the stretch to inspect.
+///
+/// @return A null-terminated string containing the stretch name. The caller owns
+/// the returned string and must free it with ``qk_str_free``.
+///
+/// # Example
+/// ```c
+/// char *name = qk_stretch_name(stretch);
+/// // Use the name...
+/// qk_str_free(name);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``stretch`` is not a valid, non-null pointer to a ``QkStretch``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_stretch_name(stretch: *const Stretch) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let stretch = unsafe { const_ptr_as_ref(stretch) };
+
+    CString::new(stretch.name.as_str())
+        .expect("Stretch should have a valid name")
+        .into_raw()
+}
+
+//////////////////////////////////////////////////////////////////
+// The functions below are used in the C testing, to generate   //
+// various objects for testing the C API. These functions       //
+// should be removed once we have the actual C API for creating //
+// classical expression constructs.                             //
+//////////////////////////////////////////////////////////////////
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_expression_structs() -> *mut Expr {
+    let v1 = Expr::Var(Var::Standalone {
+        uuid: Uuid::new_v4().as_u128(),
+        name: "v1".to_owned(),
+        ty: Type::Uint(3),
+    });
+
+    let five = Expr::Value(Value::Uint {
+        raw: BigUint::from(5u32),
+        ty: Type::Uint(3),
+    });
+
+    let gt = Expr::Binary(Box::new(Binary {
+        op: BinaryOp::Greater,
+        left: v1.clone(),
+        right: five,
+        ty: Type::Bool,
+        constant: false,
+    }));
+
+    let lt_eq = Expr::Unary(Box::new(Unary {
+        op: UnaryOp::LogicNot,
+        operand: gt,
+        ty: Type::Bool,
+        constant: false,
+    }));
+
+    let idx = Expr::Cast(Box::new(Cast {
+        operand: lt_eq,
+        ty: Type::Uint(1),
+        implicit: false,
+        constant: false,
+    }));
+
+    let index = Expr::Index(Box::new(Index {
+        target: v1,
+        index: idx,
+        ty: Type::Bool,
+        constant: false,
+    }));
+
+    Box::into_raw(Box::new(index))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_binary_expr_ops(op: CBinaryOpType) -> *mut Expr {
+    let zero = Expr::Value(Value::Float {
+        raw: 0.0,
+        ty: Type::Float,
+    });
+
+    let expr = Expr::Binary(Box::new(Binary {
+        op: op.to_binary_op(),
+        left: zero.clone(),
+        right: zero.clone(),
+        ty: Type::Float,
+        constant: true,
+    }));
+
+    Box::into_raw(Box::new(expr))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_unary_expr_ops(op: CUnaryOpType) -> *mut Expr {
+    let zero = Expr::Value(Value::Float {
+        raw: 0.0,
+        ty: Type::Float,
+    });
+
+    let expr = Expr::Unary(Box::new(Unary {
+        op: op.to_unary_op(),
+        operand: zero,
+        ty: Type::Float,
+        constant: true,
+    }));
+
+    Box::into_raw(Box::new(expr))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_expr_kinds_and_types(
+    kind: CExprNodeKind,
+    ty: CExprTypeInfo,
+) -> *mut Expr {
+    let rust_type = ty.to_type();
+
+    let dummy_value = match &rust_type {
+        Type::Bool => Expr::Value(Value::Uint {
+            raw: BigUint::from(0u32),
+            ty: Type::Bool,
+        }),
+        Type::Duration => Expr::Value(Value::Duration(Duration::dt(0))),
+        Type::Float => Expr::Value(Value::Float {
+            raw: 0.0,
+            ty: Type::Float,
+        }),
+        Type::Uint(w) => Expr::Value(Value::Uint {
+            raw: BigUint::from(0u32),
+            ty: Type::Uint(*w),
+        }),
+    };
+
+    let var = Expr::Var(Var::Standalone {
+        uuid: Uuid::new_v4().as_u128(),
+        name: "test_var".to_owned(),
+        ty: ty.to_type(),
+    });
+
+    let index = Expr::Value(Value::Uint {
+        raw: BigUint::from(0u32),
+        ty: Type::Uint(3),
+    });
+
+    let expr = match kind {
+        CExprNodeKind::Unary => Expr::Unary(Box::new(Unary {
+            op: UnaryOp::BitNot,
+            operand: dummy_value,
+            ty: rust_type,
+            constant: true,
+        })),
+        CExprNodeKind::Binary => Expr::Binary(Box::new(Binary {
+            op: BinaryOp::BitAnd,
+            left: dummy_value.clone(),
+            right: dummy_value,
+            ty: rust_type,
+            constant: true,
+        })),
+        CExprNodeKind::Cast => Expr::Cast(Box::new(Cast {
+            operand: dummy_value,
+            ty: rust_type,
+            implicit: false,
+            constant: true,
+        })),
+        CExprNodeKind::Index => Expr::Index(Box::new(Index {
+            target: var,
+            index,
+            ty: rust_type,
+            constant: false,
+        })),
+        CExprNodeKind::Value => dummy_value,
+        CExprNodeKind::Var => var,
+        CExprNodeKind::Stretch => Expr::Stretch(Stretch {
+            uuid: Uuid::new_v4().as_u128(),
+            name: "test_stretch".to_owned(),
+        }),
+    };
+
+    Box::into_raw(Box::new(expr))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_value(
+    ty: CExprType,
+    b: bool,
+    duration: CDurationInfo,
+    f_val: f64,
+    u_val: u64,
+) -> *mut Expr {
+    let value = match ty {
+        CExprType::Bool => Value::Uint {
+            raw: BigUint::from(if b { 1u32 } else { 0u32 }),
+            ty: Type::Bool,
+        },
+        CExprType::Duration => Value::Duration(duration.to_duration()),
+        CExprType::Float => Value::Float {
+            raw: f_val,
+            ty: Type::Float,
+        },
+        CExprType::Uint => Value::Uint {
+            raw: BigUint::from(u_val),
+            ty: Type::Uint(4),
+        },
+    };
+
+    Box::into_raw(Box::new(Expr::Value(value)))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_expr_free(expr: *mut Expr) {
+    drop(unsafe { Box::from_raw(expr) })
+}

--- a/crates/cext/src/lib.rs
+++ b/crates/cext/src/lib.rs
@@ -17,6 +17,7 @@ mod py;
 
 pub mod circuit;
 pub mod circuit_library;
+pub mod classical_expr;
 pub mod dag;
 pub mod exit_codes;
 pub mod param;

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -24,4 +24,5 @@
  * @defgroup QkTranspilerStageState QkTranspilerStageState
  * @defgroup QkVF2LayoutConfiguration QkVF2LayoutConfiguration
  * @defgroup QkVF2LayoutResult QkVF2LayoutResult
+ * @defgroup QkClassicalExpressions QkClassicalExpressions
  */

--- a/docs/cdoc/index.rst
+++ b/docs/cdoc/index.rst
@@ -32,6 +32,7 @@ Quantum Circuit
    qk-quantum-register
    qk-classical-register
    qk-param
+   qk-classical-expressions
 
 Circuit Library
 +++++++++++++++

--- a/docs/cdoc/qk-classical-expressions.rst
+++ b/docs/cdoc/qk-classical-expressions.rst
@@ -1,0 +1,55 @@
+=====================
+Classical Expressions
+=====================
+
+The Qiskit C API for classical expressions provides facilities for inspecting classical expressions used in Qiskit. This API enables users to
+traverse and examine expression trees through a set of enums, structs, and accessor functions. You can inspect the structure of expressions,
+identify node types, query type information and access detailed properties of each node in the expression tree. Currently, classical expressions can
+only be accessed through the control-flow API, for example when querying conditions that are comprised of classical expressions.
+
+Note that the functions in this API return borrowed pointers that remain valid as long as the parent expression tree exists,
+so these pointers do not need to be freed.
+
+Data Types
+==========
+
+.. doxygenenum:: QkExprNodeKind
+
+.. doxygenenum:: QkExprType
+
+.. doxygenstruct:: QkExprTypeInfo
+    :members:
+
+.. doxygenenum:: QkUnaryOpType
+
+.. doxygenstruct:: QkUnaryExprInfo
+    :members:
+
+.. doxygenenum:: QkBinaryOpType
+
+.. doxygenstruct:: QkBinaryExprInfo
+    :members:
+
+.. doxygenstruct:: QkCastExprInfo
+    :members:
+
+.. doxygenstruct:: QkIndexExprInfo
+    :members:
+
+.. doxygenenum:: QkDurationType
+
+.. doxygenunion:: QkDurationValue
+
+.. doxygenstruct:: QkDurationInfo
+    :members:
+
+
+Functions
+=========
+
+.. doxygengroup:: QkClassicalExpressions
+    :members:
+    :content-only:
+
+
+

--- a/releasenotes/notes/c-api-classical-exper-inspection-d7ddc3838b5397a0.yaml
+++ b/releasenotes/notes/c-api-classical-exper-inspection-d7ddc3838b5397a0.yaml
@@ -1,0 +1,28 @@
+---
+features_c:
+  - |
+    Added support for inspecting classical expressions in the C API. The new API enables users to 
+    traverse classical expression trees and extract information about node kinds, operands, 
+    underlying values, variable names, and more. To support this, new enums and structs have 
+    been introduced to represent expression node properties, along with corresponding accessor functions.
+    
+    The new functions are:
+    
+    * :c:func:`qk_expr_node_kind`
+    * :c:func:`qk_expr_binary_info`
+    * :c:func:`qk_expr_unary_info`
+    * :c:func:`qk_expr_cast_info`
+    * :c:func:`qk_expr_index_info`
+    * :c:func:`qk_expr_as_value`
+    * :c:func:`qk_expr_as_var`
+    * :c:func:`qk_expr_as_stretch`
+    * :c:func:`qk_value_type`
+    * :c:func:`qk_value_duration_info`
+    * :c:func:`qk_value_float`
+    * :c:func:`qk_value_uint`
+    * :c:func:`qk_value_bool`
+    * :c:func:`qk_var_name`
+    * :c:func:`qk_var_type_info`
+    * :c:func:`qk_stretch_name`
+    
+    Refer to the documentation of the functions for more details. 

--- a/releasenotes/notes/c-api-classical-exper-inspection-d7ddc3838b5397a0.yaml
+++ b/releasenotes/notes/c-api-classical-exper-inspection-d7ddc3838b5397a0.yaml
@@ -8,7 +8,7 @@ features_c:
     
     The new functions are:
     
-    * :c:func:`qk_expr_node_kind`
+    * :c:func:`qk_expr_kind`
     * :c:func:`qk_expr_binary_info`
     * :c:func:`qk_expr_unary_info`
     * :c:func:`qk_expr_cast_info`

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -25,7 +25,7 @@
 // These are used for generating classical expressions for testing. They are non-public C API
 // functions which should be removed once we have C API for generating classical expressions.
 QkExprNode *inner_test_expression_structs();
-QkExprNode *inner_test_unary_expr_ops(QkBinaryOpType);
+QkExprNode *inner_test_unary_expr_ops(QkUnaryOpType);
 QkExprNode *inner_test_binary_expr_ops(QkBinaryOpType);
 QkExprNode *inner_test_expr_kinds_and_types(QkExprNodeKind, QkExprTypeInfo);
 QkExprNode *inner_test_value(QkExprType, bool, QkDurationInfo, double, uint64_t);
@@ -52,7 +52,7 @@ static int test_expr_info_structs(void) {
 
     int result = Ok;
 
-    QkExprNodeKind kind = qk_expr_node_kind(expr);
+    QkExprNodeKind kind = qk_expr_kind(expr);
     if (kind != QkExprNodeKind_Index) {
         printf("Expected Index node, got %d\n", kind);
         result = EqualityError;
@@ -60,14 +60,14 @@ static int test_expr_info_structs(void) {
     }
 
     QkIndexExprInfo index_info = qk_expr_index_info(expr);
-    QkExprNodeKind target_kind = qk_expr_node_kind(index_info.target);
+    QkExprNodeKind target_kind = qk_expr_kind(index_info.target);
     if (target_kind != QkExprNodeKind_Var) {
         printf("Expected Var node for target, got %d\n", target_kind);
         result = EqualityError;
         goto cleanup;
     }
 
-    QkExprNodeKind index_kind = qk_expr_node_kind(index_info.index);
+    QkExprNodeKind index_kind = qk_expr_kind(index_info.index);
     if (index_kind != QkExprNodeKind_Cast) {
         printf("Expected Cast node for index, got %d\n", index_kind);
         result = EqualityError;
@@ -82,7 +82,7 @@ static int test_expr_info_structs(void) {
         goto cleanup;
     }
 
-    QkExprNodeKind cast_operand_kind = qk_expr_node_kind(cast_info.operand);
+    QkExprNodeKind cast_operand_kind = qk_expr_kind(cast_info.operand);
     if (cast_operand_kind != QkExprNodeKind_Unary) {
         printf("Expected Unary node for cast operand, got %d\n", cast_operand_kind);
         result = EqualityError;
@@ -96,7 +96,7 @@ static int test_expr_info_structs(void) {
         goto cleanup;
     }
 
-    QkExprNodeKind unary_operand_kind = qk_expr_node_kind(unary_info.operand);
+    QkExprNodeKind unary_operand_kind = qk_expr_kind(unary_info.operand);
     if (unary_operand_kind != QkExprNodeKind_Binary) {
         printf("Expected Binary node for unary operand, got %d\n", unary_operand_kind);
         result = EqualityError;
@@ -110,14 +110,14 @@ static int test_expr_info_structs(void) {
         goto cleanup;
     }
 
-    QkExprNodeKind left_kind = qk_expr_node_kind(binary_info.left);
+    QkExprNodeKind left_kind = qk_expr_kind(binary_info.left);
     if (left_kind != QkExprNodeKind_Var) {
         printf("Expected Var node for left operand, got %d\n", left_kind);
         result = EqualityError;
         goto cleanup;
     }
 
-    QkExprNodeKind right_kind = qk_expr_node_kind(binary_info.right);
+    QkExprNodeKind right_kind = qk_expr_kind(binary_info.right);
     if (right_kind != QkExprNodeKind_Value) {
         printf("Expected Value node for right operand, got %d\n", right_kind);
         result = EqualityError;
@@ -142,7 +142,7 @@ static int test_op_types_roundtrip(void) {
 
         expr = inner_test_unary_expr_ops(expected_op);
 
-        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        QkExprNodeKind kind = qk_expr_kind(expr);
         if (kind != QkExprNodeKind_Unary) {
             printf("Expected Unary expression node, got %d\n", kind);
             result = EqualityError;
@@ -164,7 +164,7 @@ static int test_op_types_roundtrip(void) {
 
         expr = inner_test_binary_expr_ops(expected_op);
 
-        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        QkExprNodeKind kind = qk_expr_kind(expr);
         if (kind != QkExprNodeKind_Binary) {
             printf("Expected Binary expression node, got %d\n", kind);
             result = EqualityError;
@@ -207,7 +207,7 @@ static int test_expr_kind_and_type(void) {
 
             expr = inner_test_expr_kinds_and_types(kind, type_info);
 
-            QkExprNodeKind result_kind = qk_expr_node_kind(expr);
+            QkExprNodeKind result_kind = qk_expr_kind(expr);
             if (result_kind != kind) {
                 printf("Kind mismatch: expected %d, got %d\n", kind, result_kind);
                 result = EqualityError;
@@ -279,7 +279,7 @@ static int test_expr_var(void) {
         QkExprTypeInfo type_info = {ty, ty == QkExprType_Uint ? 8 : 0};
 
         expr = inner_test_expr_kinds_and_types(QkExprNodeKind_Var, type_info);
-        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        QkExprNodeKind kind = qk_expr_kind(expr);
         if (kind != QkExprNodeKind_Var) {
             printf("Expected Var node, got %d\n", kind);
             result = EqualityError;
@@ -345,7 +345,7 @@ static int test_expr_stretch(void) {
 
         expr = inner_test_expr_kinds_and_types(QkExprNodeKind_Stretch, type_info);
 
-        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        QkExprNodeKind kind = qk_expr_kind(expr);
         if (kind != QkExprNodeKind_Stretch) {
             printf("Expected Stretch node, got %d\n", kind);
             result = EqualityError;
@@ -397,7 +397,7 @@ static int test_expr_value(void) {
     for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
         expr = inner_test_value((QkExprType)ty, true, duration_info, 3.14, 12345);
 
-        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        QkExprNodeKind kind = qk_expr_kind(expr);
         if (kind != QkExprNodeKind_Value) {
             printf("Expected Value node for Bool, got %d\n", kind);
             result = EqualityError;

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -29,6 +29,7 @@ QkExprNode *inner_test_unary_expr_ops(QkUnaryOpType);
 QkExprNode *inner_test_binary_expr_ops(QkBinaryOpType);
 QkExprNode *inner_test_expr_kinds_and_types(QkExprNodeKind, QkExprTypeInfo);
 QkExprNode *inner_test_value(QkExprType, bool, QkDurationInfo, double, uint64_t);
+void inned_test_old_style_vars(QkExprNode **);
 void *inner_expr_free(QkExprNode *);
 
 /*
@@ -325,6 +326,49 @@ static int test_expr_var(void) {
     }
 
     expr = NULL;
+
+    QkExprNode *var_nodes[2];
+    inned_test_old_style_vars(var_nodes);
+
+    // The first var is a Bit variable
+    const QkVar *var = qk_expr_as_var(var_nodes[0]);
+    QkExprTypeInfo var_type_info = qk_var_type_info(var);
+
+    if (var_type_info.ty != QkExprType_Bool) {
+        printf("Expected var type to be QkExprType_Bool, got %d\n", var_type_info.ty);
+        result = EqualityError;
+        goto cleanup_vars;
+    }
+
+    char *name = qk_var_name(var);
+    if (name != NULL) {
+        printf("Expected var name to be NULL, got %s\n", name);
+        qk_str_free(name);
+        result = EqualityError;
+        goto cleanup_vars;
+    }
+
+    // The second var is a Register variable
+    var = qk_expr_as_var(var_nodes[1]);
+    var_type_info = qk_var_type_info(var);
+
+    if (var_type_info.ty != QkExprType_Uint) {
+        printf("Expected var type to be QkExprType_Uint, got %d\n", var_type_info.ty);
+        result = EqualityError;
+        goto cleanup_vars;
+    }
+
+    name = qk_var_name(var);
+    if (name != NULL) {
+        printf("Expected var name to be NULL, got %s\n", name);
+        qk_str_free(name);
+        result = EqualityError;
+        goto cleanup_vars;
+    }
+
+cleanup_vars:
+    inner_expr_free(var_nodes[0]);
+    inner_expr_free(var_nodes[1]);
 
 cleanup:
     if (expr)

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -455,11 +455,11 @@ static int test_expr_value(void) {
             goto cleanup;
         }
 
-        QkExprType value_type = qk_value_type(value);
+        QkExprTypeInfo value_type_info = qk_value_type_info(value);
         switch (ty) {
         case QkExprType_Bool:
-            if (value_type != QkExprType_Bool) {
-                printf("Expected Bool type, got %d\n", value_type);
+            if (value_type_info.ty != QkExprType_Bool) {
+                printf("Expected Bool type, got %d\n", value_type_info.ty);
                 result = EqualityError;
                 goto cleanup;
             }
@@ -472,8 +472,8 @@ static int test_expr_value(void) {
             }
             break;
         case QkExprType_Duration:
-            if (value_type != QkExprType_Duration) {
-                printf("Expected Duration type, got %d\n", value_type);
+            if (value_type_info.ty != QkExprType_Duration) {
+                printf("Expected Duration type, got %d\n", value_type_info.ty);
                 result = EqualityError;
                 goto cleanup;
             }
@@ -492,8 +492,8 @@ static int test_expr_value(void) {
             }
             break;
         case QkExprType_Float:
-            if (value_type != QkExprType_Float) {
-                printf("Expected Float type, got %d\n", value_type);
+            if (value_type_info.ty != QkExprType_Float) {
+                printf("Expected Float type, got %d\n", value_type_info.ty);
                 result = EqualityError;
                 goto cleanup;
             }
@@ -506,8 +506,14 @@ static int test_expr_value(void) {
             }
             break;
         case QkExprType_Uint:
-            if (value_type != QkExprType_Uint) {
-                printf("Expected Uint type, got %d\n", value_type);
+            if (value_type_info.ty != QkExprType_Uint) {
+                printf("Expected Uint type, got %d\n", value_type_info.ty);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            if (value_type_info.width != 4) {
+                printf("Expected Uint width to be 4, got %" PRIu16 "\n", value_type_info.width);
                 result = EqualityError;
                 goto cleanup;
             }

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -1,0 +1,506 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include "common.h"
+#include <complex.h>
+#include <inttypes.h>
+#include <math.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// TODO: remove these forward declarations
+// These are used for generating classical expressions for testing. They are non-public C API
+// functions which should be removed once we have C API for generating classical expressions.
+QkExprNode *inner_test_expression_structs();
+QkExprNode *inner_test_unary_expr_ops(QkBinaryOpType);
+QkExprNode *inner_test_binary_expr_ops(QkBinaryOpType);
+QkExprNode *inner_test_expr_kinds_and_types(QkExprNodeKind, QkExprTypeInfo);
+QkExprNode *inner_test_value(QkExprType, bool, QkDurationInfo, double, uint64_t);
+void *inner_expr_free(QkExprNode *);
+
+/*
+ * Test that expression tree structure is captured correctly via the information structs
+ */
+static int test_expr_info_structs(void) {
+    // Build an expression with the following structure:
+    // Index(
+    //     'v1',
+    //     Cast(
+    //         Unary(LOGIC_NOT,
+    //             Binary(GREATER,
+    //                 'v1',
+    //                 Value(5)
+    //             )
+    //         )
+    //         Uint(1)
+    //     )
+    // )
+    QkExprNode *expr = inner_test_expression_structs();
+
+    int result = Ok;
+
+    QkExprNodeKind kind = qk_expr_node_kind(expr);
+    if (kind != QkExprNodeKind_Index) {
+        printf("Expected Index node, got %d\n", kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkIndexExprInfo index_info = qk_expr_index_info(expr);
+    QkExprNodeKind target_kind = qk_expr_node_kind(index_info.target);
+    if (target_kind != QkExprNodeKind_Var) {
+        printf("Expected Var node for target, got %d\n", target_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkExprNodeKind index_kind = qk_expr_node_kind(index_info.index);
+    if (index_kind != QkExprNodeKind_Cast) {
+        printf("Expected Cast node for index, got %d\n", index_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkCastExprInfo cast_info = qk_expr_cast_info(index_info.index);
+    if (cast_info.ty.ty != QkExprType_Uint || cast_info.ty.width != 1) {
+        printf("Expected Cast to Uint(1), got type %d width %d\n", cast_info.ty.ty,
+               cast_info.ty.width);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkExprNodeKind cast_operand_kind = qk_expr_node_kind(cast_info.operand);
+    if (cast_operand_kind != QkExprNodeKind_Unary) {
+        printf("Expected Unary node for cast operand, got %d\n", cast_operand_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkUnaryExprInfo unary_info = qk_expr_unary_info(cast_info.operand);
+    if (unary_info.op != QkUnaryOpType_LogicNot) {
+        printf("Expected LogicNot operation, got %d\n", unary_info.op);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkExprNodeKind unary_operand_kind = qk_expr_node_kind(unary_info.operand);
+    if (unary_operand_kind != QkExprNodeKind_Binary) {
+        printf("Expected Binary node for unary operand, got %d\n", unary_operand_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkBinaryExprInfo binary_info = qk_expr_binary_info(unary_info.operand);
+    if (binary_info.op != QkBinaryOpType_Greater) {
+        printf("Expected Greater operation, got %d\n", binary_info.op);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkExprNodeKind left_kind = qk_expr_node_kind(binary_info.left);
+    if (left_kind != QkExprNodeKind_Var) {
+        printf("Expected Var node for left operand, got %d\n", left_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkExprNodeKind right_kind = qk_expr_node_kind(binary_info.right);
+    if (right_kind != QkExprNodeKind_Value) {
+        printf("Expected Value node for right operand, got %d\n", right_kind);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+cleanup:
+    inner_expr_free(expr);
+
+    return result;
+}
+
+/*
+ * Test that unary and binary op types are assigned and retrieved correctly
+ */
+static int test_op_types_roundtrip(void) {
+    int result = Ok;
+    QkExprNode *expr = NULL;
+
+    for (int op = QkUnaryOpType_BitNot; op <= QkUnaryOpType_Negate; op++) {
+        QkUnaryOpType expected_op = (QkUnaryOpType)op;
+
+        expr = inner_test_unary_expr_ops(expected_op);
+
+        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        if (kind != QkExprNodeKind_Unary) {
+            printf("Expected Unary expression node, got %d\n", kind);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        QkUnaryExprInfo unary_info = qk_expr_unary_info(expr);
+        if (unary_info.op != expected_op) {
+            printf("Unary op type mismatch: expected %d, got %d\n", expected_op, unary_info.op);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        inner_expr_free(expr);
+    }
+
+    for (size_t op = QkBinaryOpType_BitAnd; op <= QkBinaryOpType_Div; op++) {
+        QkUnaryOpType expected_op = (QkUnaryOpType)op;
+
+        expr = inner_test_binary_expr_ops(expected_op);
+
+        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        if (kind != QkExprNodeKind_Binary) {
+            printf("Expected Binary expression node, got %d\n", kind);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        QkBinaryExprInfo binary_info = qk_expr_binary_info(expr);
+        if (binary_info.op != expected_op) {
+            printf("Op type mismatch: expected %d, got %d\n", expected_op, binary_info.op);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        inner_expr_free(expr);
+    }
+
+    expr = NULL;
+
+cleanup:
+    if (expr)
+        inner_expr_free(expr);
+
+    return result;
+}
+
+/*
+ * Test that kind and expr types round trip
+ */
+static int test_expr_kind_and_type(void) {
+    int result = Ok;
+    QkExprNodeKind kinds_to_check[] = {QkExprNodeKind_Unary, QkExprNodeKind_Binary,
+                                       QkExprNodeKind_Cast, QkExprNodeKind_Index};
+    QkExprNode *expr = NULL;
+
+    for (size_t kind_idx = 0; kind_idx < 4; kind_idx++) {
+        QkExprNodeKind kind = kinds_to_check[kind_idx];
+
+        for (size_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
+            QkExprTypeInfo type_info = {(QkExprType)ty, ty == QkExprType_Uint ? 8 : 0};
+
+            expr = inner_test_expr_kinds_and_types(kind, type_info);
+
+            QkExprNodeKind result_kind = qk_expr_node_kind(expr);
+            if (result_kind != kind) {
+                printf("Kind mismatch: expected %d, got %d\n", kind, result_kind);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            QkExprTypeInfo result_type;
+            switch (result_kind) {
+            case QkExprNodeKind_Unary: {
+                QkUnaryExprInfo info = qk_expr_unary_info(expr);
+                result_type = info.ty;
+                break;
+            }
+            case QkExprNodeKind_Binary: {
+                QkBinaryExprInfo info = qk_expr_binary_info(expr);
+                result_type = info.ty;
+                break;
+            }
+            case QkExprNodeKind_Cast: {
+                QkCastExprInfo info = qk_expr_cast_info(expr);
+                result_type = info.ty;
+                break;
+            }
+            case QkExprNodeKind_Index: {
+                QkIndexExprInfo info = qk_expr_index_info(expr);
+                result_type = info.ty;
+                break;
+            }
+            default:
+                printf("Unexpected kind for type checking: %d\n", result_kind);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            if (result_type.ty != type_info.ty) {
+                printf("Type mismatch: expected %d, got %d\n", type_info.ty, result_type.ty);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            if (type_info.ty == QkExprType_Uint && result_type.width != type_info.width) {
+                printf("Width mismatch for Uint: expected %d, got %d\n", type_info.width,
+                       result_type.width);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            inner_expr_free(expr);
+        }
+    }
+
+    expr = NULL;
+
+cleanup:
+    if (expr)
+        inner_expr_free(expr);
+
+    return result;
+}
+
+/*
+ * Test variable queries and property handling
+ */
+static int test_expr_var(void) {
+    int result = Ok;
+    QkExprNode *expr = NULL;
+
+    for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
+        QkExprTypeInfo type_info = {ty, ty == QkExprType_Uint ? 8 : 0};
+
+        expr = inner_test_expr_kinds_and_types(QkExprNodeKind_Var, type_info);
+        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        if (kind != QkExprNodeKind_Var) {
+            printf("Expected Var node, got %d\n", kind);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        const QkVar *var = qk_expr_as_var(expr);
+        if (var == NULL) {
+            printf("qk_expr_as_var returned NULL for Var expression\n");
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        char *name = qk_var_name(var);
+        if (name == NULL) {
+            printf("qk_var_name returned NULL\n");
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        if (strcmp(name, "test_var") != 0) {
+            printf("Expected var name 'test_var', got '%s'\n", name);
+            qk_str_free(name);
+            result = EqualityError;
+            goto cleanup;
+        }
+        qk_str_free(name);
+
+        QkExprTypeInfo var_type = qk_var_type_info(var);
+        if (var_type.ty != type_info.ty) {
+            printf("Var type mismatch: expected %d, got %d\n", type_info.ty, var_type.ty);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        if (type_info.ty == QkExprType_Uint && var_type.width != type_info.width) {
+            printf("Var width mismatch: expected %d, got %d\n", type_info.width, var_type.width);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        inner_expr_free(expr);
+    }
+
+    expr = NULL;
+
+cleanup:
+    if (expr)
+        inner_expr_free(expr);
+
+    return result;
+}
+
+/*
+ * Test stretch queries and property handling
+ */
+static int test_expr_stretch(void) {
+    int result = Ok;
+    QkExprNode *expr = NULL;
+
+    for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
+        QkExprTypeInfo type_info = {ty, ty == QkExprType_Uint ? 8 : 0};
+
+        expr = inner_test_expr_kinds_and_types(QkExprNodeKind_Stretch, type_info);
+
+        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        if (kind != QkExprNodeKind_Stretch) {
+            printf("Expected Stretch node, got %d\n", kind);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        const QkStretch *stretch = qk_expr_as_stretch(expr);
+        if (stretch == NULL) {
+            printf("qk_expr_as_stretch returned NULL for Stretch expression\n");
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        char *name = qk_stretch_name(stretch);
+        if (name == NULL) {
+            printf("qk_stretch_name returned NULL\n");
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        if (strcmp(name, "test_stretch") != 0) {
+            printf("Expected stretch name 'test_stretch', got '%s'\n", name);
+            qk_str_free(name);
+            result = EqualityError;
+            goto cleanup;
+        }
+        qk_str_free(name);
+
+        inner_expr_free(expr);
+    }
+
+    expr = NULL;
+
+cleanup:
+    if (expr)
+        inner_expr_free(expr);
+
+    return result;
+}
+
+/*
+ * Test operations with values
+ */
+static int test_expr_value(void) {
+    int result = Ok;
+    QkDurationInfo duration_info = {QkDurationType_Dt, {.dt = 12345}};
+    QkExprNode *expr = NULL;
+
+    for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
+        expr = inner_test_value((QkExprType)ty, true, duration_info, 3.14, 12345);
+
+        QkExprNodeKind kind = qk_expr_node_kind(expr);
+        if (kind != QkExprNodeKind_Value) {
+            printf("Expected Value node for Bool, got %d\n", kind);
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        const QkValue *value = qk_expr_as_value(expr);
+        if (value == NULL) {
+            printf("qk_expr_as_value returned NULL for Bool value\n");
+            result = EqualityError;
+            goto cleanup;
+        }
+
+        QkExprType value_type = qk_value_type(value);
+        switch (ty) {
+        case QkExprType_Bool:
+            if (value_type != QkExprType_Bool) {
+                printf("Expected Bool type, got %d\n", value_type);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            bool bool_val = qk_value_bool(value);
+            if (bool_val != true) {
+                printf("Expected true, got %d\n", bool_val);
+                result = EqualityError;
+                goto cleanup;
+            }
+            break;
+        case QkExprType_Duration:
+            if (value_type != QkExprType_Duration) {
+                printf("Expected Duration type, got %d\n", value_type);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            QkDurationInfo result_duration = qk_value_duration_info(value);
+            if (result_duration.ty != QkDurationType_Dt) {
+                printf("Expected Dt duration type, got %d\n", result_duration.ty);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            if (result_duration.value.dt != 12345) {
+                printf("Expected dt value 12345, got %" PRId64 "\n", result_duration.value.dt);
+                result = EqualityError;
+                goto cleanup;
+            }
+            break;
+        case QkExprType_Float:
+            if (value_type != QkExprType_Float) {
+                printf("Expected Float type, got %d\n", value_type);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            double float_val = qk_value_float(value);
+            if (float_val != 3.14) {
+                printf("Expected float value 3.14159, got %f\n", float_val);
+                result = EqualityError;
+                goto cleanup;
+            }
+            break;
+        case QkExprType_Uint:
+            if (value_type != QkExprType_Uint) {
+                printf("Expected Uint type, got %d\n", value_type);
+                result = EqualityError;
+                goto cleanup;
+            }
+
+            uint64_t uint_val = qk_value_uint(value);
+
+            if (uint_val != 12345) {
+                printf("Expected uint value 12345, got %" PRIu64 "\n", uint_val);
+                result = EqualityError;
+                goto cleanup;
+            }
+        }
+
+        inner_expr_free(expr);
+    }
+
+    expr = NULL;
+
+cleanup:
+    if (expr)
+        inner_expr_free(expr);
+
+    return result;
+}
+
+int test_classical_expr(void) {
+    int num_failed = 0;
+
+    num_failed += RUN_TEST(test_expr_info_structs);
+    num_failed += RUN_TEST(test_op_types_roundtrip);
+    num_failed += RUN_TEST(test_expr_kind_and_type);
+    num_failed += RUN_TEST(test_expr_var);
+    num_failed += RUN_TEST(test_expr_stretch);
+    num_failed += RUN_TEST(test_expr_value);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}


### PR DESCRIPTION
This PR adds functions for inspecting classical expressions in the C API. 

### Details
This PR part of the work on #15980. Its goal is to support full inspection of control flow operations, which might 
include conditions that rely on classical expressions. 

The properties of expression nodes are extracted using accessor functions, e.g. for querying the kind of 
an expression node and other information represented by new enums. In addition the PR adds dedicated structs 
for representing various properties of the different node kinds. For example, the information of a binary expression 
node is inspected using this struct: 
```rust
pub struct CBinaryExprInfo {
    /// The binary operator
    pub op: CBinaryOpType,
    /// Borrowed pointer to the left operand expression
    pub left: *const Expr,
    /// Borrowed pointer to the right operand expression
    pub right: *const Expr,
    /// Result type of the operation
    pub ty: CExprTypeInfo,
    /// Whether the expression is constant
    pub constant: bool,
}
``` 

In its current form, the C API for inspecting classical expressions only provides borrowed pointers access to expression nodes. So the user should not 
(and currently could not, since there is no `qk_expr_free` function) free `QkExprNode` objects while traversing a given expression. Consequently, 
the API assumes that any expression being traversed remains alive and unchanged for the duration its nodes are being accessed.

For testing the API in C (in `test_classical_expr.c`), this PR also adds inner helper functions in Rust to generate various test expressions used in the C tests. These functions will be replaced by proper C API for creating classical expressions, once we have it (there is a WIP PR for next release #16180).

~~This PR is based on #16176 and will be rebased once it's merged.~~

### AI/LLM disclosure

- [x] I used the following tool to generate or modify code:
Bob 1.0.2 was used to generate initial versions of the C tests and documentation. 

### Tasks
- [x] Add functions to the v tables
- [x] Add C tests
~~- [ ] Add Rust tests~~ Rust test will be added to the PR for creating (and freeing) control flow expression objects. 
- [x] Add documentation and reno

