### PR TITLE
Fixes #15748: Prevent Rust panic during nested control flow compose()

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6087,15 +6087,24 @@ impl DAGCircuit {
             for var in node.vars() {
                 match var {
                     expr::Var::Bit { bit } => {
-                        clbits.push(self.clbits.find(bit).unwrap());
+                        let found_bit = self.clbits.find(bit).ok_or_else(|| {
+                            pyo3::exceptions::PyValueError::new_err("Classical bit reference not found in circuit. This indicates corrupted circuit state, likely from a failed mapping during compose.")
+                        })?;
+                        clbits.push(found_bit);
                     }
                     expr::Var::Register { register, .. } => {
                         for bit in register.bits() {
-                            clbits.push(self.clbits.find(&bit).unwrap());
+                            let found_bit = self.clbits.find(&bit).ok_or_else(|| {
+                                pyo3::exceptions::PyValueError::new_err("Classical bit from register not found in circuit.")
+                            })?;
+                            clbits.push(found_bit);
                         }
                     }
                     expr::Var::Standalone { .. } => {
-                        vars.push(self.vars_stretches.vars().find(var).unwrap())
+                        let found_var = self.vars_stretches.vars().find(var).ok_or_else(|| {
+                            pyo3::exceptions::PyValueError::new_err("Standalone variable not found in circuit.")
+                        })?;
+                        vars.push(found_var);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #15748.
While running some fuzzing tests on compose(), I hit a hard Rust panic (called Option::unwrap() on a None value) in dag_circuit.rs. It gets triggered when composing circuits with nested control flow (like an if_test inside another if_test).

What changed:
I replaced the .unwrap() calls inside DAGCircuit::additional_wires (specifically the wires_from_expr closure) with .ok_or_else(). Now, instead of hard-crashing the Python interpreter, it safely raises a ValueError indicating a corrupted circuit state/mapping failure. I also added a regression test for this.

Note on the root cause:
I tracked the actual mapping bug down to CircuitData::native_extend in circuit_data.rs. When copying over other.blocks, it just clones them directly instead of recursively mapping the inner qubits and clbits. It also fails to update the stale bit references inside the expr::Expr conditions of ControlFlow ops, which is what ultimately triggers the None lookup in the DAG builder.

Since the classical expression engine is actively being rewritten in Rust right now, I figured it was safer to just catch the panic here and fail gracefully rather than trying to rewrite the AST traversal and causing massive merge conflicts with your ongoing work.

i used chatgpt to generate this description to explain better what i did