### PR TITLE
Fix MultiplierGate.decompose() with custom num_result_qubits

### DIFF
--- a/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
@@ -198,4 +198,4 @@ class MultiplierGate(Gate):
         # This particular decomposition does not use any ancilla qubits.
         # Note that the transpiler may choose a different decomposition
         # based on the number of ancilla qubits available.
-        self.definition = multiplier_qft_r17(self.num_state_qubits)
+        self.definition = multiplier_qft_r17(self.num_state_qubits, self.num_result_qubits)

--- a/releasenotes/notes/fix-multiplier-gate-decompose-num-result-qubits-a1b2c3d4e5f6.yaml
+++ b/releasenotes/notes/fix-multiplier-gate-decompose-num-result-qubits-a1b2c3d4e5f6.yaml
@@ -5,9 +5,4 @@ fixes:
     :meth:`~.MultiplierGate.decompose` (or accessing the ``definition``)
     would fail with a qubit-count mismatch when ``num_result_qubits``
     was set to a value smaller than the default ``2 * num_state_qubits``.
-    The internal ``_define()`` method was not forwarding the
-    ``num_result_qubits`` parameter to the synthesis function
-    :func:`~qiskit.synthesis.arithmetic.multiplier_qft_r17`, causing it
-    to always produce a circuit with ``2 * num_state_qubits`` result
-    qubits regardless of the gate's actual configuration.
     Fixes `#16168 <https://github.com/Qiskit/qiskit/issues/16168>`_.

--- a/releasenotes/notes/fix-multiplier-gate-decompose-num-result-qubits-a1b2c3d4e5f6.yaml
+++ b/releasenotes/notes/fix-multiplier-gate-decompose-num-result-qubits-a1b2c3d4e5f6.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.MultiplierGate` where calling
+    :meth:`~.MultiplierGate.decompose` (or accessing the ``definition``)
+    would fail with a qubit-count mismatch when ``num_result_qubits``
+    was set to a value smaller than the default ``2 * num_state_qubits``.
+    The internal ``_define()`` method was not forwarding the
+    ``num_result_qubits`` parameter to the synthesis function
+    :func:`~qiskit.synthesis.arithmetic.multiplier_qft_r17`, causing it
+    to always produce a circuit with ``2 * num_state_qubits`` result
+    qubits regardless of the gate's actual configuration.
+    Fixes `#16168 <https://github.com/Qiskit/qiskit/issues/16168>`_.

--- a/test/python/circuit/library/test_multipliers.py
+++ b/test/python/circuit/library/test_multipliers.py
@@ -185,6 +185,30 @@ class TestMultiplier(QiskitTestCase):
                 ops = set(synth.count_ops().keys())
                 self.assertIn(expected_op, ops)
 
+    @data(
+        (1, 1),
+        (2, 2),
+        (2, 3),
+        (3, 3),
+        (3, 4),
+        (3, 5),
+    )
+    @unpack
+    def test_multiplier_gate_decompose_with_custom_result_qubits(
+        self, num_state_qubits, num_result_qubits
+    ):
+        """Test that MultiplierGate.decompose() works with non-default num_result_qubits.
+
+        Regression test for https://github.com/Qiskit/qiskit/issues/16168.
+        """
+        gate = MultiplierGate(num_state_qubits, num_result_qubits)
+        self.assertEqual(gate.num_qubits, 2 * num_state_qubits + num_result_qubits)
+
+        # This should not raise -- previously it failed because _define() did not
+        # forward num_result_qubits to the synthesis function.
+        decomposed = gate.definition
+        self.assertEqual(decomposed.num_qubits, gate.num_qubits)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

`MultiplierGate._define()` was not forwarding `num_result_qubits` to the
`multiplier_qft_r17()` synthesis function. This caused the definition circuit
to always have `2 * num_state_qubits` result qubits regardless of the gate's
actual `num_result_qubits`, leading to a qubit-count mismatch and a crash
when calling `.decompose()`.

### Details and Comments

The fix adds `self.num_result_qubits` as the second argument to the
`multiplier_qft_r17()` call inside `_define()`. This is consistent with how
the HLS plugins (`MultiplierSynthesisR17`, `MultiplierSynthesisH18`) already
pass both arguments.

A regression test with 6 parametrized cases covers combinations of
`(num_state_qubits, num_result_qubits)` where `num_result_qubits` is less
than the default `2 * num_state_qubits`.

Fixed #16168
