### PR TITLE
Fix marginal counts for mixed-width hex Counts

### DIFF
--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -27,7 +27,11 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
     indices: Option<Vec<usize>>,
 ) -> HashMap<String, T> {
     let mut out_counts: HashMap<String, T> = HashMap::with_capacity(counts.len());
-    let clbit_size = counts.keys().next().unwrap().replace(['_', ' '], "").len();
+    let clbit_size = counts
+        .keys()
+        .map(|key| key.replace(['_', ' '], "").len())
+        .max()
+        .unwrap_or(0);
     let all_indices: Vec<usize> = (0..clbit_size).collect();
     counts
         .iter()
@@ -37,6 +41,12 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
                 if all_indices == *indices {
                     out_counts.insert(k, v);
                 } else {
+                    let k = if k.len() < clbit_size {
+                        format!("{:0>width$}", k, width = clbit_size)
+                    } else {
+                        k
+                    };
+
                     let key_arr = k.as_bytes();
                     let new_key: String = indices
                         .iter()
@@ -56,7 +66,7 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
                 }
             }
             None => {
-                out_counts.insert(k, v);
+                out_counts.entry(k).and_modify(|e| *e += v).or_insert(v);
             }
         });
     out_counts

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -221,7 +221,7 @@ def marginal_distribution(
         QiskitError: If any value in ``indices`` is invalid or the ``counts`` dict
         is invalid.
     """
-    num_clbits = len(max(counts.keys()).replace(" ", ""))
+    num_clbits = _max_count_width(counts)
     if indices is not None and (len(indices) == 0 or not set(indices).issubset(range(num_clbits))):
         raise QiskitError(f"indices must be in range [0, {num_clbits - 1}].")
 
@@ -243,12 +243,23 @@ def marginal_distribution(
     return res
 
 
+def _max_count_width(counts):
+    """Return the maximum bitstring width among count keys, ignoring separators."""
+    return max(len(_remove_space_underscore(key)) for key in counts)
+
+
+def _normalize_count_key(key, width):
+    """Remove separators and left-pad a count key to the requested width."""
+    return _remove_space_underscore(key).zfill(width)
+
+
 def _marginalize(counts, indices=None):
-    """Get the marginal counts for the given set of indices"""
-    num_clbits = len(next(iter(counts)).replace(" ", ""))
+    """Get the marginal counts for the given set of indices."""
+    num_clbits = _max_count_width(counts)
+
     # Check if we do not need to marginalize and if so, trim
-    # whitespace and '_' and return
-    if (indices is None) or set(range(num_clbits)) == set(indices):
+    # whitespace and '_' and return.
+    if indices is None:
         ret = {}
         for key, val in counts.items():
             key = _remove_space_underscore(key)
@@ -258,24 +269,34 @@ def _marginalize(counts, indices=None):
     if not indices or not set(indices).issubset(set(range(num_clbits))):
         raise QiskitError(f"indices must be in range [0, {num_clbits - 1}].")
 
-    # Sort the indices to keep in descending order
-    # Since bitstrings have qubit-0 as least significant bit
+    all_indices = set(range(num_clbits))
+
+    # Sort the indices to keep in descending order.
+    # Since bitstrings have qubit-0 as least significant bit.
     indices = sorted(indices, reverse=True)
 
-    # Build the return list
+    # Build the return list.
     new_counts = Counter()
     for key, val in counts.items():
-        new_key = "".join([_remove_space_underscore(key)[-idx - 1] for idx in indices])
+        key = _normalize_count_key(key, num_clbits)
+
+        if set(indices) == all_indices:
+            new_key = key
+        else:
+            new_key = "".join([key[-idx - 1] for idx in indices])
+
         new_counts[new_key] += val
+
     return dict(new_counts)
 
 
 def _format_marginal(counts, marg_counts, indices):
     """Take the output of marginalize and add placeholders for
-    multiple cregs and non-indices."""
+    multiple cregs and non-indices.
+    """
     format_counts = {}
-    counts_template = next(iter(counts))
-    counts_len = len(counts_template.replace(" ", ""))
+    counts_template = max(counts, key=lambda key: len(_remove_space_underscore(key)))
+    counts_len = len(_remove_space_underscore(counts_template))
     indices_rev = sorted(indices, reverse=True)
 
     for count in marg_counts:
@@ -283,13 +304,16 @@ def _format_marginal(counts, marg_counts, indices):
         count_bits = "".join(
             [index_dict[index] if index in index_dict else "_" for index in range(counts_len)]
         )[::-1]
+
         for index, bit in enumerate(counts_template):
             if bit == " ":
                 count_bits = count_bits[:index] + " " + count_bits[index:]
+
         format_counts[count_bits] = marg_counts[count]
+
     return format_counts
 
 
 def _remove_space_underscore(bitstring):
-    """Removes all spaces and underscores from bitstring"""
+    """Removes all spaces and underscores from bitstring."""
     return bitstring.replace(" ", "").replace("_", "")

--- a/releasenotes/notes/fix-marginal-counts-hex-width-4f8e69b900002be1.yaml
+++ b/releasenotes/notes/fix-marginal-counts-hex-width-4f8e69b900002be1.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :func:`.marginal_counts` and :func:`.marginal_distribution` so
+    mixed-width count keys, such as those produced from hexadecimal
+    :class:`.Counts` inputs without explicit ``memory_slots``, are normalized
+    consistently before marginalization. This prevents returning unmarginalized
+    results for inputs such as ``Counts({"0x0": 50, "0x3": 30})``. See
+    `#16190 <https://github.com/Qiskit/qiskit/issues/16190>`__.

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -14,6 +14,8 @@
 
 import numpy as np
 
+
+from qiskit.result import Counts
 from qiskit.result import models
 from qiskit.result import marginal_counts
 from qiskit.result import marginal_distribution
@@ -59,6 +61,41 @@ class TestResultOperations(QiskitTestCase):
         result = Result(results=[exp_result], **self.base_result_args)
 
         self.assertEqual(result.get_counts(0), no_header_processed_counts)
+
+    def test_marginal_counts_hex_without_memory_slots(self):
+        """Hex Counts without memory_slots are padded for marginalization."""
+        counts = Counts({"0x0": 50, "0x3": 30})
+
+        self.assertEqual(counts, {"0": 50, "11": 30})
+        self.assertEqual(marginal_counts(counts, indices=[0]), {"0": 50, "1": 30})
+
+    def test_marginal_counts_hex_without_memory_slots_aggregates_after_padding(self):
+        """Short hex outcomes should be left-zero-padded before marginalization."""
+        counts = Counts({"0x0": 50, "0x2": 30})
+
+        self.assertEqual(marginal_counts(counts, indices=[0]), {"0": 80})
+
+    def test_marginal_counts_hex_without_memory_slots_all_indices(self):
+        """Keeping all inferred bits should normalize mixed-width keys."""
+        counts = Counts({"0x0": 50, "0x3": 30})
+
+        self.assertEqual(marginal_counts(counts, indices=[0, 1]), {"00": 50, "11": 30})
+
+    def test_marginal_counts_hex_without_memory_slots_format_marginal(self):
+        """format_marginal should use the inferred maximum width."""
+        counts = Counts({"0x0": 50, "0x3": 30})
+
+        self.assertEqual(
+            marginal_counts(counts, indices=[1], format_marginal=True),
+            {"0_": 50, "1_": 30},
+        )
+
+    def test_marginal_distribution_mixed_width_keys(self):
+        """The accelerated marginal_distribution path should infer width from all keys."""
+        self.assertEqual(
+            marginal_distribution({"0": 0.5, "11": 0.5}, [0]),
+            {"0": 0.5, "1": 0.5},
+        )
 
     def test_counts_header(self):
         """Test that counts are extracted properly with header."""


### PR DESCRIPTION
### Summary

Fixes Qiskit/qiskit#16190.

This PR fixes marginalization for mixed-width count keys produced from hexadecimal
`Counts` inputs without explicit `memory_slots`.

For example:

```python
Counts({"0x0": 50, "0x3": 30})
```

is normalized to mixed-width bitstrings:

```python
{"0": 50, "11": 30}
```

Before this change, `marginal_counts(..., indices=[0])` could infer the classical
bit width from only the first key and incorrectly return the unmarginalized result.

This PR updates marginalization to infer the bit width from all count keys and
left-pad shorter keys before indexing.

### Details

This PR updates:

- `qiskit/result/utils.py`
  - infers count width from all keys instead of only the first key
  - normalizes shorter keys with leading zeroes before marginalization
  - preserves aggregation when padded keys collide

- `test/python/result/test_result.py`
  - adds regression tests for mixed-width hexadecimal `Counts`
  - adds coverage for aggregation, all-indices marginalization, formatted marginal
    output, and `marginal_distribution`

### Tests

Locally run:

```bash
tox -elint
python -X utf8 -m unittest test.python.result.test_result
```

`tox -elint` passed locally.

The original reproducer now returns the expected result:

```python
from qiskit.result import Counts, marginal_counts

counts = Counts({"0x0": 50, "0x3": 30})
marginal_counts(counts, indices=[0])
```

Result:

```python
{"0": 50, "1": 30}
```

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: ChatGPT, GPT-5.5 Thinking.
- [x] I used the following tool to generate or modify code: ChatGPT, GPT-5.5 Thinking.

I reviewed the generated suggestions before applying them and tested the changes locally.