### PR TITLE
Use rust-native error for `CommutationCancellation`

### DIFF
--- a/crates/transpiler/src/passes/commutation_cancellation.rs
+++ b/crates/transpiler/src/passes/commutation_cancellation.rs
@@ -16,16 +16,49 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::{Bound, PyResult, pyfunction, wrap_pyfunction};
 
+use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_util::IndexMap;
 use smallvec::{SmallVec, smallvec};
 
 use super::analyze_commutations;
-use crate::commutation_checker::CommutationChecker;
+use crate::commutation_checker::{CommutationChecker, CommutationError};
 use approx::abs_diff_eq;
 use qiskit_circuit::Qubit;
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, DAGError, NodeType};
 use qiskit_circuit::operations::{Operation, Param, StandardGate};
 use qiskit_synthesis::QiskitError;
+
+/// Possible errors during the `CommutationCancellation` pass
+#[derive(Debug, thiserror::Error)]
+pub enum CommutationCancelError {
+    #[error("Rotational gate with parameter expression encountered in cancellation {0:?}")]
+    RotationalParameter(PackedOperation),
+    #[error("Angle for operation {0} is not defined")]
+    OperationUndefinedAngle(String),
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
+    #[error(transparent)]
+    Analysis(#[from] CommutationError),
+}
+
+impl From<CommutationCancelError> for PyErr {
+    fn from(value: CommutationCancelError) -> Self {
+        match value {
+            CommutationCancelError::RotationalParameter(_) => {
+                QiskitError::new_err(value.to_string())
+            }
+            CommutationCancelError::OperationUndefinedAngle(_) => {
+                PyRuntimeError::new_err(value.to_string())
+            }
+            CommutationCancelError::Analysis(commutation_analysis_error) => {
+                commutation_analysis_error.into()
+            }
+            CommutationCancelError::DAGCircuit(dagcircuit_inner_error) => {
+                dagcircuit_inner_error.into()
+            }
+        }
+    }
+}
 
 const _CUTOFF_PRECISION: f64 = 1e-5;
 static ROTATION_GATES: [&str; 4] = ["p", "u1", "rz", "rx"];
@@ -73,14 +106,24 @@ struct CancellationSetKey {
     second_index: Option<usize>,
 }
 
-#[pyfunction]
+#[pyfunction(name = "cancel_commutations")]
 #[pyo3(signature = (dag, commutation_checker, basis_gates=None, approximation_degree=1.))]
-pub fn cancel_commutations(
+fn py_cancel_commutations(
     dag: &mut DAGCircuit,
     commutation_checker: &mut CommutationChecker,
     basis_gates: Option<Vec<String>>,
     approximation_degree: f64,
 ) -> PyResult<()> {
+    cancel_commutations(dag, commutation_checker, basis_gates, approximation_degree)
+        .map_err(Into::into)
+}
+
+pub fn cancel_commutations(
+    dag: &mut DAGCircuit,
+    commutation_checker: &mut CommutationChecker,
+    basis_gates: Option<Vec<String>>,
+    approximation_degree: f64,
+) -> Result<(), CommutationCancelError> {
     let basis = basis_gates.unwrap_or_default();
     let z_var_gate = dag
         .get_op_counts()
@@ -246,10 +289,9 @@ pub fn cancel_commutations(
                         let node_angle = match node_op.params_view().first() {
                             Some(Param::Float(f)) => *f,
                             _ => {
-                                return Err(QiskitError::new_err(format!(
-                                    "Rotational gate with parameter expression encountered in cancellation {:?}",
-                                    node_op.op
-                                )));
+                                return Err(CommutationCancelError::RotationalParameter(
+                                    node_op.op.clone(),
+                                ));
                             }
                         };
                         let phase_shift = z_phase_shift(node_op_name, node_angle);
@@ -264,9 +306,9 @@ pub fn cancel_commutations(
                             "x" => Ok((PI, FRAC_PI_2)),
                             "sx" => Ok((FRAC_PI_2, FRAC_PI_4)),
                             "sxdg" => Ok((-FRAC_PI_2, -FRAC_PI_4)),
-                            _ => Err(PyRuntimeError::new_err(format!(
-                                "Angle for operation {node_op_name} is not defined"
-                            ))),
+                            _ => Err(CommutationCancelError::OperationUndefinedAngle(
+                                node_op_name.to_owned(),
+                            )),
                         }
                     }?;
                     total_angle += node_angle;
@@ -303,7 +345,8 @@ pub fn cancel_commutations(
                     }
                 }
 
-                dag.add_global_phase(&Param::Float(total_phase))?;
+                dag.add_global_phase(&Param::Float(total_phase))
+                    .map_err(CommutationCancelError::DAGCircuit)?;
 
                 for node in cancel_set {
                     dag.remove_op_node(*node);
@@ -324,6 +367,6 @@ fn is_multiple_of_pi(angle: f64, factor: f64) -> bool {
 }
 
 pub fn commutation_cancellation_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(cancel_commutations))?;
+    m.add_wrapped(wrap_pyfunction!(py_cancel_commutations))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/commutation_cancellation.rs
+++ b/crates/transpiler/src/passes/commutation_cancellation.rs
@@ -345,8 +345,7 @@ pub fn cancel_commutations(
                     }
                 }
 
-                dag.add_global_phase(&Param::Float(total_phase))
-                    .map_err(CommutationCancelError::DAGCircuit)?;
+                dag.add_global_phase(&Param::Float(total_phase))?;
 
                 for node in cancel_set {
                     dag.remove_op_node(*node);


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

The following commits modify `CommutationCancellation` to use rust-native errors throughout its pipeline.
We implement the `CommutationCancelError` enumeration which derives from both `DAGCircuitError` and `CommutationError` as well as adding two new variants for operations with parameter expressions or undefined angles.

### Pre-requisites
- [x] #16134 
- [x] #16193

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
