### PR TITLE
Fix ctest errors in Windows

### DIFF
--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -1207,13 +1207,13 @@ static int test_dag_replace_qubitless_block_with_unitary(void) {
 
     qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){1}, NULL, false);
     uint32_t idx =
-        qk_dag_apply_gate(dag, QkGate_GlobalPhase, (uint32_t[0]){}, (double[]){0.0}, false);
+        qk_dag_apply_gate(dag, QkGate_GlobalPhase, (uint32_t[]){0}, (double[]){0.0}, false);
     qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
 
     // Replace the global phase gate by a 0-qubit unitary gate
     static const QkComplex64 identity_mat[1] = {{1, 0}};
     uint32_t new_node_idx = qk_dag_replace_block_with_unitary(
-        dag, 1, (uint32_t[]){idx}, identity_mat, 0, (uint32_t[0]){}, false);
+        dag, 1, (uint32_t[]){idx}, identity_mat, 0, (uint32_t[]){0}, false);
 
     // The resulting DAG should have 3 operations
     size_t num_ops = qk_dag_num_op_nodes(dag);

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -1207,13 +1207,13 @@ static int test_dag_replace_qubitless_block_with_unitary(void) {
 
     qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){1}, NULL, false);
     uint32_t idx =
-        qk_dag_apply_gate(dag, QkGate_GlobalPhase, (uint32_t[]){}, (double[]){0.0}, false);
+        qk_dag_apply_gate(dag, QkGate_GlobalPhase, (uint32_t[0]){}, (double[]){0.0}, false);
     qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
 
     // Replace the global phase gate by a 0-qubit unitary gate
     static const QkComplex64 identity_mat[1] = {{1, 0}};
     uint32_t new_node_idx = qk_dag_replace_block_with_unitary(
-        dag, 1, (uint32_t[]){idx}, identity_mat, 0, (uint32_t[]){}, false);
+        dag, 1, (uint32_t[]){idx}, identity_mat, 0, (uint32_t[0]){}, false);
 
     // The resulting DAG should have 3 operations
     size_t num_ops = qk_dag_num_op_nodes(dag);

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -1206,14 +1206,13 @@ static int test_dag_replace_qubitless_block_with_unitary(void) {
     qk_dag_add_quantum_register(dag, qr);
 
     qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){1}, NULL, false);
-    uint32_t idx =
-        qk_dag_apply_gate(dag, QkGate_GlobalPhase, (uint32_t[]){0}, (double[]){0.0}, false);
+    uint32_t idx = qk_dag_apply_gate(dag, QkGate_GlobalPhase, NULL, (double[]){0.0}, false);
     qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
 
     // Replace the global phase gate by a 0-qubit unitary gate
     static const QkComplex64 identity_mat[1] = {{1, 0}};
-    uint32_t new_node_idx = qk_dag_replace_block_with_unitary(
-        dag, 1, (uint32_t[]){idx}, identity_mat, 0, (uint32_t[]){0}, false);
+    uint32_t new_node_idx =
+        qk_dag_replace_block_with_unitary(dag, 1, (uint32_t[]){idx}, identity_mat, 0, NULL, false);
 
     // The resulting DAG should have 3 operations
     size_t num_ops = qk_dag_num_op_nodes(dag);

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -101,8 +101,8 @@ static int test_scaled_add(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[] = {0};
-    uint32_t indices[] = {0};
+    QkBitTerm *bit_terms = NULL;
+    uint32_t *indices = NULL;
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -128,8 +128,8 @@ static int test_scaled_add_inplace(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[] = {0};
-    uint32_t indices[] = {0};
+    QkBitTerm *bit_terms = NULL;
+    uint32_t *indices = NULL;
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -277,8 +277,8 @@ static int test_mult(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[] = {0};
-        uint32_t indices[] = {0};
+        QkBitTerm *bit_terms = NULL;
+        uint32_t *indices = NULL;
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -311,8 +311,8 @@ static int test_mult_inplace(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[] = {0};
-        uint32_t indices[] = {0};
+        QkBitTerm *bit_terms = NULL;
+        uint32_t *indices = NULL;
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -344,8 +344,8 @@ static int test_canonicalize(void) {
 
     // construct the expected observable: 2 * Id
     QkObs *expected = qk_obs_zero(100);
-    QkBitTerm bit_terms[] = {0};
-    uint32_t indices[] = {0};
+    QkBitTerm *bit_terms = NULL;
+    uint32_t *indices = NULL;
     QkComplex64 coeff = {2.0, 0.0};
     QkObsTerm term = {coeff, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -101,8 +101,8 @@ static int test_scaled_add(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[] = {};
-    uint32_t indices[] = {};
+    QkBitTerm bit_terms[0] = {};
+    uint32_t indices[0] = {};
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -128,8 +128,8 @@ static int test_scaled_add_inplace(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[] = {};
-    uint32_t indices[] = {};
+    QkBitTerm bit_terms[0] = {};
+    uint32_t indices[0] = {};
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -277,8 +277,8 @@ static int test_mult(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[] = {};
-        uint32_t indices[] = {};
+        QkBitTerm bit_terms[0] = {};
+        uint32_t indices[0] = {};
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -311,8 +311,8 @@ static int test_mult_inplace(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[] = {};
-        uint32_t indices[] = {};
+        QkBitTerm bit_terms[0] = {};
+        uint32_t indices[0] = {};
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -344,8 +344,8 @@ static int test_canonicalize(void) {
 
     // construct the expected observable: 2 * Id
     QkObs *expected = qk_obs_zero(100);
-    QkBitTerm bit_terms[] = {};
-    uint32_t indices[] = {};
+    QkBitTerm bit_terms[0] = {};
+    uint32_t indices[0] = {};
     QkComplex64 coeff = {2.0, 0.0};
     QkObsTerm term = {coeff, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
@@ -715,7 +715,7 @@ static int test_boundaries(void) {
     // indices = [0, 1, 2]
     // bit_terms = [X, Y, Z]
     // boundaries = [0, 0, 3]
-    size_t expected[] = {0, 0, 3};
+    size_t expected[3] = {0, 0, 3};
 
     for (size_t i = 0; i < num_terms + 1; i++) {
         if (boundaries[i] != expected[i]) {

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -101,8 +101,8 @@ static int test_scaled_add(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[0] = {};
-    uint32_t indices[0] = {};
+    QkBitTerm bit_terms[] = {0};
+    uint32_t indices[] = {0};
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -128,8 +128,8 @@ static int test_scaled_add_inplace(void) {
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
-    QkBitTerm bit_terms[0] = {};
-    uint32_t indices[0] = {};
+    QkBitTerm bit_terms[] = {0};
+    uint32_t indices[] = {0};
     QkObsTerm term = {factor, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);
 
@@ -277,8 +277,8 @@ static int test_mult(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[0] = {};
-        uint32_t indices[0] = {};
+        QkBitTerm bit_terms[] = {0};
+        uint32_t indices[] = {0};
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -311,8 +311,8 @@ static int test_mult_inplace(void) {
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
-        QkBitTerm bit_terms[0] = {};
-        uint32_t indices[0] = {};
+        QkBitTerm bit_terms[] = {0};
+        uint32_t indices[] = {0};
         QkObsTerm term = {coeffs[i], 0, bit_terms, indices, 100};
         qk_obs_add_term(expected, &term);
 
@@ -344,8 +344,8 @@ static int test_canonicalize(void) {
 
     // construct the expected observable: 2 * Id
     QkObs *expected = qk_obs_zero(100);
-    QkBitTerm bit_terms[0] = {};
-    uint32_t indices[0] = {};
+    QkBitTerm bit_terms[] = {0};
+    uint32_t indices[] = {0};
     QkComplex64 coeff = {2.0, 0.0};
     QkObsTerm term = {coeff, 0, bit_terms, indices, 100};
     qk_obs_add_term(expected, &term);

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -729,11 +729,11 @@ static int test_target_iteration(void) {
             }
             // Global phase
             else if (op_idx == 6) {
-                if (!compare_qargs(qargs, (uint32_t[0]){}, 0)) {
+                if (!compare_qargs(qargs, (uint32_t[]){0}, 0)) {
                     printf(
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
-                    print_qargs((uint32_t[0]){}, 0);
+                    print_qargs((uint32_t[]){0}, 0);
                     printf("', found '");
                     print_qargs(qargs, qargs_len);
                     printf("'\n");

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -729,11 +729,11 @@ static int test_target_iteration(void) {
             }
             // Global phase
             else if (op_idx == 6) {
-                if (!compare_qargs(qargs, (uint32_t[]){}, 0)) {
+                if (!compare_qargs(qargs, (uint32_t[0]){}, 0)) {
                     printf(
                         "Unexpected qargs found for operation %s at qarg index: %zu. Expected: '",
                         name, props_idx);
-                    print_qargs((uint32_t[]){}, 0);
+                    print_qargs((uint32_t[0]){}, 0);
                     printf("', found '");
                     print_qargs(qargs, qargs_len);
                     printf("'\n");


### PR DESCRIPTION
The following commits specify the length of zero length arrays in some of the tests in Windows.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
