### PR TITLE
Use rust-native error for `CommutationAnalysis `

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -15,6 +15,7 @@ use ndarray::Array2;
 use ndarray::linalg::kron;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
+use qiskit_circuit::dag_circuit::DAGError;
 use qiskit_circuit::object_registry::PyObjectAsKey;
 use qiskit_circuit::standard_gate::standard_generators::standard_gate_exponent;
 use qiskit_quantum_info::sparse_observable::{PySparseObservable, SparseObservable};
@@ -54,6 +55,8 @@ pub enum CommutationError {
     HashingNaN,
     #[error("Invalid hash type: parameterized")]
     HashingParameter,
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
 }
 
 impl From<CommutationError> for PyErr {
@@ -63,6 +66,7 @@ impl From<CommutationError> for PyErr {
             CommutationError::HashingParameter | CommutationError::FirstInstructionTooLarge => {
                 QiskitError::new_err(value.to_string())
             }
+            CommutationError::DAGCircuit(err) => err.into(),
             _ => PyRuntimeError::new_err(value.to_string()),
         }
     }

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -15,7 +15,6 @@ use ndarray::Array2;
 use ndarray::linalg::kron;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
-use qiskit_circuit::dag_circuit::DAGError;
 use qiskit_circuit::object_registry::PyObjectAsKey;
 use qiskit_circuit::standard_gate::standard_generators::standard_gate_exponent;
 use qiskit_quantum_info::sparse_observable::{PySparseObservable, SparseObservable};
@@ -55,8 +54,6 @@ pub enum CommutationError {
     HashingNaN,
     #[error("Invalid hash type: parameterized")]
     HashingParameter,
-    #[error(transparent)]
-    DAGCircuit(#[from] DAGError),
 }
 
 impl From<CommutationError> for PyErr {
@@ -66,7 +63,6 @@ impl From<CommutationError> for PyErr {
             CommutationError::HashingParameter | CommutationError::FirstInstructionTooLarge => {
                 QiskitError::new_err(value.to_string())
             }
-            CommutationError::DAGCircuit(err) => err.into(),
             _ => PyRuntimeError::new_err(value.to_string()),
         }
     }

--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -19,7 +19,7 @@ use indexmap::IndexMap;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
-use crate::commutation_checker::CommutationChecker;
+use crate::commutation_checker::{CommutationChecker, CommutationError};
 use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 
@@ -54,7 +54,7 @@ pub fn analyze_commutations(
     dag: &mut DAGCircuit,
     commutation_checker: &CommutationChecker,
     approximation_degree: f64,
-) -> PyResult<(CommutationSet, NodeIndices)> {
+) -> Result<(CommutationSet, NodeIndices), CommutationError> {
     let mut commutation_set = vec![vec![]; dag.num_qubits()];
     let mut node_indices: NodeIndices = vec![IndexMap::default(); dag.num_qubits()];
 
@@ -62,7 +62,7 @@ pub fn analyze_commutations(
         |qubit: usize,
          commutation_entry: &mut Vec<Vec<NodeIndex>>,
          node_indices: &mut IndexMap<NodeIndex, usize, ::foldhash::fast::RandomState>|
-         -> PyResult<()> {
+         -> Result<(), CommutationError> {
             let wire = Wire::Qubit(Qubit(qubit as u32));
 
             for current_gate_idx in dag.nodes_on_wire(wire) {
@@ -143,12 +143,12 @@ pub fn analyze_commutations(
             .zip(node_indices.par_iter_mut())
             .enumerate()
             .map(
-                |(qubit, (local_commutation_set, local_indices))| -> PyResult<()> {
+                |(qubit, (local_commutation_set, local_indices))| -> Result<(), CommutationError> {
                     evaluate_qubit(qubit, local_commutation_set, local_indices)?;
                     Ok(())
                 },
             )
-            .collect::<PyResult<()>>()?;
+            .collect::<Result<(), CommutationError>>()?;
         Ok((commutation_set, node_indices))
     } else {
         for qubit in 0..dag.num_qubits() {


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

The following commits modify `CommutationAnalysis` to use rust-native errors throughout its pipeline.
This is done mostly by implementing `DAGCircuitInnerError` based on https://github.com/Qiskit/qiskit/pull/16134 as a possible error in `CommutationError`.

[Click here to see the actual diff of this PR.](https://github.com/Qiskit/qiskit/pull/16193/changes/cc1713bb37f3a2461aa72a7557ccb156cc820ac5)

### Pre-requisites:
- [x] #16134

### AI/LLM disclosure
- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
