### PR TITLE
Speedup `SubstitutePi4Rotations`

### DIFF
--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -13,10 +13,9 @@
 use num_complex::ComplexFloat;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::operations::Operation;
-use rustworkx_core::petgraph::algo::toposort;
+use qiskit_circuit::packed_instruction::PackedOperation;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, PI};
 
 use crate::gate_metrics::rotation_trace_and_dim;
@@ -1122,8 +1121,31 @@ pub fn py_run_substitute_pi4_rotations(
         let k = rotation_to_pi_div(gate);
         let num_qubits = gate.num_qubits();
 
-        if let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) {
-            if num_qubits == 2 {
+        let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) else {
+            continue;
+        };
+
+        match num_qubits {
+            1 => {
+                let (sequence, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
+                let num_gates = sequence.len();
+                if num_gates == 0 {
+                    // in the special case that we have a 0-length sequence, remove the gate
+                    dag.remove_1q_sequence(&[node_index]);
+                } else {
+                    // add all gates except the last one, and then substitute the existing op
+                    // for the very last gate
+                    for gate in sequence[..num_gates - 1].iter() {
+                        dag.insert_1q_on_incoming_qubit((*gate, &[]), node_index);
+                    }
+                    let last_op = PackedOperation::from_standard_gate(
+                        *sequence.last().expect("sequence has at least 1 element"),
+                    );
+                    dag.substitute_op(node_index, last_op, None, None)?;
+                }
+                global_phase_update += phase_update;
+            }
+            2 => {
                 let (sequence, phase_update) = replace_2q_rotation_by_discrete(gate, multiple);
                 let mut local_dag =
                     DAGCircuit::with_capacity(2, 0, None, Some(sequence.len()), None, None);
@@ -1131,20 +1153,17 @@ pub fn py_run_substitute_pi4_rotations(
                 local_dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
 
                 for (gate, qubits) in sequence {
-                    let qargs = qubits.iter().map(|index| Qubit(*index)).collect::<Vec<_>>();
-                    let interned = local_dag.add_qargs(&qargs);
+                    let qargs = ::bytemuck::cast_slice(qubits);
+                    let interned = local_dag.add_qargs(qargs);
                     let packed = PackedInstruction::from_standard_gate(*gate, None, interned);
                     local_dag.push_back(packed)?;
                 }
                 dag.substitute_node_with_dag(node_index, &local_dag, None, None, None, None)?;
                 global_phase_update += phase_update;
-            } else {
-                let (sequence, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
-                for gate in sequence {
-                    dag.insert_1q_on_incoming_qubit((*gate, &[]), node_index);
-                }
-                dag.remove_1q_sequence(&[node_index]);
-                global_phase_update += phase_update;
+            }
+            _ => {
+                // There's no standard rotation gates with more than 2 qubits.
+                continue;
             }
         };
     }

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -14,12 +14,13 @@ use num_complex::ComplexFloat;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use qiskit_circuit::bit::ShareableQubit;
+use qiskit_circuit::dag_circuit::NodeIndex;
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::packed_instruction::PackedOperation;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, PI};
 
 use crate::gate_metrics::rotation_trace_and_dim;
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedInstruction;
 
@@ -1095,37 +1096,31 @@ pub fn py_run_substitute_pi4_rotations(
     let tol = MINIMUM_TOL.max(1.0 - approximation_degree);
     let mut global_phase_update: f64 = 0.;
 
-    // We collect into a Vec here since we need to iterate over the node_indices while modifying
-    // the DAG. So we can't keep a const ref (in dag.op_nodes()) while borrowing mutable later.
-    let nodes = dag.op_node_indices(false).collect::<Vec<_>>();
-    for node_index in nodes {
-        let NodeType::Operation(inst) = &dag[node_index] else {
-            unreachable!();
-        };
-        let gate = if let OperationRef::StandardGate(gate) = inst.op.view() {
-            gate
-        } else {
-            continue;
-        };
+    // We first collect all nodes that need changing and store their pi/4 multiple. Then
+    // we iterate over the DAG to apply these changes.
+    let nodes_to_replace: Vec<(NodeIndex, StandardGate, usize)> = dag
+        .op_nodes(false)
+        .filter_map(|(node_index, inst)| {
+            let OperationRef::StandardGate(gate) = inst.op.view() else {
+                return None;
+            };
 
-        if gate.num_params() != 1 {
-            continue;
-        }
+            if gate.num_params() != 1 {
+                return None;
+            };
 
-        let angle = if let Param::Float(angle) = inst.params_view()[0] {
-            angle
-        } else {
-            continue;
-        };
+            let Param::Float(angle) = inst.params_view()[0] else {
+                return None;
+            };
 
-        let k = rotation_to_pi_div(gate);
-        let num_qubits = gate.num_qubits();
+            let k = rotation_to_pi_div(gate);
+            let multiple = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol)?;
+            Some((node_index, gate, multiple))
+        })
+        .collect();
 
-        let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) else {
-            continue;
-        };
-
-        match num_qubits {
+    for (node_index, gate, multiple) in nodes_to_replace {
+        match gate.num_qubits() {
             1 => {
                 let (sequence, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
                 let num_gates = sequence.len();

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -1096,45 +1096,31 @@ pub fn py_run_substitute_pi4_rotations(
     let tol = MINIMUM_TOL.max(1.0 - approximation_degree);
     let mut global_phase_update: f64 = 0.;
 
-    // TODO make this iter over op_nodes and modify in place
-    for node_index in toposort(dag.dag(), None).expect("DAG has no cycles") {
+    // We collect into a Vec here since we need to iterate over the node_indices while modifying
+    // the DAG. So we can't keep a const ref (in dag.op_nodes()) while borrowing mutable later.
+    let nodes = dag.op_node_indices(false).collect::<Vec<_>>();
+    for node_index in nodes {
         let NodeType::Operation(inst) = &dag[node_index] else {
-            continue;
+            unreachable!();
         };
         let gate = if let OperationRef::StandardGate(gate) = inst.op.view() {
             gate
         } else {
-            // new_dag.push_back(inst.clone())?;
             continue;
         };
 
         if gate.num_params() != 1 {
-            // new_dag.push_back(inst.clone())?;
             continue;
         }
 
         let angle = if let Param::Float(angle) = inst.params_view()[0] {
             angle
         } else {
-            // new_dag.push_back(inst.clone())?;
             continue;
         };
 
         let k = rotation_to_pi_div(gate);
         let num_qubits = gate.num_qubits();
-
-        // let original_qubits = dag.get_qargs(inst.qubits);
-        // let mut push_gate = |(gate, qubits): (StandardGate, &[u32])| -> PyResult<()> {
-        //     let updated_qubits: Vec<Qubit> = qubits
-        //         .iter()
-        //         .map(|q| original_qubits[*q as usize])
-        //         .collect();
-        //     let new_qubits = new_dag.add_qargs(&updated_qubits);
-        //     new_dag.push_back(PackedInstruction::from_standard_gate(
-        //         gate, None, new_qubits,
-        //     ))?;
-        //     Ok(())
-        // };
 
         if let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) {
             if num_qubits == 2 {

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -17,6 +17,7 @@ use qiskit_circuit::BlocksMode;
 use qiskit_circuit::Qubit;
 use qiskit_circuit::VarsMode;
 use qiskit_circuit::operations::Operation;
+use rustworkx_core::petgraph::algo::toposort;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, PI};
 
 use crate::gate_metrics::rotation_trace_and_dim;
@@ -1078,7 +1079,7 @@ fn rotation_to_pi_div(gate: StandardGate) -> usize {
 #[pyfunction]
 #[pyo3(name = "substitute_pi4_rotations")]
 pub fn py_run_substitute_pi4_rotations(
-    dag: &DAGCircuit,
+    dag: &mut DAGCircuit,
     approximation_degree: f64,
 ) -> PyResult<Option<DAGCircuit>> {
     // Skip the pass if there are no rotation gates.
@@ -1098,9 +1099,10 @@ pub fn py_run_substitute_pi4_rotations(
     let tol = MINIMUM_TOL.max(1.0 - approximation_degree);
     let mut global_phase_update: f64 = 0.;
 
-    for node_index in dag.topological_op_nodes(false) {
+    // TODO make this iter over op_nodes and modify in place
+    for node_index in toposort(dag.dag(), None).expect("DAG has no cycles") {
         let NodeType::Operation(inst) = &dag[node_index] else {
-            unreachable!("dag.topological_op_nodes only returns Operations");
+            continue;
         };
         let gate = if let OperationRef::StandardGate(gate) = inst.op.view() {
             gate
@@ -1124,30 +1126,33 @@ pub fn py_run_substitute_pi4_rotations(
         let k = rotation_to_pi_div(gate);
         let num_qubits = gate.num_qubits();
 
-        if let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) {
-            let (sequence, phase_update) = if num_qubits == 2 {
-                let (sequence, phase_update) = replace_2q_rotation_by_discrete(gate, multiple);
-                (sequence.to_vec(), phase_update)
-            } else {
-                // num_qubits == 1
-                let (new_gate, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
+        let original_qubits = dag.get_qargs(inst.qubits);
+        let mut push_gate = |(gate, qubits): (StandardGate, &[u32])| -> PyResult<()> {
+            let updated_qubits: Vec<Qubit> = qubits
+                .iter()
+                .map(|q| original_qubits[*q as usize])
+                .collect();
+            let new_qubits = new_dag.add_qargs(&updated_qubits);
+            new_dag.push_back(PackedInstruction::from_standard_gate(
+                gate, None, new_qubits,
+            ))?;
+            Ok(())
+        };
 
-                let qubit: &[u32] = &[0];
-                let sequence = new_gate.iter().map(|g| (*g, qubit)).collect();
-                (sequence, phase_update)
-            };
-            for (new_gate, qubits) in sequence {
-                let original_qubits = dag.get_qargs(inst.qubits);
-                let updated_qubits: Vec<Qubit> = qubits
-                    .iter()
-                    .map(|q| original_qubits[*q as usize])
-                    .collect();
-                let new_qubits = new_dag.add_qargs(&updated_qubits);
-                new_dag.push_back(PackedInstruction::from_standard_gate(
-                    new_gate, None, new_qubits,
-                ))?;
+        if let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) {
+            if num_qubits == 2 {
+                let (sequence, phase_update) = replace_2q_rotation_by_discrete(gate, multiple);
+                for (gate, qubits) in sequence {
+                    push_gate((*gate, qubits))?;
+                }
+                global_phase_update += phase_update;
+            } else {
+                let (sequence, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
+                for gate in sequence {
+                    push_gate((*gate, &[0]))?;
+                }
+                global_phase_update += phase_update;
             }
-            global_phase_update += phase_update;
         } else {
             new_dag.push_back(inst.clone())?;
         }

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -13,9 +13,8 @@
 use num_complex::ComplexFloat;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use qiskit_circuit::BlocksMode;
 use qiskit_circuit::Qubit;
-use qiskit_circuit::VarsMode;
+use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::operations::Operation;
 use rustworkx_core::petgraph::algo::toposort;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, PI};
@@ -1081,17 +1080,15 @@ fn rotation_to_pi_div(gate: StandardGate) -> usize {
 pub fn py_run_substitute_pi4_rotations(
     dag: &mut DAGCircuit,
     approximation_degree: f64,
-) -> PyResult<Option<DAGCircuit>> {
+) -> PyResult<()> {
     // Skip the pass if there are no rotation gates.
     if dag
         .get_op_counts()
         .keys()
         .all(|k| !ROTATION_GATE_NAMES.contains(&k.as_str()))
     {
-        return Ok(None);
+        return Ok(());
     }
-
-    let mut new_dag = dag.copy_empty_like_with_capacity(0, 0, VarsMode::Alike, BlocksMode::Keep)?;
 
     // Iterate over nodes in the DAG and collect nodes that are rotation gates
     // with an angle that is sufficiently close to a multiple of pi/4
@@ -1107,60 +1104,67 @@ pub fn py_run_substitute_pi4_rotations(
         let gate = if let OperationRef::StandardGate(gate) = inst.op.view() {
             gate
         } else {
-            new_dag.push_back(inst.clone())?;
+            // new_dag.push_back(inst.clone())?;
             continue;
         };
 
         if gate.num_params() != 1 {
-            new_dag.push_back(inst.clone())?;
+            // new_dag.push_back(inst.clone())?;
             continue;
         }
 
         let angle = if let Param::Float(angle) = inst.params_view()[0] {
             angle
         } else {
-            new_dag.push_back(inst.clone())?;
+            // new_dag.push_back(inst.clone())?;
             continue;
         };
 
         let k = rotation_to_pi_div(gate);
         let num_qubits = gate.num_qubits();
 
-        let original_qubits = dag.get_qargs(inst.qubits);
-        let mut push_gate = |(gate, qubits): (StandardGate, &[u32])| -> PyResult<()> {
-            let updated_qubits: Vec<Qubit> = qubits
-                .iter()
-                .map(|q| original_qubits[*q as usize])
-                .collect();
-            let new_qubits = new_dag.add_qargs(&updated_qubits);
-            new_dag.push_back(PackedInstruction::from_standard_gate(
-                gate, None, new_qubits,
-            ))?;
-            Ok(())
-        };
+        // let original_qubits = dag.get_qargs(inst.qubits);
+        // let mut push_gate = |(gate, qubits): (StandardGate, &[u32])| -> PyResult<()> {
+        //     let updated_qubits: Vec<Qubit> = qubits
+        //         .iter()
+        //         .map(|q| original_qubits[*q as usize])
+        //         .collect();
+        //     let new_qubits = new_dag.add_qargs(&updated_qubits);
+        //     new_dag.push_back(PackedInstruction::from_standard_gate(
+        //         gate, None, new_qubits,
+        //     ))?;
+        //     Ok(())
+        // };
 
         if let Some(multiple) = is_angle_close_to_multiple_of_pi_k(gate, k, angle, tol) {
             if num_qubits == 2 {
                 let (sequence, phase_update) = replace_2q_rotation_by_discrete(gate, multiple);
+                let mut local_dag =
+                    DAGCircuit::with_capacity(2, 0, None, Some(sequence.len()), None, None);
+                local_dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
+                local_dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
+
                 for (gate, qubits) in sequence {
-                    push_gate((*gate, qubits))?;
+                    let qargs = qubits.iter().map(|index| Qubit(*index)).collect::<Vec<_>>();
+                    let interned = local_dag.add_qargs(&qargs);
+                    let packed = PackedInstruction::from_standard_gate(*gate, None, interned);
+                    local_dag.push_back(packed)?;
                 }
+                dag.substitute_node_with_dag(node_index, &local_dag, None, None, None, None)?;
                 global_phase_update += phase_update;
             } else {
                 let (sequence, phase_update) = replace_1q_rotation_by_discrete(gate, multiple);
                 for gate in sequence {
-                    push_gate((*gate, &[0]))?;
+                    dag.insert_1q_on_incoming_qubit((*gate, &[]), node_index);
                 }
+                dag.remove_1q_sequence(&[node_index]);
                 global_phase_update += phase_update;
             }
-        } else {
-            new_dag.push_back(inst.clone())?;
-        }
+        };
     }
+    dag.add_global_phase(&Param::Float(global_phase_update))?;
 
-    new_dag.add_global_phase(&Param::Float(global_phase_update))?;
-
-    Ok(Some(new_dag))
+    Ok(())
 }
 
 pub fn substitute_pi4_rotations_mod(m: &Bound<PyModule>) -> PyResult<()> {

--- a/qiskit/transpiler/passes/optimization/substitute_pi4_rotations.py
+++ b/qiskit/transpiler/passes/optimization/substitute_pi4_rotations.py
@@ -86,10 +86,5 @@ class SubstitutePi4Rotations(TransformationPass):
         Returns:
             The output DAG.
         """
-        new_dag = substitute_pi4_rotations(dag, self.approximation_degree)
-
-        # If the pass did not do anything, the result is None
-        if new_dag is None:
-            return dag
-
-        return new_dag
+        substitute_pi4_rotations(dag, self.approximation_degree)
+        return dag

--- a/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
+++ b/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
@@ -3,7 +3,7 @@ performance:
   - Improved the runtime of :class:`.SubstitutePi4Rotations` in practical scenarios.
     Typically, only a very small fraction of rotation gates is replaced by fixed equivalent gates,
     and it is significantly faster to replace the operations in place compared to rebuilding
-    the DAG.  For circuits with a large number of gates this can significantlyreduce the runtime, 
+    the DAG.  For circuits with a large number of gates this can significantly reduce the runtime, 
     for example a more than 10x reduction for QSVT circuit with 43 million gates.
     See `#16217 <https://github.com/Qiskit/qiskit/pull/16217>__` for more details and benchmarks.
 

--- a/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
+++ b/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
@@ -2,7 +2,7 @@
 performance:
   - Improved the runtime of :class:`.SubstitutePi4Rotations` in practical scenarios.
     Typically, only a very small fraction of rotation gates is replaced by fixed equivalent gates,
-    and it is significantly faster to replace the operations inplace compared to rebuilding
+    and it is significantly faster to replace the operations in place compared to rebuilding
     the DAG.  For circuits with a large number of gates this can significantlyreduce the runtime, 
     for example a more than 10x reduction for QSVT circuit with 43 million gates.
     See `#16217 <https://github.com/Qiskit/qiskit/pull/16217>__` for more details and benchmarks.

--- a/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
+++ b/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
@@ -3,6 +3,7 @@ performance:
   - Improved the runtime of :class:`.SubstitutePi4Rotations` in practical scenarios.
     Typically, only a very small fraction of rotation gates is replaced by fixed equivalent gates,
     and it is significantly faster to replace the operations inplace compared to rebuilding
-    the DAG.  For circuits with a large number of gates this has shown to reduce the runtime
-    signifcantly, for example a more than 10x reduction for QSVT circuit with 43 million gates.
+    the DAG.  For circuits with a large number of gates this can significantlyreduce the runtime, 
+    for example a more than 10x reduction for QSVT circuit with 43 million gates.
+    See `#16217 <https://github.com/Qiskit/qiskit/pull/16217>__` for more details and benchmarks.
 

--- a/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
+++ b/releasenotes/notes/speedups-substitute-pi4-9a367596602b1fa6.yaml
@@ -1,0 +1,8 @@
+---
+performance:
+  - Improved the runtime of :class:`.SubstitutePi4Rotations` in practical scenarios.
+    Typically, only a very small fraction of rotation gates is replaced by fixed equivalent gates,
+    and it is significantly faster to replace the operations inplace compared to rebuilding
+    the DAG.  For circuits with a large number of gates this has shown to reduce the runtime
+    signifcantly, for example a more than 10x reduction for QSVT circuit with 43 million gates.
+


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

In an ongoing profiling session with @jan-an and @alexanderivrii we found easy-to-fix bottlenecks in the Clifford+T pipeline. One of them is around `SubstitutePi4Rotations` which takes a significant amount of time in large circuits (say 1 million gates and above). 

Only a very small fraction of gates is expected to be a rotations with $pi/4$ multiples, so the pass only modifies a small fraction of gates in the circuit. At that scale it is much cheaper to just modify the DAG inplace rather than rebuilding it. Also there is no need for iterating over the nodes in topological order (thanks for the hint @mtreinish!).

This improves the benchmarks but is only one of the bottlenecks, there's still some other improvements to be done in the pipeline.

### Benchmarks

**asv benchmarks (FT ones only)**

Not a significant change, except one which is 10x faster. The others are around the same time. This is to be expected as the circuits are relatively small and the rebuild doesn't take much time. They are that small such that asv runs in a reasonable time.

asv is run on https://github.com/Qiskit/qiskit/commit/0f9c4cae8d36f603382cca0fdffe23f520ae0d28 

<details>
<summary>PERFORMANCE INCREASED.</summary>

```
Benchmarks that have improved:

| Change   |   Before [d6a4c24f] <main> |   After [0f9c4cae] <speedup-subs-pi4> |   Ratio | Benchmark (Parameter)                                                         |
|----------|----------------------------|---------------------------------------|---------|-------------------------------------------------------------------------------|
| -        |                        769 |                                   145 |    0.19 | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 8, 2) |

Benchmarks that have stayed the same:

| Change   | Before [d6a4c24f] <main>   | After [0f9c4cae] <speedup-subs-pi4>   | Ratio   | Benchmark (Parameter)                                                             |
|----------|----------------------------|---------------------------------------|---------|-----------------------------------------------------------------------------------|
|          | 3.21±0.04ms                | 32.6±30ms                             | ~10.14  | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 8, 2)    |
|          | 33.0±30ms                  | 3.17±0.1ms                            | ~0.10   | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 8, 3)    |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 8, 1)        |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 8, 2)        |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 8, 3)        |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 8, 1)         |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 8, 2)         |
|          | n/a                        | n/a                                   | n/a     | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 8, 3)         |
|          | 26.6±0.09ms                | 28.8±3ms                              | 1.09    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 4, 1)       |
|          | 28.0±0.3ms                 | 30.5±1ms                              | 1.09    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 4, 2)       |
|          | 604±6μs                    | 643±9μs                               | 1.06    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 8, 3) |
|          | 307±6μs                    | 323±7μs                               | 1.05    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 4, 2)           |
|          | 214±2μs                    | 226±9μs                               | 1.05    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 4, 0) |
|          | 439±9μs                    | 462±20μs                              | 1.05    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 4, 2) |
|          | 28.0±0.3ms                 | 29.5±2ms                              | 1.05    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 4, 3)       |
|          | 551±20μs                   | 573±10μs                              | 1.04    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 8, 3)           |
|          | 26.2±0.1ms                 | 27.1±1ms                              | 1.04    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 4, 1)    |
|          | 51.1±0.6ms                 | 52.9±6ms                              | 1.04    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 4, 3)           |
|          | 23.4±0.2ms                 | 24.0±0.7ms                            | 1.03    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 4, 0)    |
|          | 25.2±0.9ms                 | 25.8±2ms                              | 1.03    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 8, 0)       |
|          | 37.7±0.4ms                 | 38.9±1ms                              | 1.03    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 8, 2)       |
|          | 370±4μs                    | 379±20μs                              | 1.02    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 8, 1) |
|          | 2.02±0.03ms                | 2.06±0.07ms                           | 1.02    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 8, 0)    |
|          | 279±0.6ms                  | 283±4ms                               | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 8, 0)        |
|          | 194±4μs                    | 196±3μs                               | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 8, 0)           |
|          | 292±10μs                   | 295±9μs                               | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 4, 1) |
|          | 624±8μs                    | 629±6μs                               | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 8, 2) |
|          | 2.34±0.09ms                | 2.36±0.1ms                            | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 8, 1)    |
|          | 21.9±0.2ms                 | 22.2±0.3ms                            | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 4, 0)       |
|          | 34.7±0.5ms                 | 35.2±1ms                              | 1.01    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 8, 1)       |
|          | 440±10μs                   | 441±20μs                              | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 4, 3) |
|          | 27.8±0.2ms                 | 27.7±0.4ms                            | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 4, 2)    |
|          | 27.8±0.1ms                 | 27.9±2ms                              | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('multiplier', 4, 3)    |
|          | 50.2±0.4ms                 | 49.9±0.4ms                            | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 4, 1)           |
|          | 50.6±0.2ms                 | 50.4±0.6ms                            | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 4, 2)           |
|          | 133±0.8ms                  | 133±0.4ms                             | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 8, 0)           |
|          | 3649                       | 3649                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 4, 0)         |
|          | 3649                       | 3649                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 4, 1)         |
|          | 3402                       | 3402                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 4, 2)         |
|          | 3402                       | 3402                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 4, 3)         |
|          | 21390                      | 21390                                 | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('grover', 8, 0)         |
|          | 7                          | 7                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 4, 0)            |
|          | 7                          | 7                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 4, 1)            |
|          | 7                          | 7                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 4, 2)            |
|          | 7                          | 7                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 4, 3)            |
|          | 39                         | 39                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 8, 0)            |
|          | 39                         | 39                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 8, 1)            |
|          | 39                         | 39                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 8, 2)            |
|          | 39                         | 39                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('mcx', 8, 3)            |
|          | 8                          | 8                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 4, 0)  |
|          | 8                          | 8                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 4, 1)  |
|          | 8                          | 8                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 4, 2)  |
|          | 8                          | 8                                     | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 4, 3)  |
|          | 24                         | 24                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 8, 0)  |
|          | 24                         | 24                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 8, 1)  |
|          | 24                         | 24                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 8, 2)  |
|          | 24                         | 24                                    | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('modular_adder', 8, 3)  |
|          | 1912                       | 1912                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 4, 0)     |
|          | 1912                       | 1912                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 4, 1)     |
|          | 1911                       | 1911                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 4, 2)     |
|          | 1911                       | 1911                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 4, 3)     |
|          | 153                        | 153                                   | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 8, 0)     |
|          | 149                        | 149                                   | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 8, 1)     |
|          | 145                        | 145                                   | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('multiplier', 8, 3)     |
|          | 1140                       | 1140                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 4, 0)            |
|          | 1140                       | 1140                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 4, 1)            |
|          | 1011                       | 1011                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 4, 2)            |
|          | 1011                       | 1011                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 4, 3)            |
|          | 7926                       | 7926                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 8, 0)            |
|          | 7926                       | 7926                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 8, 1)            |
|          | 6038                       | 6038                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 8, 2)            |
|          | 6038                       | 6038                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('qft', 8, 3)            |
|          | 3240                       | 3240                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 4, 0)        |
|          | 3240                       | 3240                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 4, 1)        |
|          | 3240                       | 3240                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 4, 2)        |
|          | 3240                       | 3240                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 4, 3)        |
|          | 7224                       | 7224                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 8, 0)        |
|          | 7224                       | 7224                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 8, 1)        |
|          | 7224                       | 7224                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 8, 2)        |
|          | 7224                       | 7224                                  | 1.00    | transpiler_ft.TranspilerCliffordTBenchmarks.track_t_count('trotter', 8, 3)        |
|          | 112±5ms                    | 111±1ms                               | 0.99    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 4, 1)        |
|          | 141±1μs                    | 139±3μs                               | 0.99    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 4, 0)           |
|          | 556±10μs                   | 551±10μs                              | 0.99    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 8, 2)           |
|          | 266±7μs                    | 263±6μs                               | 0.99    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('modular_adder', 8, 0) |
|          | 317±100μs                  | 311±7μs                               | 0.98    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 4, 3)           |
|          | 148±1ms                    | 145±1ms                               | 0.98    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 8, 1)           |
|          | 150±1ms                    | 147±0.7ms                             | 0.98    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 8, 3)           |
|          | 38.2±0.4ms                 | 37.5±1ms                              | 0.98    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('trotter', 8, 3)       |
|          | 114±1ms                    | 111±0.7ms                             | 0.97    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 4, 3)        |
|          | 151±0.9ms                  | 146±3ms                               | 0.97    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 8, 2)           |
|          | 107±4ms                    | 102±0.6ms                             | 0.96    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 4, 0)        |
|          | 319±20μs                   | 307±6μs                               | 0.96    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 8, 1)           |
|          | 117±5ms                    | 111±0.7ms                             | 0.95    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('grover', 4, 2)        |
|          | 226±50μs                   | 213±10μs                              | 0.94    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('mcx', 4, 1)           |
|          | 53.9±7ms                   | 50.9±2ms                              | 0.94    | transpiler_ft.TranspilerCliffordTBenchmarks.time_transpile('qft', 4, 0)           |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```
</details>

**FT circuit bench**

Here we do see a systematic improvement. This is due to the circuits being significantly larger than the asv ones, and the avoided copies paying off a lot.

<img width="990" height="490" alt="image" src="https://github.com/user-attachments/assets/32f720b2-b628-422d-ae4d-89eee5388c6e" />

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->