### PR TITLE
Add C API for creating classical expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,9 @@ dependencies = [
  "mimalloc",
  "nalgebra 0.34.2",
  "ndarray",
+ "num-bigint",
  "num-complex",
+ "num-traits",
  "pyo3",
  "qiskit-circuit",
  "qiskit-circuit-library",
@@ -2299,6 +2301,7 @@ dependencies = [
  "rand_pcg 0.10.2",
  "smallvec",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -98,7 +98,23 @@ pub static EXPORT_RENAME: &[(&str, &str)] = &[
     ("DAGCircuit", "Dag"),
     ("SparseObservable", "Obs"),
     ("StandardGate", "Gate"),
+    // Classical expression types
+    ("Expr", "ExprNode"),
+    ("CExprNodeKind", "ExprNodeKind"),
+    ("CBinaryExprInfo", "BinaryExprInfo"),
+    ("CBinaryExprOp", "BinaryExprOp"),
+    ("CUnaryExprInfo", "UnaryExprInfo"),
+    ("CUnaryOp", "UnaryOp"),
+    ("CCastExprInfo", "CastExprInfo"),
+    ("CIndexExprInfo", "IndexExprInfo"),
+    ("CExprType", "ExprType"),
+    ("CExprTypeInfo", "ExprTypeInfo"),
+    ("CDurationType", "DurationType"),
+    ("CDurationInfo", "DurationInfo"),
+    ("CDurationValue", "DurationValue"),
+    ("CValueType", "ValueType"),
 ];
+
 pub static EXPORT_VERBATIM: &[&str] = &["PyObject"];
 
 // Defined in `qiskit/attributes.h`.
@@ -179,6 +195,7 @@ fn get_config() -> anyhow::Result<cbindgen::Config> {
         prefix: Some(EXPORT_PREFIX.into()),
         rename,
         renaming_overrides_prefixing: true,
+        exclude: vec!["inner_build_test_expression".to_string()],
         ..Default::default()
     };
     let function = cbindgen::FunctionConfig {

--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -195,7 +195,6 @@ fn get_config() -> anyhow::Result<cbindgen::Config> {
         prefix: Some(EXPORT_PREFIX.into()),
         rename,
         renaming_overrides_prefixing: true,
-        exclude: vec!["inner_build_test_expression".to_string()],
         ..Default::default()
     };
     let function = cbindgen::FunctionConfig {

--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -71,7 +71,7 @@ impl Primitive {
             Self::I8 => "ctypes.c_int8",
             Self::U8 => "ctypes.c_uint8",
             Self::I16 => "ctypes.c_int16",
-            Self::U16 => "ctypes.c_uin16",
+            Self::U16 => "ctypes.c_uint16",
             Self::I32 => "ctypes.c_int32",
             Self::U32 => "ctypes.c_uint32",
             Self::I64 => "ctypes.c_int64",
@@ -248,6 +248,26 @@ mod parse {
         })
     }
 
+    pub fn r#union(
+        val: &ir::Union,
+        mut override_fn: impl FnMut(&str) -> Option<Primitive>,
+    ) -> anyhow::Result<simple_ir::Union<Primitive>> {
+        let fields = val
+            .fields
+            .iter()
+            .map(|field| -> anyhow::Result<_> {
+                Ok(simple_ir::StructField {
+                    name: field.name.clone(),
+                    ty: r#type(&field.ty, &mut override_fn)?,
+                })
+            })
+            .collect::<anyhow::Result<_>>()?;
+        Ok(simple_ir::Union {
+            name: val.export_name.clone(),
+            fields,
+        })
+    }
+
     /// Extract all objects from a set of `cbindgen::Bindings`, adding them to ourselves.
     ///
     /// This fails if the bindings contain any unsupported constructs.
@@ -276,9 +296,11 @@ mod parse {
                 ir::ItemContainer::Struct(item) => items
                     .structs
                     .push(r#struct(item, |path| overrides.get(path).copied())?),
+                ir::ItemContainer::Union(item) => items
+                    .unions
+                    .push(r#union(item, |path| overrides.get(path).copied())?),
                 ir::ItemContainer::Constant(_)
                 | ir::ItemContainer::Static(_)
-                | ir::ItemContainer::Union(_)
                 | ir::ItemContainer::Typedef(_) => {
                     bail!("unhandled item: {item:?}");
                 }
@@ -384,6 +406,22 @@ mod export {
         out
     }
 
+    /// Get a string representing the declaration of this `union`` as a Python `ctypes.Union`.
+    pub fn r#union(val: &simple_ir::Union<Primitive>) -> String {
+        let mut out = format!("\nclass {}(ctypes.Union):\n", &val.name);
+        out.push_str("    _fields_ = [\n");
+
+        for simple_ir::StructField { name, ty } in &val.fields {
+            out.push_str("        (\"");
+            out.push_str(name);
+            out.push_str("\", ");
+            render_type(ty, &mut out);
+            out.push_str("),\n");
+        }
+        out.push_str("    ]");
+        out
+    }
+
     /// Export this complete set of objects, subject to the given configuration.
     ///
     /// This includes an `__all__`, a suitable set of `import` statements, a `PyDLL`, and then all
@@ -431,6 +469,9 @@ mod export {
         writeln!(out)?;
         for item in &items.enums {
             writeln!(out, "{}", r#enum(item))?;
+        }
+        for item in &items.unions {
+            writeln!(out, "{}", r#union(item))?;
         }
         for item in &items.structs {
             writeln!(out, "{}", r#struct(item))?;
@@ -480,6 +521,7 @@ impl Items {
             enums: vec![],
             structs: vec![complex],
             functions: vec![],
+            unions: vec![],
         }
     }
 

--- a/crates/bindgen/src/simple_ir.rs
+++ b/crates/bindgen/src/simple_ir.rs
@@ -165,9 +165,19 @@ pub struct Function<T> {
     pub ret: Option<Type<T>>,
 }
 
+/// A union to declare. Unions cannot be opaque.
+#[derive(Clone, Debug)]
+pub struct Union<T> {
+    /// The export name of the union.
+    pub name: String,
+    /// The fields.
+    pub fields: Vec<StructField<T>>,
+}
+
 #[derive(Clone, Debug)]
 pub struct Items<T> {
     pub enums: Vec<Enum>,
     pub structs: Vec<Struct<T>>,
     pub functions: Vec<Function<T>>,
+    pub unions: Vec<Union<T>>,
 }

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -31,6 +31,9 @@ rand.workspace = true
 rand_pcg.workspace = true
 anyhow.workspace = true
 mimalloc = { workspace = true, optional = true}
+uuid.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
 
 [features]
 python_binding = ["dep:pyo3"]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -204,6 +204,43 @@ pub unsafe extern "C" fn qk_classical_register_new(
     Box::into_raw(Box::new(reg))
 }
 
+// Returns the owning register given a circuit qubit index
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_classical_register_from_bit(
+    circuit: *const CircuitData,
+    clbit: usize,
+) -> *const ClassicalRegister {
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    let shareable_clbit = circuit
+        .clbits()
+        .get(Clbit::new(clbit))
+        .expect("TODO");
+
+    let Some(bit_locations) = circuit.clbit_indices().get(shareable_clbit) else {
+        panic!("TODO")
+    };
+
+    let creg = bit_locations.registers().first().expect("TODO");
+    &creg.0 as *const ClassicalRegister
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_name(creg: *const ClassicalRegister) -> *mut c_char {
+    let creg = unsafe { const_ptr_as_ref(creg) };
+
+    CString::new(creg.name())
+        .expect("TODO")
+        .into_raw()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRegister) -> usize {
+    let creg = unsafe { const_ptr_as_ref(creg) };
+
+    creg.len()
+}
+
 /// @ingroup QkCircuit
 /// Add a quantum register to a given quantum circuit
 ///

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -1,0 +1,537 @@
+use std::{ptr, str::FromStr};
+
+use qiskit_circuit::{classical::{expr::{Binary, BinaryOp, Expr, Stretch, UnaryOp, Value, Var}, types::Type}, duration::Duration};
+use uuid::Uuid;
+use crate::pointers::const_ptr_as_ref;
+use num_bigint::BigUint;
+use std::ffi::{c_char, CString};
+use num_traits::ToPrimitive;
+
+#[repr(u8)]
+pub enum CExprNodeKind { 
+    Unary = 0, 
+    Binary = 1,
+    Cast = 2,
+    Value = 3,
+    Var = 4, 
+    Stretch = 5, 
+    Index = 6,
+}
+
+impl From<&Expr> for CExprNodeKind {
+    fn from(value: &Expr) -> Self {
+        match value {
+            Expr::Unary(_) => Self::Unary, 
+            Expr::Binary(_) => Self::Binary, 
+            Expr::Cast(_) => Self::Cast,
+            Expr::Index(_) => Self::Index,
+            Expr::Stretch(_) => Self::Stretch, 
+            Expr::Value(_) => Self::Value,
+            Expr::Var(_) => Self::Var,
+        }
+    }
+}
+
+#[repr(u8)]
+pub enum CExprType {
+    Bool = 0,
+    Duration = 1,
+    Float = 2,
+    Uint = 3,
+}
+
+impl From<&Type> for CExprType {
+    fn from(value: &Type) -> Self {
+        match value {
+            Type::Bool => Self::Bool,
+            Type::Duration => Self::Duration,
+            Type::Float => Self::Float,
+            Type::Uint(_) => Self::Uint,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CExprTypeInfo {
+    ty: CExprType,
+    width: u16,
+}
+
+impl CExprTypeInfo {
+    fn to_type(&self) -> Type {
+        match self.ty {
+            CExprType::Bool => Type::Bool,
+            CExprType::Duration => Type::Duration,
+            CExprType::Float => Type::Float,
+            CExprType::Uint => Type::Uint(self.width),
+        }
+    }
+}
+
+impl From<&Type> for CExprTypeInfo {
+    fn from(ty: &Type) -> Self {
+        match ty {
+            Type::Bool => CExprTypeInfo{ty: CExprType::Bool, width: 0},
+            Type::Duration => CExprTypeInfo{ty: CExprType::Duration, width: 0},
+            Type::Float => CExprTypeInfo{ty: CExprType::Float, width: 0},
+            Type::Uint(w) => CExprTypeInfo{ty: CExprType::Uint, width: *w},
+        }
+    }
+}
+
+
+#[repr(u8)]
+pub enum CUnaryOpType {
+    BitNot = 1, // TODO: keeping it one-based on purpose, to avoid confusion with the convention in Python
+    LogicNot = 2,
+    Negate = 3,
+}
+
+impl From<UnaryOp> for CUnaryOpType {
+    fn from(value: UnaryOp) -> Self {
+        match value { 
+        UnaryOp::BitNot => Self::BitNot,
+        UnaryOp::LogicNot => Self::LogicNot,
+        UnaryOp::Negate => Self::Negate,
+        }
+    }
+}
+
+impl CUnaryOpType {
+    fn to_unary_op(self) -> UnaryOp {
+        match self {
+            CUnaryOpType::BitNot => UnaryOp::BitNot,
+            CUnaryOpType::LogicNot => UnaryOp::LogicNot,
+            CUnaryOpType::Negate => UnaryOp::Negate,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CUnaryExprInfo {
+    pub op: CUnaryOpType,
+    pub operand: *const Expr,
+    pub ty: CExprTypeInfo,
+    pub constant: bool,
+}
+
+#[repr(u8)]
+pub enum CBinaryOpType {
+    BitAnd = 1, // TODO: keeping it one-based on purpose, to avoid confusion with the convention in Python
+    BitOr = 2,
+    BitXor = 3,
+    LogicAnd = 4,
+    LogicOr = 5,
+    Equal = 6,
+    NotEqual = 7,
+    Less = 8,
+    LessEqual = 9,
+    Greater = 10,
+    GreaterEqual = 11,
+    ShiftLeft = 12,
+    ShiftRight = 13,
+    Add = 14,
+    Sub = 15,
+    Mul = 16,
+    Div = 17,
+}
+
+impl From<BinaryOp> for CBinaryOpType {
+    fn from(value: BinaryOp) -> Self {
+        match value {
+            BinaryOp::BitAnd => Self::BitAnd,
+            BinaryOp::BitOr => Self::BitOr,
+            BinaryOp::BitXor => Self::BitXor,
+            BinaryOp::LogicAnd => Self::LogicAnd,
+            BinaryOp::LogicOr => Self::LogicOr,
+            BinaryOp::Equal => Self::Equal,
+            BinaryOp::NotEqual => Self::NotEqual,
+            BinaryOp::Less => Self::Less,
+            BinaryOp::LessEqual => Self::LessEqual,
+            BinaryOp::Greater => Self::Greater,
+            BinaryOp::GreaterEqual => Self::GreaterEqual,
+            BinaryOp::ShiftLeft => Self::ShiftLeft,
+            BinaryOp::ShiftRight => Self::ShiftRight,
+            BinaryOp::Add => Self::Add,
+            BinaryOp::Sub => Self::Sub,
+            BinaryOp::Mul => Self::Mul,
+            BinaryOp::Div => Self::Div,
+        }
+    }
+}
+
+impl CBinaryOpType {
+    fn to_binary_op(self) -> BinaryOp {
+        match self {
+            CBinaryOpType::BitAnd => BinaryOp::BitAnd,
+            CBinaryOpType::BitOr => BinaryOp::BitOr,
+            CBinaryOpType::BitXor => BinaryOp::BitXor,
+            CBinaryOpType::LogicAnd => BinaryOp::LogicAnd,
+            CBinaryOpType::LogicOr => BinaryOp::LogicOr,
+            CBinaryOpType::Equal => BinaryOp::Equal,
+            CBinaryOpType::NotEqual => BinaryOp::NotEqual,
+            CBinaryOpType::Less => BinaryOp::Less,
+            CBinaryOpType::LessEqual => BinaryOp::LessEqual,
+            CBinaryOpType::Greater => BinaryOp::Greater,
+            CBinaryOpType::GreaterEqual => BinaryOp::GreaterEqual,
+            CBinaryOpType::ShiftLeft => BinaryOp::ShiftLeft,
+            CBinaryOpType::ShiftRight => BinaryOp::ShiftRight,
+            CBinaryOpType::Add => BinaryOp::Add,
+            CBinaryOpType::Sub => BinaryOp::Sub,
+            CBinaryOpType::Mul => BinaryOp::Mul,
+            CBinaryOpType::Div => BinaryOp::Div,
+        }
+    }
+}
+
+
+
+#[repr(C)]
+pub struct CBinaryExprInfo {
+    pub op: CBinaryOpType,
+    pub left: *const Expr,
+    pub right: *const Expr,
+    pub ty: CExprTypeInfo,
+    pub constant: bool,
+}
+
+#[repr(C)]
+pub struct CCastExprInfo {
+    pub operand: *const Expr,
+    pub ty: CExprTypeInfo,
+    pub implicit: bool,
+    pub constant: bool,
+}
+
+#[repr(u8)]
+pub enum CValueType {
+    Duration = 0,
+    Float = 1, 
+    Uint = 2, 
+}
+
+impl From<&Value> for CValueType {
+    fn from(value: &Value) -> Self {
+        match value {
+            Value::Duration(_) => Self::Duration,
+            Value::Float{..} => Self::Float,
+            Value::Uint{..} => Self::Uint,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CIndexExprInfo {
+    pub target: *const Expr,
+    pub index: *const Expr,
+    pub ty: CExprTypeInfo,
+    pub constant: bool,
+}
+
+#[repr(u8)]
+pub enum CDurationType {
+    Dt = 0,
+    Ps = 1,
+    Ns = 2,
+    Us = 3,
+    Ms = 4,
+    S = 5, 
+}
+impl From<&Duration> for CDurationType {
+    fn from(duration: &Duration) -> Self {
+        match duration {
+            Duration::dt(_) => Self::Dt,
+            Duration::ps(_) => Self::Ps,
+            Duration::ns(_) => Self::Ns,
+            Duration::us(_) => Self::Us,
+            Duration::ms(_) => Self::Ms,
+            Duration::s(_) => Self::S,
+        }
+    }
+}
+
+#[repr(C)]
+pub union CDurationValue {
+    dt: i64,
+    time: f64,
+}
+
+#[repr(C)]
+pub struct CDurationInfo {
+    pub ty: CDurationType,
+    pub value: CDurationValue,
+}
+
+impl From<&Duration> for CDurationInfo {
+    fn from(duration: &Duration) -> Self {
+        match duration {
+            Duration::dt(v) => CDurationInfo {
+                ty: CDurationType::Dt,
+                value: CDurationValue{dt: *v},
+            },
+            Duration::ps(v) => CDurationInfo {
+                ty: CDurationType::Ps,
+                value: CDurationValue{time: *v},
+            },
+            Duration::ns(v) => CDurationInfo {
+                ty: CDurationType::Ns,
+                value: CDurationValue{time: *v},
+            },
+            Duration::us(v) => CDurationInfo {
+                ty: CDurationType::Us,
+                value: CDurationValue{time: *v},
+            },
+            Duration::ms(v) => CDurationInfo {
+                ty: CDurationType::Ms,
+                value: CDurationValue{time: *v},
+            },
+            Duration::s(v) => CDurationInfo {
+                ty: CDurationType::S,
+                value: CDurationValue{time: *v},
+            },
+        }
+    }
+}
+
+impl CDurationInfo {
+    pub fn to_duration(&self) -> Duration {
+        match self.ty {
+            CDurationType::Dt => Duration::dt(unsafe{self.value.dt}),
+            CDurationType::Ps => Duration::ps(unsafe{self.value.time}),
+            CDurationType::Ns => Duration::ns(unsafe{self.value.time}),
+            CDurationType::Us => Duration::us(unsafe{self.value.time}),
+            CDurationType::Ms => Duration::ms(unsafe{self.value.time}),
+            CDurationType::S => Duration::s(unsafe{self.value.time}),
+        }
+    }
+}
+
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_node_kind(expr: *const Expr) -> CExprNodeKind {
+    let expr = unsafe{ const_ptr_as_ref(expr) };
+
+    CExprNodeKind::from(expr)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_binary_info(expr: *const Expr) -> CBinaryExprInfo {
+    let expr = unsafe{ const_ptr_as_ref(expr) };
+
+    let Expr::Binary(binary) = expr else {
+        panic!("TODO")
+    };
+
+    CBinaryExprInfo {
+        op: CBinaryOpType::from(binary.op),
+        left: &binary.left as *const Expr,
+        right: &binary.right as *const Expr,
+        ty: CExprTypeInfo::from(&binary.ty),
+        constant: binary.constant,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_unary_info(expr: *const Expr) -> CUnaryExprInfo {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Unary(unary) = expr else {
+        panic!("TODO")
+    };
+
+    CUnaryExprInfo {
+        op: CUnaryOpType::from(unary.op),
+        operand: &unary.operand as *const Expr,
+        ty: CExprTypeInfo::from(&unary.ty),
+        constant: unary.constant,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_cast_info(expr: *const Expr) -> CCastExprInfo {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Cast(cast) = expr else {
+        panic!("TODO")
+    };
+
+    CCastExprInfo {
+        operand: &cast.operand as *const Expr,
+        ty: CExprTypeInfo::from(&cast.ty),
+        implicit: cast.implicit,
+        constant: cast.constant,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_index_info(expr: *const Expr) -> CIndexExprInfo {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Index(index) = expr else {
+        panic!("TODO")
+    };
+
+    CIndexExprInfo {
+        target: &index.target as *const Expr,
+        index: &index.index as *const Expr,
+        ty: CExprTypeInfo::from(&index.ty),
+        constant: index.constant,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_value(expr: *const Expr) -> *const Value {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Value(val) = expr else {
+        panic!("TODO")
+    };
+
+    val as *const Value
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_var(expr: *const Expr) -> *const Var {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Var(var) = expr else {
+        panic!("TODO")
+    };
+
+    ptr::from_ref(var)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_as_stretch(expr: *const Expr) -> *const Stretch {
+    let expr = unsafe { const_ptr_as_ref(expr) };
+
+    let Expr::Stretch(stretch) = expr else {
+        panic!("TODO")
+    };
+
+    ptr::from_ref(stretch)
+}
+
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_type(value: *const Value) -> CValueType { 
+    let value = unsafe { const_ptr_as_ref(value) };
+    
+    CValueType::from(value)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_duration_info(value: *const Value) -> CDurationInfo {
+    let value = unsafe { const_ptr_as_ref(value) };
+    
+    let Value::Duration(duration) = value else {
+        panic!("TODO")
+    };
+    
+    CDurationInfo::from(duration)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_float(value: *const Value) -> f64{
+    let value = unsafe { const_ptr_as_ref(value) };
+    
+    let Value::Float{raw, ..} = value else { // TODO: what should we do with ty?
+        panic!("TODO")
+    };
+
+    *raw
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_uint(value: *const Value) -> u64 {
+    let value = unsafe { const_ptr_as_ref(value) };
+    
+    let Value::Uint { raw, .. } = value else { // TODO: what should we do with ty?
+        panic!("TODO")
+    };
+
+    raw.to_u64()
+        .expect("TODO") // TODO: handle BitUint. Is there a better way?
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_name(var: *const Var) -> *mut c_char {
+    let var = unsafe { const_ptr_as_ref(var) };
+
+    let name = match var {
+        Var::Standalone { name, .. } => name.as_str(),
+        Var::Register { register, .. } => register.name(),
+        Var::Bit { .. } => return ptr::null_mut(),
+    };
+
+    CString::new(name)
+        .map_or(std::ptr::null_mut(), |name| name.into_raw()) // TODO: panic if name can't be constructed?
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_type_info(var: *const Var) -> CExprTypeInfo {
+    let var = unsafe { const_ptr_as_ref(var) };
+
+    let ty = match var {
+        Var::Standalone { ty, .. } => ty,
+        Var::Register { ty, ..} => ty,
+        Var::Bit { .. } => panic!("TODO"),
+    };
+
+    let width = if let Type::Uint(width) = ty {*width} else {0u16};
+
+    CExprTypeInfo{ty: CExprType::from(ty), width: width}
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_as_expr(var: *const Var) -> *mut Expr {
+    let var = unsafe{ const_ptr_as_ref(var) };
+
+    Box::into_raw(Box::new(Expr::Var(var.clone())))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_stretch_name(stretch: *const Stretch) -> *mut c_char {
+    let stretch = unsafe { const_ptr_as_ref(stretch) };
+    
+    CString::new(stretch.name.as_str())
+        .map_or(std::ptr::null_mut(), |name| name.into_raw()) // TODO: panic if name can't be constructed?
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_stretch_as_expr(stretch: *const Stretch) -> *mut Expr {
+    let stretch = unsafe { const_ptr_as_ref(stretch) };
+
+    Box::into_raw(Box::new(Expr::Stretch(stretch.clone())))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_build_test_expression() -> *mut Expr {
+    let var = Expr::Var(Var::Standalone {
+                    uuid: Uuid::new_v4().as_u128(),
+                    name: "a".to_owned(),
+                    ty: Type::Uint(8),
+                });
+
+    let three = Expr::Value(Value::Uint { raw: BigUint::from_str("3").unwrap(), ty: Type::Uint(8) });
+    
+    let add = Expr::Binary(Box::new(Binary {
+        op: BinaryOp::Add,
+        left: var,
+        right: three,
+        ty: Type::Uint(8),
+        constant: false,
+    }));
+    
+    let five = Expr::Value(Value::Uint { raw: BigUint::from_str("5").unwrap(), ty: Type::Uint(8) });
+
+    let lt = Expr::Binary(Box::new(Binary {
+        op: BinaryOp::LessEqual,
+        left: add,
+        right: five,
+        ty: Type::Uint(8),
+        constant: false,
+    }));
+
+    Box::into_raw(Box::new(lt))
+}

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -1,8 +1,8 @@
-use std::{ptr, str::FromStr};
+use std::{ffi::CStr, ptr, str::FromStr};
 
-use qiskit_circuit::{classical::{expr::{Binary, BinaryOp, Expr, Stretch, UnaryOp, Value, Var}, types::Type}, duration::Duration};
+use qiskit_circuit::{classical::{expr::{Binary, BinaryOp, Cast, Expr, Stretch, Unary, Index, UnaryOp, Value, Var}, types::Type}, duration::Duration};
 use uuid::Uuid;
-use crate::pointers::const_ptr_as_ref;
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use num_bigint::BigUint;
 use std::ffi::{c_char, CString};
 use num_traits::ToPrimitive;
@@ -506,32 +506,143 @@ pub unsafe extern "C" fn qk_stretch_as_expr(stretch: *const Stretch) -> *mut Exp
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn inner_build_test_expression() -> *mut Expr {
-    let var = Expr::Var(Var::Standalone {
-                    uuid: Uuid::new_v4().as_u128(),
-                    name: "a".to_owned(),
-                    ty: Type::Uint(8),
-                });
+pub unsafe extern "C" fn qk_var_new(name: *const c_char, type_info: *const CExprTypeInfo) -> *mut Var {
+    let name = unsafe {
+        CStr::from_ptr(name)
+            .to_str()
+            .expect("Invalid UTF-8 character")
+            .to_string()
+    };
 
-    let three = Expr::Value(Value::Uint { raw: BigUint::from_str("3").unwrap(), ty: Type::Uint(8) });
-    
-    let add = Expr::Binary(Box::new(Binary {
-        op: BinaryOp::Add,
-        left: var,
-        right: three,
-        ty: Type::Uint(8),
-        constant: false,
-    }));
-    
-    let five = Expr::Value(Value::Uint { raw: BigUint::from_str("5").unwrap(), ty: Type::Uint(8) });
+    let type_info = unsafe {const_ptr_as_ref(type_info)} ;
 
-    let lt = Expr::Binary(Box::new(Binary {
-        op: BinaryOp::LessEqual,
-        left: add,
-        right: five,
-        ty: Type::Uint(8),
-        constant: false,
-    }));
-
-    Box::into_raw(Box::new(lt))
+    let var = Var::Standalone { uuid: Uuid::new_v4().as_u128(), name, ty: type_info.to_type() };
+    Box::into_raw(Box::new(var))
 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_var_free(var: *mut Var) {
+    let var = unsafe { mut_ptr_as_ref(var) };
+
+    drop( unsafe{ Box::from_raw(var) } );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_stretch_new(name: *const c_char) -> *mut Stretch {
+    let name = unsafe {
+        CStr::from_ptr(name)
+            .to_str()
+            .expect("Invalid UTF-8 character")
+            .to_string()
+    };
+
+    let stretch = Stretch {
+        uuid: Uuid::new_v4().as_u128(),
+        name,
+    };
+    
+    Box::into_raw(Box::new(stretch))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_stretch_free(stretch: *mut Stretch) {
+    drop(unsafe { Box::from_raw(stretch) });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_new_duration(duration: *const CDurationInfo) -> *mut Value {
+    let duration = unsafe { const_ptr_as_ref(duration) };
+
+    Box::into_raw(Box::new(Value::Duration(duration.to_duration())))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_new_float(val: f64) -> *mut Value {
+    Box::into_raw(Box::new(Value::Float { raw: val, ty: Type::Float }))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_new_uint(val: u64, width: u16) -> *mut Value {
+    Box::into_raw(Box::new(Value::Uint { raw: BigUint::from(val), ty: Type::Uint(width) }))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_free(value: *mut Value) {
+    drop( unsafe{Box::from_raw(value) } );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_as_expr(value: *const Value) -> *mut Expr {
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    Box::into_raw(Box::new(Expr::Value(value.clone())))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_binary_new(op: CBinaryOpType, left: *const Expr, right: *const Expr, type_info: *const CExprTypeInfo) -> *mut Expr {
+    let left = unsafe { const_ptr_as_ref(left) };
+    let right = unsafe { const_ptr_as_ref(right) };
+    let type_info = unsafe { const_ptr_as_ref(type_info) };
+
+    let binary = Binary{
+        op: op.to_binary_op(),
+        left: left.clone(),
+        right: right.clone(),
+        ty: type_info.to_type(),
+        constant: left.is_const() && right.is_const(),    
+        };
+
+    Box::into_raw(Box::new(Expr::Binary(Box::new(binary))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_unary_new(op: CUnaryOpType, operand: *const Expr, type_info: *const CExprTypeInfo,) -> *mut Expr {
+    let operand = unsafe { const_ptr_as_ref(operand) };
+    let type_info = unsafe { const_ptr_as_ref(type_info) };
+
+    let unary = Unary {
+        op: op.to_unary_op(),
+        operand: operand.clone(),
+        ty: type_info.to_type(),
+        constant: operand.is_const(),
+    };
+
+    Box::into_raw(Box::new(Expr::Unary(Box::new(unary))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_cast_new(operand: *const Expr, type_info: *const CExprTypeInfo) -> *mut Expr { 
+    let operand = unsafe { const_ptr_as_ref(operand) };
+    let type_info = unsafe { const_ptr_as_ref(type_info) };
+
+    let cast = Cast {
+        operand: operand.clone(),
+        ty: type_info.to_type(),
+        constant: operand.is_const(),
+        implicit: false, // TODO: should this be exposed? or should we add qk_expr_cast_implicit_new?
+    };
+
+    Box::into_raw(Box::new(Expr::Cast(Box::new(cast))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_index_new(target: *const Expr, index: *const Expr, type_info: *const CExprTypeInfo) -> *mut Expr { 
+    let target = unsafe { const_ptr_as_ref(target) };
+    let index = unsafe { const_ptr_as_ref(index) };
+    let type_info = unsafe { const_ptr_as_ref(type_info) };
+
+    let index_obj = Index {
+        target: target.clone(),
+        index: index.clone(),
+        ty: type_info.to_type(),
+        constant: target.is_const() && index.is_const(),
+    };
+
+    Box::into_raw(Box::new(Expr::Index(Box::new(index_obj))))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_expr_free(expr: *mut Expr) {
+    drop( unsafe{Box::from_raw(expr)});
+}
+

--- a/crates/cext/src/lib.rs
+++ b/crates/cext/src/lib.rs
@@ -22,6 +22,7 @@ pub mod exit_codes;
 pub mod param;
 pub mod sparse_observable;
 pub mod transpiler;
+pub mod classical_expr;
 
 pub use exit_codes::ExitCode;
 

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -1,0 +1,28 @@
+#include "common.h"
+#include <complex.h>
+#include <math.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+QkExprNode *inner_build_test_expression();
+static int test_expression(void) {
+    QkExprNode *expr = inner_build_test_expression();
+    printf("NODE TYPE %d\n", qk_expr_node_kind(expr));
+
+    return RuntimeError;
+}
+
+int test_classical_expr(void) {
+    int num_failed = 0;
+    num_failed += RUN_TEST(test_expression);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}
+

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -8,6 +8,342 @@
 #include <stdio.h>
 #include <string.h>
 
+static int test_var(void) {
+    int result = Ok;
+
+    QkVar *var_bool = qk_var_new("v",  &(QkExprTypeInfo){QkExprType_Bool, 0});
+    QkExprTypeInfo type_info = qk_var_type_info(var_bool);
+    if ( type_info.ty != QkExprType_Bool ) {
+        fprintf(stderr, "Bool var type mismatch: expected %d, got %d\n", QkExprType_Bool, type_info.ty);
+        result = EqualityError;
+        goto clear_var_bool;
+    }
+
+    QkVar *var_float = qk_var_new("v",  &(QkExprTypeInfo){QkExprType_Float, 0});
+    type_info = qk_var_type_info(var_float);
+    if ( type_info.ty != QkExprType_Float ) {
+        fprintf(stderr, "Float var type mismatch: expected %d, got %d\n", QkExprType_Float, type_info.ty);
+        result = EqualityError;
+        goto clear_var_float;
+    }
+
+    QkVar *var_duration = qk_var_new("v",  &(QkExprTypeInfo){QkExprType_Duration, 0});
+    type_info = qk_var_type_info(var_duration);
+    if ( type_info.ty != QkExprType_Duration ) {
+        fprintf(stderr, "Duration var type mismatch: expected %d, got %d\n", QkExprType_Duration, type_info.ty);
+        result = EqualityError;
+        goto clear_var_duration;
+    }
+
+    QkVar *var_uint = qk_var_new("my_var",  &(QkExprTypeInfo){QkExprType_Uint, 7});
+    type_info = qk_var_type_info(var_uint);
+    if ( type_info.ty != QkExprType_Uint || type_info.width != 7 ) {
+        fprintf(stderr, "Uint var type/width mismatch: expected type=%d width=7, got type=%d width=%u\n",
+                QkExprType_Uint, type_info.ty, type_info.width);
+        result = EqualityError;
+        goto clear_var_uint;
+    }
+
+    QkExprNode *var_expr = qk_var_as_expr(var_uint);
+    QkExprNodeKind kind = qk_expr_node_kind(var_expr);
+    if (kind != QkExprNodeKind_Var) {
+        fprintf(stderr, "Expr node kind mismatch: expected %d, got %d\n", QkExprNodeKind_Var, kind);
+        result = EqualityError;
+        goto clear_var_expr;
+    }
+
+    const QkVar *extracted_var = qk_expr_as_var(var_expr);
+
+    char *name = qk_var_name(extracted_var);
+    if (strcmp(name, "my_var") != 0) {
+        fprintf(stderr, "Var name mismatch: expected 'my_var', got '%s'\n", name);
+        result = EqualityError;
+    }
+    qk_str_free(name);
+
+clear_var_expr:
+    qk_expr_free(var_expr);
+clear_var_uint:
+    qk_var_free(var_uint);
+clear_var_duration:
+    qk_var_free(var_duration);
+clear_var_float:
+    qk_var_free(var_float);
+clear_var_bool:
+    qk_var_free(var_bool);
+
+    return result;
+}
+
+static int test_stretch(void) {
+    int result = Ok;
+
+    QkStretch *stretch = qk_stretch_new("my_stretch");
+
+    char *name = qk_stretch_name(stretch);
+    if (strcmp(name, "my_stretch") != 0) {
+        fprintf(stderr, "Stretch name mismatch: expected 'my_stretch', got '%s'\n", name);
+        result = EqualityError;
+        goto clear_stretch;
+    }
+
+    QkExprNode *stretch_expr = qk_stretch_as_expr(stretch);
+    QkExprNodeKind kind = qk_expr_node_kind(stretch_expr);
+    if (kind != QkExprNodeKind_Stretch) {
+        fprintf(stderr, "Stretch expr node kind mismatch: expected %d, got %d\n", QkExprNodeKind_Stretch, kind);
+        result = EqualityError;
+        goto clear_stretch_expr;
+    }
+
+    const QkStretch *extracted_stretch = qk_expr_as_stretch(stretch_expr);
+
+    char *extracted_name = qk_stretch_name(extracted_stretch);
+    if (strcmp(extracted_name, "my_stretch") != 0) {
+        fprintf(stderr, "Extracted stretch name mismatch: expected 'my_stretch', got '%s'\n", extracted_name);
+        result = EqualityError;
+    }
+
+    qk_str_free(extracted_name);
+clear_stretch_expr:
+    qk_expr_free(stretch_expr);
+clear_stretch:
+    qk_str_free(name);
+    qk_stretch_free(stretch);
+
+    return result;
+}
+
+static int test_value(void) {
+    int result = Ok;
+
+    QkValue *float_val = qk_value_new_float(3.14);
+    QkExprNode *float_expr = qk_value_as_expr(float_val);
+    QkExprNodeKind kind = qk_expr_node_kind(float_expr);
+    if (kind != QkExprNodeKind_Value) {
+        fprintf(stderr, "Float value expr node kind mismatch: expected %d, got %d\n", QkExprNodeKind_Value, kind);
+        result = EqualityError;
+        goto clear_float_expr;
+    }
+
+    const QkValue *extracted_val = qk_expr_as_value(float_expr);
+
+    double extracted_float = qk_value_float(extracted_val);
+    if (extracted_float != 3.14) {
+        fprintf(stderr, "Float value mismatch: expected 3.14, got %f\n", extracted_float);
+        result = EqualityError;
+        goto clear_float_expr;
+    }
+
+    QkValue *uint_val = qk_value_new_uint(42, 8);
+    QkExprNode *uint_expr = qk_value_as_expr(uint_val);
+    const QkValue *extracted_uint_val = qk_expr_as_value(uint_expr);
+
+    uint64_t extracted_uint = qk_value_uint(extracted_uint_val);
+    if (extracted_uint != 42) {
+        fprintf(stderr, "Uint value mismatch: expected 42, got %lu\n", (unsigned long)extracted_uint);
+        result = EqualityError;
+        goto clear_uint_expr;
+    }
+
+    QkDurationInfo dur_info = {
+        .ty = QkDurationType_Ns,
+        .value.time = 100.0
+    };
+    QkValue *dur_val = qk_value_new_duration(&dur_info);
+    QkExprNode *dur_expr = qk_value_as_expr(dur_val);
+    const QkValue *extracted_dur_val = qk_expr_as_value(dur_expr);
+
+    QkDurationInfo extracted_dur_info  = qk_value_duration_info(extracted_dur_val);
+
+    if (extracted_dur_info.ty != QkDurationType_Ns ||
+        extracted_dur_info.value.time != 100.0) {
+        fprintf(stderr, "Duration value mismatch: expected type=%d time=100.0, got type=%d time=%f\n",
+                QkDurationType_Ns, extracted_dur_info.ty, extracted_dur_info.value.time);
+        result = EqualityError;
+    }
+
+    qk_expr_free(dur_expr);
+    qk_value_free(dur_val);
+clear_uint_expr:
+    qk_expr_free(uint_expr);
+    qk_value_free(uint_val);
+clear_float_expr:
+    qk_expr_free(float_expr);
+    qk_value_free(float_val);
+
+    return result;
+}
+
+static int test_expr_structs(void) {
+    int result = Ok;
+    
+    QkExprTypeInfo type_info = {QkExprType_Uint, 8};
+    QkVar *var1 = qk_var_new("V1", &type_info);
+    QkVar *var2 = qk_var_new("V2", &type_info);
+    QkExprNode *v1Expr = qk_var_as_expr(var1);
+    QkExprNode *v2Expr = qk_var_as_expr(var2);
+
+    // Test Binary expressions
+    for (uint8_t op = 1; op <= 17; op++) {
+        QkExprNode *expr = qk_expr_binary_new(op, v1Expr, v2Expr, &type_info);
+        
+        QkBinaryExprInfo binary = qk_expr_binary_info(expr);
+        
+        if (binary.op != op) {
+            fprintf(stderr, "Binary operator mismatch for op %u: expected %u, got %u\n",
+                    op, op, binary.op);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (binary.left != v1Expr || binary.right != v2Expr) {
+            fprintf(stderr, "Binary operand mismatch\n");
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (binary.ty.ty != type_info.ty || binary.ty.width != type_info.width) {
+            fprintf(stderr, "Binary type mismatch for op %u: expected type=%u width=%u, got type=%u width=%u\n",
+                    op, type_info.ty, type_info.width, binary.ty.ty, binary.ty.width);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (binary.constant) {
+            fprintf(stderr, "Binary constant flag mismatch for op %u: expected false, got true\n", op);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        qk_expr_free(expr);
+    }
+
+    // Test Unary expressions
+    for (uint8_t op = 1; op <= 3; op++) {
+        QkExprNode *expr = qk_expr_unary_new(op, v1Expr, &type_info);
+        
+        QkUnaryExprInfo unary = qk_expr_unary_info(expr);
+        
+        if (unary.op != op) {
+            fprintf(stderr, "Unary operator mismatch for op %u: expected %u, got %u\n",
+                    op, op, unary.op);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (unary.operand != v1Expr) {
+            fprintf(stderr, "Unary operand mismatch for op %u: operand=%p (expected %p)\n",
+                    op, (void*)unary.operand, (void*)v1Expr);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (unary.ty.ty != type_info.ty || unary.ty.width != type_info.width) {
+            fprintf(stderr, "Unary type mismatch for op %u: expected type=%u width=%u, got type=%u width=%u\n",
+                    op, type_info.ty, type_info.width, unary.ty.ty, unary.ty.width);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        if (unary.constant) {
+            fprintf(stderr, "Unary constant flag mismatch for op %u: expected false, got true\n", op);
+            result = EqualityError;
+            qk_expr_free(expr);
+            goto cleanup;
+        }
+        
+        qk_expr_free(expr);
+    }
+
+    // Test Cast expression
+    QkExprTypeInfo target_type = {QkExprType_Float, 0};
+    QkExprNode *cast_expr = qk_expr_cast_new(v1Expr, &target_type);
+    
+    QkCastExprInfo cast = qk_expr_cast_info(cast_expr);
+    
+    if (cast.operand != v1Expr) {
+        fprintf(stderr, "Cast operand mismatch: operand=%p (expected %p)\n",
+                (void*)cast.operand, (void*)v1Expr);
+        result = EqualityError;
+        qk_expr_free(cast_expr);
+        goto cleanup;
+    }
+    
+    if (cast.ty.ty != target_type.ty || cast.ty.width != target_type.width) {
+        fprintf(stderr, "Cast type mismatch: expected type=%u width=%u, got type=%u width=%u\n",
+                target_type.ty, target_type.width, cast.ty.ty, cast.ty.width);
+        result = EqualityError;
+        qk_expr_free(cast_expr);
+        goto cleanup;
+    }
+    
+    if (cast.implicit) {
+        fprintf(stderr, "Cast implicit flag mismatch: expected false, got true\n");
+        result = EqualityError;
+        qk_expr_free(cast_expr);
+        goto cleanup;
+    }
+    
+    qk_expr_free(cast_expr);
+
+    // Test Index expression
+    QkValue *index_val = qk_value_new_uint(5, 8);
+    QkExprNode *index_val_expr = qk_value_as_expr(index_val);
+    QkExprNode *index_expr = qk_expr_index_new(v1Expr, index_val_expr, &type_info);
+    
+    QkIndexExprInfo index = qk_expr_index_info(index_expr);
+    
+    if (index.target != v1Expr) {
+        fprintf(stderr, "Index target mismatch: target=%p (expected %p)\n",
+                (void*)index.target, (void*)v1Expr);
+        result = EqualityError;
+        qk_expr_free(index_expr);
+        qk_expr_free(index_val_expr);
+        qk_value_free(index_val);
+        goto cleanup;
+    }
+    
+    if (index.index != index_val_expr) {
+        fprintf(stderr, "Index index mismatch: index=%p (expected %p)\n",
+                (void*)index.index, (void*)index_val_expr);
+        result = EqualityError;
+        qk_expr_free(index_expr);
+        qk_expr_free(index_val_expr);
+        qk_value_free(index_val);
+        goto cleanup;
+    }
+    
+    if (index.ty.ty != type_info.ty || index.ty.width != type_info.width) {
+        fprintf(stderr, "Index type mismatch: expected type=%u width=%u, got type=%u width=%u\n",
+                type_info.ty, type_info.width, index.ty.ty, index.ty.width);
+        result = EqualityError;
+        qk_expr_free(index_expr);
+        qk_expr_free(index_val_expr);
+        qk_value_free(index_val);
+        goto cleanup;
+    }
+    
+    qk_expr_free(index_expr);
+    qk_expr_free(index_val_expr);
+    qk_value_free(index_val);
+
+cleanup:
+    qk_expr_free(v2Expr);
+    qk_expr_free(v1Expr);
+    qk_var_free(var2);
+    qk_var_free(var1);
+
+    return result;
+}
+
+
 QkExprNode *inner_build_test_expression();
 static int test_expression(void) {
     QkExprNode *expr = inner_build_test_expression();
@@ -18,7 +354,10 @@ static int test_expression(void) {
 
 int test_classical_expr(void) {
     int num_failed = 0;
-    num_failed += RUN_TEST(test_expression);
+    num_failed += RUN_TEST(test_var);
+    num_failed += RUN_TEST(test_stretch);
+    num_failed += RUN_TEST(test_value);
+    num_failed += RUN_TEST(test_expr_structs);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
This PR adds functions for creating classical expressions in the C API. This part of the work on #15980.

This is an early preview, to hopefully assist in the review of #16178 . It's marked for 2.6 for now. More details TBD.

Based on #16178.

Fixes #16667 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.

### Tasks
- [ ] Add functions to the v tables
- [ ] Add C and Rust testing
- [ ] Add documentation and reno
