### PR TITLE
Write policy on dependency versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -954,10 +954,22 @@ def test_method2(self):
 
 ## Using dependencies
 
-We distinguish between "requirements" and "optional dependencies" in qiskit.
-A requirement is a package that is absolutely necessary for core functionality in qiskit, such as Numpy or Scipy.
+We distinguish between "requirements" and "optional dependencies" in Qiskit.
+A requirement is a package that is absolutely necessary for core functionality in Qiskit, such as NumPy or SciPy.
 An optional dependency is a package that is used for specialized functionality, which might not be needed by all users.
 If a new feature has a new dependency, it is almost certainly optional.
+
+
+### Version support policy
+
+For Python-space dependencies, Qiskit follows [the scientific-computing standard SPEC 0](https://scientific-python.org/specs/spec-0000/).
+In short: Qiskit will require versions of NumPy and SciPy that are at least two years old.
+For packages not covered by SPEC 0, the requirements must be satisfiable with published binary artifacts from PyPI for the oldest supported Python version, but the two-year limit does not apply.
+
+Python dependencies that are optional at runtime, only used during the build, or only used during the development process are not constrained.
+Qiskit supports all versions of CPython that are not end of life, which is wider than the minimum SPEC 0 support.
+
+Rust dependencies are not constrained, other than by the platform support requirements and minimum supported Rust version of the repository.
 
 ### Adding a requirement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ community in this goal.
   * [Release Cycle](#release-cycle)
 * [Adding deprecation warnings](#adding-deprecation-warnings)
 * [Using dependencies](#using-dependencies)
+  * [Version support policy](#version-support-policy)
   * [Adding a requirement](#adding-a-requirement)
   * [Adding an optional dependency](#adding-an-optional-dependency)
   * [Checking for optionals](#checking-for-optionals)
@@ -976,7 +977,7 @@ Rust dependencies are not constrained, other than by the platform support requir
 Any new requirement must have broad system support; it needs to be supported on all the Python versions and operating systems that qiskit supports.
 It also cannot impose many version restrictions on other packages.
 Users often install qiskit into virtual environments with many different packages in, and we need to ensure that neither we, nor any of our requirements, conflict with their other packages.
-When adding a new requirement, you must add it to [`requirements.txt`](requirements.txt) with as loose a constraint on the allowed versions as possible.
+When adding a new requirement, you must add it to [`requirements.txt`](requirements.txt) following the [version-support policy](#version-support-policy).
 
 ### Adding an optional dependency
 
@@ -984,7 +985,6 @@ New features can also use optional dependencies, which might be used only in ver
 These are not required to use the rest of the package, and so should not be added to `requirements.txt`.
 Instead, if several optional dependencies are grouped together to provide one feature, you can consider adding an "extra" to the package metadata, such as the `visualization` extra that installs Matplotlib and Seaborn (amongst others).
 To do this, modify the [`setup.py`](setup.py) file, adding another entry in the `extras_require` keyword argument to `setup()` at the bottom of the file.
-You do not need to be quite as accepting of all versions here, but it is still a good idea to be as permissive as you possibly can be.
 You should also add a new "tester" to [`qiskit.utils.optionals`](qiskit/utils/optionals.py), for use in the next section.
 
 ### Checking for optionals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -965,7 +965,7 @@ If a new feature has a new dependency, it is almost certainly optional.
 
 For Python-space dependencies, Qiskit follows [the scientific-computing standard SPEC 0](https://scientific-python.org/specs/spec-0000/).
 In short: Qiskit will require versions of NumPy and SciPy that are at least two years old.
-For packages not covered by SPEC 0, the requirements must be satisfiable with published binary artifacts from PyPI for the oldest supported Python version, but the two-year limit does not apply.
+For packages not covered by SPEC 0, the requirements must be satisfiable with published binary artifacts from PyPI for all supported Python versions on [all platforms with tier 1 and tier 2 support](https://quantum.cloud.ibm.com/docs/guides/install-qiskit#operating-system-support).
 
 Python dependencies that are optional at runtime, only used during the build, or only used during the development process are not constrained.
 Qiskit supports all versions of CPython that are not end of life, which is wider than the minimum SPEC 0 support.

--- a/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
+++ b/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
@@ -1,11 +1,13 @@
 ---
 upgrade_misc:
   - |
-    Qiskit now has a formal dependency-version policy, tracked in the repository's ``CONTRIBUTING.md`` documentation.
+    Qiskit now has a formal dependency-version policy, tracked in the
+    `repository's contributing documentation
+    <https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#using-dependencies>`__.
     This is:
 
-    * `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ (two years of support) for NumPy
-      and SciPy;
-    * no constraints beyond platform support on other Python dependencies or all Rust dependencies;
-    * no constraints, including no requirement to support all runtime versions of Python, for
-      optional, build-only and developer-only Python dependencies.
+    * NumPy and SciPy follow the scientific Python community's `SPEC 0
+      <https://scientific-python.org/specs/spec-0000/>`__ (two years of support);
+    * All other Python and Rust dependencies have no constraints beyond platform support;
+    * Option, build-only and developer-only Python dependencies have no constraints, and do not need
+      to support all runtime versions of Python or host platforms.

--- a/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
+++ b/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
@@ -9,5 +9,5 @@ upgrade_misc:
     * NumPy and SciPy follow the scientific Python community's `SPEC 0
       <https://scientific-python.org/specs/spec-0000/>`__ (two years of support);
     * All other Python and Rust dependencies have no constraints beyond platform support;
-    * Option, build-only and developer-only Python dependencies have no constraints, and do not need
+    * Optional, build-only, and developer-only Python dependencies have no constraints, and do not need
       to support all runtime versions of Python or host platforms.

--- a/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
+++ b/releasenotes/notes/numpy-policy-97fd8af2da27715b.yaml
@@ -1,0 +1,11 @@
+---
+upgrade_misc:
+  - |
+    Qiskit now has a formal dependency-version policy, tracked in the repository's ``CONTRIBUTING.md`` documentation.
+    This is:
+
+    * `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`__ (two years of support) for NumPy
+      and SciPy;
+    * no constraints beyond platform support on other Python dependencies or all Rust dependencies;
+    * no constraints, including no requirement to support all runtime versions of Python, for
+      optional, build-only and developer-only Python dependencies.


### PR DESCRIPTION
We have not previously had a formal policy other than a vague "we try to be conservative".  This lack of clarity was getting in the way of merging performance improvements that depend on features in more recent versions of NumPy and SciPy.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Close #15853

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
