### PR TITLE
Use rust-native error for `RemoveIdentityEquiv `

### DIFF
--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -12,6 +12,7 @@
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use pyo3::prelude::*;
+use qiskit_circuit::dag_circuit::DAGError;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use rustworkx_core::petgraph::visit::NodeIndexable;
@@ -27,6 +28,27 @@ use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{Operation, OperationRef};
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use qiskit_util::getenv_use_multiple_threads;
+
+/// Possible errors returned by the `RemoveIdentityEquiv` pass.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveIdentityEquivError {
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
+    // TODO: Remove once Pauli Gates are in Rust.
+    #[error(transparent)]
+    PyPauliRotationTraceAndDim(PyErr),
+}
+
+impl From<RemoveIdentityEquivError> for PyErr {
+    fn from(value: RemoveIdentityEquivError) -> Self {
+        match value {
+            RemoveIdentityEquivError::DAGCircuit(dagcircuit_inner_error) => {
+                dagcircuit_inner_error.into()
+            }
+            RemoveIdentityEquivError::PyPauliRotationTraceAndDim(py_err) => py_err,
+        }
+    }
+}
 
 // The point at which to start running the analysis in parallel.
 // This value was found experimentally during the development of
@@ -80,7 +102,7 @@ pub fn is_identity_equiv<F>(
     matrix_from_definition: bool,
     matrix_from_definition_max_qubits: Option<u32>,
     error_cutoff_fn: F,
-) -> PyResult<Option<f64>>
+) -> Result<Option<f64>, RemoveIdentityEquivError>
 where
     F: Fn(&PackedInstruction) -> f64,
 {
@@ -202,7 +224,8 @@ where
                     .call1((py_gate.instruction.clone_ref(py),))?
                     .extract()?;
                 Ok(result)
-            })?;
+            })
+            .map_err(RemoveIdentityEquivError::PyPauliRotationTraceAndDim)?;
 
             if let Some((tr_over_dim, dim)) = result {
                 return Ok(average_gate_fidelity_below_tol(
@@ -264,7 +287,7 @@ pub fn run_remove_identity_equiv(
     dag: &mut DAGCircuit,
     approx_degree: Option<f64>,
     target: Option<&Target>,
-) -> PyResult<()> {
+) -> Result<(), RemoveIdentityEquivError> {
     // Minimum threshold to compare average gate fidelity to 1. This is chosen to account
     // for roundoff errors and to be consistent with other places.
     let get_error_cutoff = |inst: &PackedInstruction| -> f64 {
@@ -325,11 +348,11 @@ pub fn run_remove_identity_equiv(
                         None
                     }
                 })
-                .collect::<PyResult<Vec<(NodeIndex, f64)>>>()?
+                .collect::<Result<Vec<(NodeIndex, f64)>, RemoveIdentityEquivError>>()?
         } else {
             dag.op_nodes(false)
                 .filter_map(|x| process_node(x.0, x.1).transpose())
-                .collect::<PyResult<Vec<(NodeIndex, f64)>>>()?
+                .collect::<Result<Vec<(NodeIndex, f64)>, RemoveIdentityEquivError>>()?
         };
 
     for (node, phase_update) in remove_list {


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

The following commits modify `RemoveIdentityEquiv` to use rust-native errors throughout its pipeline.
In this PR we introduce the error enumeration `RemoveIdentityEquivEerror` which only has two variants, one for `DAGCircuitError` and the other is for a specific case involving `PauliEvolution` gates that only exist in Python currently.

[Use this to visualize the actual diff](https://github.com/Qiskit/qiskit/pull/16195/changes/e3b94cae5e4a80036344d62363461d7e08605a5a)

### Pre-requisites
- [x]  #16134

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
