### PR TITLE
Fix marginal counts for mixed-width hex Counts

### DIFF
--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -27,38 +27,43 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
     indices: Option<Vec<usize>>,
 ) -> HashMap<String, T> {
     let mut out_counts: HashMap<String, T> = HashMap::with_capacity(counts.len());
-    let clbit_size = counts.keys().next().unwrap().replace(['_', ' '], "").len();
-    let all_indices: Vec<usize> = (0..clbit_size).collect();
-    counts
+    let counts: Vec<(String, T)> = counts
         .iter()
         .map(|(k, v)| (k.replace(['_', ' '], ""), *v))
-        .for_each(|(k, v)| match &indices {
-            Some(indices) => {
-                if all_indices == *indices {
-                    out_counts.insert(k, v);
-                } else {
-                    let key_arr = k.as_bytes();
-                    let new_key: String = indices
-                        .iter()
-                        .map(|bit| {
-                            let index = clbit_size - *bit - 1;
-                            match key_arr.get(index) {
-                                Some(bit) => *bit as char,
-                                None => '0',
-                            }
-                        })
-                        .rev()
-                        .collect();
-                    out_counts
-                        .entry(new_key)
-                        .and_modify(|e| *e += v)
-                        .or_insert(v);
-                }
+        .collect();
+    let clbit_size = counts.iter().map(|(k, _)| k.len()).max().unwrap();
+    let all_indices: Vec<usize> = (0..clbit_size).collect();
+    counts.iter().for_each(|(k, v)| match &indices {
+        Some(indices) => {
+            if all_indices == *indices {
+                out_counts.insert(format!("{k:0>clbit_size$}"), *v);
+            } else {
+                let key_arr = k.as_bytes();
+                let offset = clbit_size.saturating_sub(key_arr.len());
+                let new_key: String = indices
+                    .iter()
+                    .map(|bit| {
+                        let index = clbit_size - *bit - 1;
+                        if index < offset {
+                            return '0';
+                        }
+                        match key_arr.get(index - offset) {
+                            Some(bit) => *bit as char,
+                            None => '0',
+                        }
+                    })
+                    .rev()
+                    .collect();
+                out_counts
+                    .entry(new_key)
+                    .and_modify(|e| *e += *v)
+                    .or_insert(*v);
             }
-            None => {
-                out_counts.insert(k, v);
-            }
-        });
+        }
+        None => {
+            out_counts.insert(k.clone(), *v);
+        }
+    });
     out_counts
 }
 

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -245,15 +245,18 @@ def marginal_distribution(
 
 def _marginalize(counts, indices=None):
     """Get the marginal counts for the given set of indices"""
-    num_clbits = len(next(iter(counts)).replace(" ", ""))
+    counts = [(_remove_space_underscore(key), val) for key, val in counts.items()]
+    num_clbits = max(len(key) for key, _ in counts)
     # Check if we do not need to marginalize and if so, trim
     # whitespace and '_' and return
-    if (indices is None) or set(range(num_clbits)) == set(indices):
+    if indices is None:
         ret = {}
-        for key, val in counts.items():
-            key = _remove_space_underscore(key)
+        for key, val in counts:
             ret[key] = val
         return ret
+
+    if set(range(num_clbits)) == set(indices):
+        return {key.zfill(num_clbits): val for key, val in counts}
 
     if not indices or not set(indices).issubset(set(range(num_clbits))):
         raise QiskitError(f"indices must be in range [0, {num_clbits - 1}].")
@@ -264,8 +267,9 @@ def _marginalize(counts, indices=None):
 
     # Build the return list
     new_counts = Counter()
-    for key, val in counts.items():
-        new_key = "".join([_remove_space_underscore(key)[-idx - 1] for idx in indices])
+    for key, val in counts:
+        key = key.zfill(num_clbits)
+        new_key = "".join([key[-idx - 1] for idx in indices])
         new_counts[new_key] += val
     return dict(new_counts)
 

--- a/releasenotes/notes/marginal-counts-mixed-width-94fc84c74203663b.yaml
+++ b/releasenotes/notes/marginal-counts-mixed-width-94fc84c74203663b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed :func:`~.marginal_counts` and :func:`~.marginal_distribution` when a
+    :class:`~.Counts` object created from hexadecimal keys has mixed-width
+    bitstrings because ``memory_slots`` was not supplied. These functions now
+    infer the classical-bit width from the longest key and treat shorter keys as
+    left-zero-padded while marginalizing.

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -44,12 +44,26 @@ class TestCounts(unittest.TestCase):
         result = utils.marginal_counts(counts_obj, [0, 1])
         self.assertEqual(expected, result)
 
+    def test_marginal_counts_mixed_width_hex_without_memory_slots(self):
+        counts_obj = counts.Counts({"0x0": 50, "0x3": 30})
+        expected = {"0": 50, "1": 30}
+
+        self.assertEqual(expected, utils.marginal_counts(counts_obj, [0]))
+        self.assertEqual(expected, utils.marginal_counts(counts_obj, [1]))
+
     def test_marginal_distribution(self):
         raw_counts = {"0x0": 4, "0x1": 7, "0x2": 10, "0x6": 5, "0x9": 11, "0xD": 9, "0xE": 8}
         expected = {"00": 4, "01": 27, "10": 23}
         counts_obj = counts.Counts(raw_counts, creg_sizes=[["c0", 4]], memory_slots=4)
         result = utils.marginal_distribution(counts_obj, [0, 1])
         self.assertEqual(expected, result)
+
+    def test_marginal_distribution_mixed_width_hex_without_memory_slots(self):
+        counts_obj = counts.Counts({"0x0": 50, "0x3": 30})
+        expected = {"0": 50, "1": 30}
+
+        self.assertEqual(expected, utils.marginal_distribution(counts_obj, [0]))
+        self.assertEqual(expected, utils.marginal_distribution(counts_obj, [1]))
 
     def test_marginal_distribution_numpy_indices(self):
         raw_counts = {"0x0": 4, "0x1": 7, "0x2": 10, "0x6": 5, "0x9": 11, "0xD": 9, "0xE": 8}


### PR DESCRIPTION
Fixes #16190.

### Summary

This updates count marginalization to infer the classical-bit width from the longest cleaned count key, then treats shorter keys as left-zero-padded while marginalizing. This fixes `Counts` objects created from hexadecimal input without `memory_slots`, where the stored bitstrings can have mixed widths such as `"0"` and `"11"`.

The same width handling is applied to the accelerated marginal-distribution path so higher-bit indices do not panic on mixed-width keys.

### Details and comments

- `marginal_counts(Counts({"0x0": 50, "0x3": 30}), [0])` now returns `{"0": 50, "1": 30}`.
- `marginal_distribution(..., [1])` now handles the same input instead of panicking in the Rust helper.
- The no-indices path still only strips spaces/underscores and does not pad keys.

### Testing

- `python -X utf8 -m unittest test.python.result.test_counts.TestCounts.test_marginal_counts_mixed_width_hex_without_memory_slots test.python.result.test_counts.TestCounts.test_marginal_distribution_mixed_width_hex_without_memory_slots`
- `python -X utf8 -m unittest test.python.result.test_counts`
- `python -X utf8 -m unittest test.python.result.test_result.TestResultOperations.test_marginal_counts test.python.result.test_result.TestResultOperations.test_marginal_distribution test.python.result.test_result.TestResultOperations.test_marginal_counts_result test.python.result.test_result.TestResultOperations.test_marginal_counts_with_dict test.python.result.test_result.TestResultOperationsFailed.test_marginal_counts_no_cregs`
- `python -X utf8 -m unittest discover -s test/python/result -p 'test_*.py'`
- `cargo test -p qiskit-accelerate --lib`
- `cargo fmt --check`
- `black --check qiskit/result/utils.py test/python/result/test_counts.py`
- `ruff check qiskit/result/utils.py test/python/result/test_counts.py`
- `reno lint`

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used OpenAI Codex (GPT-5) to help write this PR description.
- [ ] I used OpenAI Codex (GPT-5) to help investigate the issue and draft code/test changes; I reviewed and verified the final diff locally.