### PR TITLE
Use rust-native error for `CommutativeOptimization`

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -15,6 +15,7 @@ use ndarray::Array2;
 use ndarray::linalg::kron;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
+use qiskit_circuit::dag_circuit::DAGError;
 use qiskit_circuit::object_registry::PyObjectAsKey;
 use qiskit_circuit::standard_gate::standard_generators::standard_gate_exponent;
 use qiskit_quantum_info::sparse_observable::{PySparseObservable, SparseObservable};
@@ -54,6 +55,8 @@ pub enum CommutationError {
     HashingNaN,
     #[error("Invalid hash type: parameterized")]
     HashingParameter,
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
 }
 
 impl From<CommutationError> for PyErr {
@@ -63,6 +66,7 @@ impl From<CommutationError> for PyErr {
             CommutationError::HashingParameter | CommutationError::FirstInstructionTooLarge => {
                 QiskitError::new_err(value.to_string())
             }
+            CommutationError::DAGCircuit(err) => err.into(),
             _ => PyRuntimeError::new_err(value.to_string()),
         }
     }

--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -19,7 +19,7 @@ use indexmap::IndexMap;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
-use crate::commutation_checker::CommutationChecker;
+use crate::commutation_checker::{CommutationChecker, CommutationError};
 use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 
@@ -54,7 +54,7 @@ pub fn analyze_commutations(
     dag: &mut DAGCircuit,
     commutation_checker: &CommutationChecker,
     approximation_degree: f64,
-) -> PyResult<(CommutationSet, NodeIndices)> {
+) -> Result<(CommutationSet, NodeIndices), CommutationError> {
     let mut commutation_set = vec![vec![]; dag.num_qubits()];
     let mut node_indices: NodeIndices = vec![IndexMap::default(); dag.num_qubits()];
 
@@ -62,7 +62,7 @@ pub fn analyze_commutations(
         |qubit: usize,
          commutation_entry: &mut Vec<Vec<NodeIndex>>,
          node_indices: &mut IndexMap<NodeIndex, usize, ::foldhash::fast::RandomState>|
-         -> PyResult<()> {
+         -> Result<(), CommutationError> {
             let wire = Wire::Qubit(Qubit(qubit as u32));
 
             for current_gate_idx in dag.nodes_on_wire(wire) {
@@ -143,12 +143,12 @@ pub fn analyze_commutations(
             .zip(node_indices.par_iter_mut())
             .enumerate()
             .map(
-                |(qubit, (local_commutation_set, local_indices))| -> PyResult<()> {
+                |(qubit, (local_commutation_set, local_indices))| -> Result<(), CommutationError> {
                     evaluate_qubit(qubit, local_commutation_set, local_indices)?;
                     Ok(())
                 },
             )
-            .collect::<PyResult<()>>()?;
+            .collect::<Result<(), CommutationError>>()?;
         Ok((commutation_set, node_indices))
     } else {
         for qubit in 0..dag.num_qubits() {

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -20,12 +20,14 @@ use pyo3::{Bound, PyResult, pyfunction, wrap_pyfunction};
 use qiskit_circuit::instruction::Parameters;
 use smallvec::smallvec;
 
-use crate::commutation_checker::{CommutationChecker, try_matrix_with_definition};
+use crate::commutation_checker::{
+    CommutationChecker, CommutationError, try_matrix_with_definition,
+};
 use crate::passes::remove_identity_equiv::{
-    MINIMUM_TOL, average_gate_fidelity_below_tol, is_identity_equiv,
+    MINIMUM_TOL, RemoveIdentityEquivError, average_gate_fidelity_below_tol, is_identity_equiv,
 };
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, DAGError};
 use qiskit_circuit::operations::{
     Operation, OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation,
     StandardGate, multiply_param, radd_param,
@@ -34,6 +36,41 @@ use qiskit_circuit::{BlocksMode, Clbit, NoBlocks, Qubit, imports};
 
 use qiskit_circuit::VarsMode;
 use qiskit_circuit::packed_instruction::PackedInstruction;
+
+/// Possible errors that can occur during the `CommutativeOptimization` pass
+#[derive(Debug, thiserror::Error)]
+pub enum CommutativeOptimizationError {
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
+    #[error(transparent)]
+    RemoveIdentityEq(#[from] RemoveIdentityEquivError),
+    #[error(transparent)]
+    CommutationAnalysis(#[from] CommutationError),
+    // TODO: Replace with Param rust native error.
+    #[error(transparent)]
+    PyParamError(PyErr),
+    // TODO: Replace when Pauli Evolution is in Rust.
+    #[error(transparent)]
+    PyMergeTwoPauliEvolutions(PyErr),
+}
+
+impl From<CommutativeOptimizationError> for PyErr {
+    fn from(value: CommutativeOptimizationError) -> Self {
+        match value {
+            CommutativeOptimizationError::DAGCircuit(dagcircuit_inner_error) => {
+                dagcircuit_inner_error.into()
+            }
+            CommutativeOptimizationError::RemoveIdentityEq(remove_identity_equiv_error) => {
+                remove_identity_equiv_error.into()
+            }
+            CommutativeOptimizationError::PyParamError(py_err)
+            | CommutativeOptimizationError::PyMergeTwoPauliEvolutions(py_err) => py_err,
+            CommutativeOptimizationError::CommutationAnalysis(commutation_analysis_error) => {
+                commutation_analysis_error.into()
+            }
+        }
+    }
+}
 
 /// Holds the action for each node in the original DAGCircuit.
 #[derive(Clone, Debug)]
@@ -372,7 +409,7 @@ fn commute(
     approximation_degree: f64,
     matrix_max_num_qubits: u32,
     commutation_checker: &mut CommutationChecker,
-) -> PyResult<bool> {
+) -> Result<bool, CommutationError> {
     let qargs1 = dag.get_qargs(inst1.qubits);
     let qargs2 = dag.get_qargs(inst2.qubits);
     let cargs1 = dag.get_cargs(inst1.clbits);
@@ -388,7 +425,7 @@ fn commute(
         return Ok(val);
     }
 
-    Ok(commutation_checker.commute(
+    commutation_checker.commute(
         &op1,
         inst1.params.as_deref(),
         qargs1,
@@ -400,7 +437,7 @@ fn commute(
         None,
         matrix_max_num_qubits,
         approximation_degree,
-    )?)
+    )
 }
 
 /// Merge two instructions.
@@ -430,7 +467,7 @@ fn try_merge(
     inst2: &PackedInstruction,
     tol: f64,
     matrix_max_num_qubits: u32,
-) -> PyResult<(bool, Option<PackedInstruction>, f64)> {
+) -> Result<(bool, Option<PackedInstruction>, f64), CommutativeOptimizationError> {
     if inst1.op.num_qubits() != inst2.op.num_qubits() {
         return Ok((false, None, 0.));
     }
@@ -454,7 +491,10 @@ fn try_merge(
     {
         // Check whether the two gates are self-inverse.
         if let Some((gate1inv, params1inv)) = gate1.inverse(params1) {
-            if (gate1inv == gate2) && compare_params(&params1inv, params2)? {
+            if (gate1inv == gate2)
+                && compare_params(&params1inv, params2)
+                    .map_err(CommutativeOptimizationError::PyParamError)?
+            {
                 return Ok((true, None, 0.));
             }
         }
@@ -539,7 +579,8 @@ fn try_merge(
                         py_op: std::sync::OnceLock::new(),
                     }))
                 }
-            })?;
+            })
+            .map_err(CommutativeOptimizationError::PyMergeTwoPauliEvolutions)?;
 
             if let Some(merged_instruction) = merged_instruction {
                 if let Some(phase_update) = is_identity_equiv(
@@ -596,12 +637,27 @@ fn disjoint_instructions(
 #[pyfunction]
 #[pyo3(name = "commutative_optimization")]
 #[pyo3(signature = (dag, commutation_checker, approximation_degree=1., matrix_max_num_qubits=0))]
-pub fn run_commutative_optimization(
+fn py_run_commutative_optimization(
     dag: &mut DAGCircuit,
     commutation_checker: &mut CommutationChecker,
     approximation_degree: f64,
     matrix_max_num_qubits: u32,
 ) -> PyResult<Option<DAGCircuit>> {
+    run_commutative_optimization(
+        dag,
+        commutation_checker,
+        approximation_degree,
+        matrix_max_num_qubits,
+    )
+    .map_err(Into::into)
+}
+
+pub fn run_commutative_optimization(
+    dag: &mut DAGCircuit,
+    commutation_checker: &mut CommutationChecker,
+    approximation_degree: f64,
+    matrix_max_num_qubits: u32,
+) -> Result<Option<DAGCircuit>, CommutativeOptimizationError> {
     let tol = MINIMUM_TOL.max(1. - approximation_degree);
     let error_cutoff_fn = |_inst: &PackedInstruction| -> f64 { tol };
 
@@ -737,6 +793,6 @@ pub fn run_commutative_optimization(
 }
 
 pub fn commutative_optimization_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_commutative_optimization))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_commutative_optimization))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -12,6 +12,7 @@
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use pyo3::prelude::*;
+use qiskit_circuit::dag_circuit::DAGError;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use rustworkx_core::petgraph::visit::NodeIndexable;
@@ -27,6 +28,27 @@ use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{Operation, OperationRef};
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use qiskit_util::getenv_use_multiple_threads;
+
+/// Possible errors returned by the `RemoveIdentityEquiv` pass.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveIdentityEquivError {
+    #[error(transparent)]
+    DAGCircuit(#[from] DAGError),
+    // TODO: Remove once Pauli Gates are in Rust.
+    #[error(transparent)]
+    PyPauliRotationTraceAndDim(PyErr),
+}
+
+impl From<RemoveIdentityEquivError> for PyErr {
+    fn from(value: RemoveIdentityEquivError) -> Self {
+        match value {
+            RemoveIdentityEquivError::DAGCircuit(dagcircuit_inner_error) => {
+                dagcircuit_inner_error.into()
+            }
+            RemoveIdentityEquivError::PyPauliRotationTraceAndDim(py_err) => py_err,
+        }
+    }
+}
 
 // The point at which to start running the analysis in parallel.
 // This value was found experimentally during the development of
@@ -80,7 +102,7 @@ pub fn is_identity_equiv<F>(
     matrix_from_definition: bool,
     matrix_from_definition_max_qubits: Option<u32>,
     error_cutoff_fn: F,
-) -> PyResult<Option<f64>>
+) -> Result<Option<f64>, RemoveIdentityEquivError>
 where
     F: Fn(&PackedInstruction) -> f64,
 {
@@ -202,7 +224,8 @@ where
                     .call1((py_gate.instruction.clone_ref(py),))?
                     .extract()?;
                 Ok(result)
-            })?;
+            })
+            .map_err(RemoveIdentityEquivError::PyPauliRotationTraceAndDim)?;
 
             if let Some((tr_over_dim, dim)) = result {
                 return Ok(average_gate_fidelity_below_tol(
@@ -264,7 +287,7 @@ pub fn run_remove_identity_equiv(
     dag: &mut DAGCircuit,
     approx_degree: Option<f64>,
     target: Option<&Target>,
-) -> PyResult<()> {
+) -> Result<(), RemoveIdentityEquivError> {
     // Minimum threshold to compare average gate fidelity to 1. This is chosen to account
     // for roundoff errors and to be consistent with other places.
     let get_error_cutoff = |inst: &PackedInstruction| -> f64 {
@@ -325,11 +348,11 @@ pub fn run_remove_identity_equiv(
                         None
                     }
                 })
-                .collect::<PyResult<Vec<(NodeIndex, f64)>>>()?
+                .collect::<Result<Vec<(NodeIndex, f64)>, RemoveIdentityEquivError>>()?
         } else {
             dag.op_nodes(false)
                 .filter_map(|x| process_node(x.0, x.1).transpose())
-                .collect::<PyResult<Vec<(NodeIndex, f64)>>>()?
+                .collect::<Result<Vec<(NodeIndex, f64)>, RemoveIdentityEquivError>>()?
         };
 
     for (node, phase_update) in remove_list {


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
The following commits modify `CommutativeOptimization` to use rust-native errors throughout its pipeline.
We implement the `CommutativeOptimizationError` enumeration which derives from `DAGCircuitError`, `RemoveIdentityEquivError`, and `CommutationError` as well as adding two new variants for python specific errors dealing with parameters and pauli evolution gates.

### Pre-requisites
- [x] #16134
- [ ] #16195 
- [ ] #16193 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
