### PR TITLE
RFC2: Add a Param::Int(i64) variant

### DIFF
--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -46,6 +46,7 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                                 if let Some(dt) = dt {
                                     match dur {
                                         Param::Float(val) => Ok(val * dt),
+                                        Param::Int(val) => Ok((*val as f64) * dt),
                                         Param::Obj(val) => Python::attach(|py| {
                                             let dur_float: f64 = val.extract(py)?;
                                             Ok(dur_float * dt)

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -95,6 +95,7 @@ mod circuit {
             export_fn!(qk_classical_register_borrow_from_python, feature = "python_binding"),
             export_fn!(qk_classical_register_convert_from_python, feature = "python_binding"),
             export_fn!(qk_circuit_draw),
+            export_fn!(qk_circuit_delay_dt),
         ]
     });
 }
@@ -200,6 +201,8 @@ mod param {
             export_fn!(qk_param_conjugate),
             export_fn!(qk_param_equal),
             export_fn!(qk_param_as_real),
+            export_fn!(qk_param_from_int),
+            export_fn!(qk_param_as_int),
         ]
     });
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1088,7 +1088,7 @@ impl CInstruction {
     /// allocations.
     ///
     /// Panics if the operation name contains a nul, or if the instruction has non-numeric
-    /// parameters (not [Param::Float] or [Param::ParameterExpression]).
+    /// parameters (not [Param::Float], [Param::Int], or [Param::ParameterExpression]).
     pub(crate) fn from_packed_instruction_with_numeric(
         packed: &PackedInstruction,
         qargs_interner: &Interner<[Qubit]>,
@@ -1103,7 +1103,7 @@ impl CInstruction {
             .params_view()
             .iter()
             .map(|p| match p {
-                Param::Float(_) | Param::ParameterExpression(_) => {
+                Param::Float(_) | Param::Int(_) | Param::ParameterExpression(_) => {
                     Some(Box::into_raw(Box::new(p.clone())))
                 }
                 _ => None,
@@ -1909,6 +1909,8 @@ pub enum CDelayUnit {
     NS = 3,
     /// Picoseconds.
     PS = 4,
+    /// Backend-native discrete time-step.
+    DT = 5,
 }
 
 impl From<CDelayUnit> for DelayUnit {
@@ -1919,6 +1921,7 @@ impl From<CDelayUnit> for DelayUnit {
             CDelayUnit::US => DelayUnit::US,
             CDelayUnit::NS => DelayUnit::NS,
             CDelayUnit::PS => DelayUnit::PS,
+            CDelayUnit::DT => DelayUnit::DT,
         }
     }
 }
@@ -1956,6 +1959,56 @@ pub unsafe extern "C" fn qk_circuit_delay(
 
     let duration_param: Param = duration.into();
     let delay_instruction = StandardInstruction::Delay(delay_unit_variant);
+
+    let params = Parameters::Params(smallvec![duration_param]);
+    circuit
+        .push_packed_operation(
+            PackedOperation::from_standard_instruction(delay_instruction),
+            Some(params),
+            &[Qubit(qubit)],
+            &[],
+        )
+        .unwrap();
+
+    ExitCode::Success
+}
+
+/// @ingroup QkCircuit
+/// Append a dt-unit delay instruction to the circuit with an integer duration.
+///
+/// Unlike ``qk_circuit_delay`` which takes a floating-point duration, this entry point
+/// accepts a 64-bit unsigned integer count of backend-native discrete time-steps and
+/// always uses the ``QkDelayUnit_DT`` unit. The duration is stored internally as a
+/// signed integer parameter.
+///
+/// @param circuit A pointer to the circuit to add the delay to.
+/// @param qubit The ``uint32_t`` index of the qubit to apply the delay to.
+/// @param duration The duration of the delay in dt units.
+///
+/// @return An exit code.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(1, 0);
+///     qk_circuit_delay_dt(qc, 0, 100);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_delay_dt(
+    circuit: *mut CircuitData,
+    qubit: u32,
+    duration: u64,
+) -> ExitCode {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { mut_ptr_as_ref(circuit) };
+
+    // Cast u64 to i64 for the Param::Int variant. Durations exceeding i64::MAX are
+    // unrealistic for any real circuit so a saturating cast is sufficient.
+    let duration_param = Param::Int(duration as i64);
+    let delay_instruction = StandardInstruction::Delay(DelayUnit::DT);
 
     let params = Parameters::Params(smallvec![duration_param]);
     circuit

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -21,6 +21,15 @@ use qiskit_circuit::operations::Param;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::{Symbol, SymbolExpr, Value};
 
+/// Helper: promote `Param::Int` to `Param::Float` so the rest of the C API arithmetic
+/// can work in floating-point. Other variants are returned by clone.
+fn promote_int(param: &Param) -> std::borrow::Cow<'_, Param> {
+    match param {
+        Param::Int(i) => std::borrow::Cow::Owned(Param::Float(*i as f64)),
+        _ => std::borrow::Cow::Borrowed(param),
+    }
+}
+
 /// @ingroup QkParam
 /// Construct a new ``QkParam`` representing an unbound symbol.
 ///
@@ -126,6 +135,25 @@ pub extern "C" fn qk_param_from_double(value: f64) -> *mut Param {
 }
 
 /// @ingroup QkParam
+/// Construct a new ``QkParam`` from a 64-bit signed integer.
+///
+/// @param value An ``int64_t`` to initialize the ``QkParam``.
+///
+/// @return A pointer to the created ``QkParam``.
+///
+/// # Example
+///
+/// ```c
+/// QkParam *r = qk_param_from_int(42);
+/// ```
+///
+#[unsafe(no_mangle)]
+pub extern "C" fn qk_param_from_int(value: i64) -> *mut Param {
+    let value = Param::Int(value);
+    Box::into_raw(Box::new(value))
+}
+
+/// @ingroup QkParam
 /// Construct a new ``QkParam`` from a complex number, given as ``QkComplex64``.
 ///
 /// @param value A ``QkComplex64`` to initialize the ``QkParam``.
@@ -205,6 +233,7 @@ pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
     let str = match expr {
         Param::ParameterExpression(expr) => expr.to_string(),
         Param::Float(f) => f.to_string(),
+        Param::Int(i) => i.to_string(),
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
     };
     let out = CString::new(str.to_string()).unwrap();
@@ -241,8 +270,13 @@ pub unsafe extern "C" fn qk_param_add(
 ) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let lhs = unsafe { const_ptr_as_ref(lhs) };
-    let rhs = unsafe { const_ptr_as_ref(rhs) };
+    let lhs_raw = unsafe { const_ptr_as_ref(lhs) };
+    let rhs_raw = unsafe { const_ptr_as_ref(rhs) };
+    // Promote any Param::Int to Param::Float so float-arithmetic patterns match.
+    let lhs_promoted = promote_int(lhs_raw);
+    let rhs_promoted = promote_int(rhs_raw);
+    let lhs = lhs_promoted.as_ref();
+    let rhs = rhs_promoted.as_ref();
 
     let ret = match (lhs, rhs) {
         (Param::ParameterExpression(lhs), Param::ParameterExpression(rhs)) => lhs
@@ -297,8 +331,13 @@ pub unsafe extern "C" fn qk_param_sub(
 ) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let lhs = unsafe { const_ptr_as_ref(lhs) };
-    let rhs = unsafe { const_ptr_as_ref(rhs) };
+    let lhs_raw = unsafe { const_ptr_as_ref(lhs) };
+    let rhs_raw = unsafe { const_ptr_as_ref(rhs) };
+    // Promote any Param::Int to Param::Float so float-arithmetic patterns match.
+    let lhs_promoted = promote_int(lhs_raw);
+    let rhs_promoted = promote_int(rhs_raw);
+    let lhs = lhs_promoted.as_ref();
+    let rhs = rhs_promoted.as_ref();
 
     let ret = match (lhs, rhs) {
         (Param::ParameterExpression(lhs), Param::ParameterExpression(rhs)) => lhs
@@ -352,8 +391,13 @@ pub unsafe extern "C" fn qk_param_mul(
 ) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let lhs = unsafe { const_ptr_as_ref(lhs) };
-    let rhs = unsafe { const_ptr_as_ref(rhs) };
+    let lhs_raw = unsafe { const_ptr_as_ref(lhs) };
+    let rhs_raw = unsafe { const_ptr_as_ref(rhs) };
+    // Promote any Param::Int to Param::Float so float-arithmetic patterns match.
+    let lhs_promoted = promote_int(lhs_raw);
+    let rhs_promoted = promote_int(rhs_raw);
+    let lhs = lhs_promoted.as_ref();
+    let rhs = rhs_promoted.as_ref();
 
     let ret = match (lhs, rhs) {
         (Param::ParameterExpression(lhs), Param::ParameterExpression(rhs)) => lhs
@@ -513,7 +557,9 @@ pub unsafe extern "C" fn qk_param_pow(
 pub unsafe extern "C" fn qk_param_sin(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -552,7 +598,9 @@ pub unsafe extern "C" fn qk_param_sin(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_cos(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -591,7 +639,9 @@ pub unsafe extern "C" fn qk_param_cos(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_tan(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -630,7 +680,9 @@ pub unsafe extern "C" fn qk_param_tan(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_asin(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -669,7 +721,9 @@ pub unsafe extern "C" fn qk_param_asin(out: *mut Param, src: *const Param) -> Ex
 pub unsafe extern "C" fn qk_param_acos(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -708,7 +762,9 @@ pub unsafe extern "C" fn qk_param_acos(out: *mut Param, src: *const Param) -> Ex
 pub unsafe extern "C" fn qk_param_atan(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -747,7 +803,9 @@ pub unsafe extern "C" fn qk_param_atan(out: *mut Param, src: *const Param) -> Ex
 pub unsafe extern "C" fn qk_param_log(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -786,7 +844,9 @@ pub unsafe extern "C" fn qk_param_log(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_exp(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -825,7 +885,9 @@ pub unsafe extern "C" fn qk_param_exp(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_abs(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -864,7 +926,9 @@ pub unsafe extern "C" fn qk_param_abs(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_sign(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -903,7 +967,9 @@ pub unsafe extern "C" fn qk_param_sign(out: *mut Param, src: *const Param) -> Ex
 pub unsafe extern "C" fn qk_param_neg(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -942,7 +1008,9 @@ pub unsafe extern "C" fn qk_param_neg(out: *mut Param, src: *const Param) -> Exi
 pub unsafe extern "C" fn qk_param_conjugate(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
-    let src = unsafe { const_ptr_as_ref(src) };
+    let src_raw = unsafe { const_ptr_as_ref(src) };
+    let src_promoted = promote_int(src_raw);
+    let src = src_promoted.as_ref();
 
     match src {
         Param::ParameterExpression(expr) => {
@@ -1031,6 +1099,37 @@ pub unsafe extern "C" fn qk_param_as_real(param: *const Param) -> f64 {
             Err(_) => f64::NAN,
         },
         Param::Float(f) => *f,
+        Param::Int(i) => *i as f64,
+        Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+    }
+}
+
+/// @ingroup QkParam
+/// Attempt casting the ``QkParam`` as ``int64_t``.
+///
+/// Returns the integer value for an integer-valued ``QkParam``. For non-integer parameters
+/// (floats, parameter expressions that don't bind to an integer, etc.), ``INT64_MIN`` is
+/// returned as a sentinel.
+///
+/// @param param A pointer to the ``QkParam`` to evaluate.
+///
+/// @return The integer value, or ``INT64_MIN`` if the parameter is not an integer.
+///
+/// # Safety
+///
+/// The behavior is undefined if ``param`` is not a valid, non-null pointer to a ``QkParam``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_param_as_int(param: *const Param) -> i64 {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let param = unsafe { const_ptr_as_ref(param) };
+
+    match param {
+        Param::Int(i) => *i,
+        Param::ParameterExpression(expr) => match expr.try_to_value(true) {
+            Ok(Value::Int(i)) => i,
+            _ => i64::MIN,
+        },
+        Param::Float(_) => i64::MIN,
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
     }
 }

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -1455,7 +1455,7 @@ pub unsafe extern "C" fn qk_target_op_get(
                     .params_view()
                     .iter()
                     .map(|param| match param {
-                        Param::Float(_) | Param::ParameterExpression(_) => {
+                        Param::Float(_) | Param::Int(_) | Param::ParameterExpression(_) => {
                             std::ptr::from_ref(param)
                         }
                         Param::Obj(_) => panic!("Objects are not supported in the C API."),

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -885,7 +885,7 @@ impl CircuitData {
         match parameters {
             Parameters::Params(params) => {
                 for (index, param) in params.iter().enumerate() {
-                    if matches!(param, Param::Float(_)) {
+                    if matches!(param, Param::Float(_) | Param::Int(_)) {
                         continue;
                     }
                     let usage = ParameterUse::Index {
@@ -922,7 +922,7 @@ impl CircuitData {
         match parameters {
             Parameters::Params(params) => {
                 for (index, param) in params.iter().enumerate() {
-                    if matches!(param, Param::Float(_)) {
+                    if matches!(param, Param::Float(_) | Param::Int(_)) {
                         continue;
                     }
                     let usage = ParameterUse::Index {
@@ -956,7 +956,7 @@ impl CircuitData {
         for inst_index in 0..self.len() {
             self.track_instruction_parameters(inst_index)?;
         }
-        if matches!(self.global_phase, Param::Float(_)) {
+        if matches!(self.global_phase, Param::Float(_) | Param::Int(_)) {
             return Ok(());
         }
         for symbol in self.global_phase.iter_parameters()? {
@@ -1210,32 +1210,27 @@ impl CircuitData {
                     let map: HashMap<&Symbol, Value> = HashMap::from([(symbol, Value::Real(*f))]);
                     expr.bind(&map, false)?
                 }
+                Param::Int(i) => {
+                    let map: HashMap<&Symbol, Value> = HashMap::from([(symbol, Value::Int(*i))]);
+                    expr.bind(&map, false)?
+                }
                 Param::ParameterExpression(e) => {
                     let map: HashMap<Symbol, ParameterExpression> =
                         HashMap::from([(symbol.clone(), e.as_ref().clone())]);
                     expr.subs(&map, false)?
                 }
-                Param::Obj(ob) => {
-                    Python::attach(|py| -> Result<_, CircuitDataError> {
-                        // The integer handling is only needed to support the case where an int is
-                        // passed in directly instead of a float. This will be handled when we add
-                        // int to the param enum to support dt target.
-                        if let Ok(int) = ob.extract::<i64>(py) {
-                            let map: HashMap<&Symbol, Value> =
-                                HashMap::from([(symbol, Value::Int(int))]);
-                            Ok(expr.bind(&map, false)?)
-                        } else if let Ok(c) = ob.extract::<Complex64>(py) {
-                            let map: HashMap<&Symbol, Value> =
-                                HashMap::from([(symbol, Value::Complex(c))]);
-                            Ok(expr.bind(&map, false)?)
-                        } else {
-                            Err(PyTypeError::new_err(format!(
-                                "Cannot assign object ({ob}) object to parameter."
-                            ))
-                            .into())
-                        }
-                    })?
-                }
+                Param::Obj(ob) => Python::attach(|py| -> Result<_, CircuitDataError> {
+                    if let Ok(c) = ob.extract::<Complex64>(py) {
+                        let map: HashMap<&Symbol, Value> =
+                            HashMap::from([(symbol, Value::Complex(c))]);
+                        Ok(expr.bind(&map, false)?)
+                    } else {
+                        Err(PyTypeError::new_err(format!(
+                            "Cannot assign object ({ob}) object to parameter."
+                        ))
+                        .into())
+                    }
+                })?,
             };
             // Param::from_expr() only errors in the python path when calling Python
             Ok(Param::from_expr(new_expr, coerce)?)
@@ -1360,6 +1355,7 @@ impl CircuitData {
                                 let previous_param = &previous.params_view()[parameter];
                                 let new_param = match previous_param {
                                     Param::Float(_) => inconsistent(),
+                                    Param::Int(_) => inconsistent(),
                                     Param::ParameterExpression(expr) => {
                                         let new_param =
                                             bind_expr(expr, &symbol, value.as_ref(), false)?;
@@ -1784,6 +1780,10 @@ impl CircuitData {
         match &angle {
             Param::Float(angle) => {
                 self.set_global_phase_f64(*angle);
+                Ok(())
+            }
+            Param::Int(angle) => {
+                self.set_global_phase_f64(*angle as f64);
                 Ok(())
             }
             Param::ParameterExpression(expr) => {

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -830,28 +830,29 @@ impl TextDrawer {
 
     fn get_label(instruction: &PackedInstruction) -> String {
         match instruction.op.view() {
-            OperationRef::StandardInstruction(std_instruction) => {
-                match std_instruction {
-                    StandardInstruction::Measure => "M".to_string(),
-                    StandardInstruction::Reset => "|0>".to_string(),
-                    StandardInstruction::Barrier(_) => BARRIER.to_string(),
-                    StandardInstruction::Delay(delay_unit) => {
-                        match instruction.params_view().first().unwrap() {
-                            Param::Float(duration) => {
-                                format!(
-                                    "Delay({}[{}])",
-                                    F64UiFormatter::new(5).format(*duration),
-                                    delay_unit
-                                )
-                            }
-                            Param::ParameterExpression(expr) => {
-                                format!("Delay({}[{}])", expr, delay_unit)
-                            }
-                            Param::Obj(obj) => format!("Delay({:?}[{}])", obj, delay_unit), // TODO: extract the int
+            OperationRef::StandardInstruction(std_instruction) => match std_instruction {
+                StandardInstruction::Measure => "M".to_string(),
+                StandardInstruction::Reset => "|0>".to_string(),
+                StandardInstruction::Barrier(_) => BARRIER.to_string(),
+                StandardInstruction::Delay(delay_unit) => {
+                    match instruction.params_view().first().unwrap() {
+                        Param::Float(duration) => {
+                            format!(
+                                "Delay({}[{}])",
+                                F64UiFormatter::new(5).format(*duration),
+                                delay_unit
+                            )
                         }
+                        Param::Int(duration) => {
+                            format!("Delay({}[{}])", duration, delay_unit)
+                        }
+                        Param::ParameterExpression(expr) => {
+                            format!("Delay({}[{}])", expr, delay_unit)
+                        }
+                        Param::Obj(obj) => format!("Delay({:?}[{}])", obj, delay_unit),
                     }
                 }
-            }
+            },
             OperationRef::StandardGate(standard_gate) => {
                 static STANDARD_GATE_LABELS: [&str; crate::operations::STANDARD_GATE_SIZE] = [
                     "", "H", "I", "X", "Y", "Z", "P", "R", "Rx", "Ry", "Rz", "S", "Sdg", "√X",
@@ -892,6 +893,7 @@ impl TextDrawer {
                 .unwrap_or("Unitary".to_string()),
             OperationRef::PauliProductRotation(ppr) => match &ppr.angle {
                 Param::Float(f) => format!("PPR({})", F64UiFormatter::new(5).format_with_pi(*f)),
+                Param::Int(i) => format!("PPR({})", i),
                 Param::ParameterExpression(e) => format!("PPR({})", e),
                 Param::Obj(o) => format!("PPR({:?})", o),
             },

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -440,14 +440,26 @@ impl CircuitInstruction {
                         let eq = match left {
                             Param::Float(left) => match right {
                                 Param::Float(right) => left == right,
+                                Param::Int(right) => *left == (*right as f64),
                                 Param::ParameterExpression(right) => {
                                     &ParameterExpression::from_f64(*left) == right.as_ref()
                                 }
                                 Param::Obj(right) => right.bind(py).eq(left)?,
                             },
+                            Param::Int(left) => match right {
+                                Param::Float(right) => (*left as f64) == *right,
+                                Param::Int(right) => left == right,
+                                Param::ParameterExpression(right) => {
+                                    &ParameterExpression::from_i64(*left) == right.as_ref()
+                                }
+                                Param::Obj(right) => right.bind(py).eq(*left)?,
+                            },
                             Param::ParameterExpression(left) => match right {
                                 Param::Float(right) => {
                                     left.as_ref() == &ParameterExpression::from_f64(*right)
+                                }
+                                Param::Int(right) => {
+                                    left.as_ref() == &ParameterExpression::from_i64(*right)
                                 }
                                 Param::ParameterExpression(right) => left == right,
                                 Param::Obj(right) => right.bind(py).eq(left.as_ref().clone())?,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1810,15 +1810,16 @@ impl DAGCircuit {
                 }
             };
 
-            let phase_eq = match [
-                normalize_param(&slf.global_phase)?,
-                normalize_param(&other.global_phase)?,
-            ] {
-                [Param::Float(self_phase), Param::Float(other_phase)] => {
-                    Ok(phase_is_close(self_phase, other_phase))
-                }
-                _ => slf.global_phase.eq(&other.global_phase),
-            }?;
+            let phase_eq = {
+                let self_norm = normalize_param(&slf.global_phase)?;
+                let other_norm = normalize_param(&other.global_phase)?;
+                match (self_norm.try_float(), other_norm.try_float()) {
+                    (Some(self_phase), Some(other_phase)) => {
+                        Ok(phase_is_close(self_phase, other_phase))
+                    }
+                    _ => slf.global_phase.eq(&other.global_phase),
+                }?
+            };
             if !phase_eq {
                 return Ok(false);
             }
@@ -2544,6 +2545,7 @@ impl DAGCircuit {
         let param_eq = |left: &Param, right: &Param| -> PyResult<bool> {
             match (left, right) {
                 (Param::Float(a), Param::Float(b)) => Ok(a.total_cmp(b) == Ordering::Equal),
+                (Param::Int(a), Param::Int(b)) => Ok(a == b),
                 (Param::ParameterExpression(a), Param::ParameterExpression(b)) => Ok(a.eq(b)),
                 (Param::Obj(a), Param::Obj(b)) => Python::attach(|py| a.bind(py).eq(b.bind(py))),
                 _ => Ok(false),
@@ -6244,6 +6246,7 @@ impl DAGCircuit {
     pub fn set_global_phase_param(&mut self, angle: Param) -> PyResult<Param> {
         match angle {
             Param::Float(angle) => Ok(self.set_global_phase_f64(angle)),
+            Param::Int(angle) => Ok(self.set_global_phase_f64(angle as f64)),
             Param::ParameterExpression(angle) => Ok(std::mem::replace(
                 &mut self.global_phase,
                 Param::ParameterExpression(angle),
@@ -8437,7 +8440,16 @@ impl ::std::ops::Index<NodeIndex> for DAGCircuit {
 /// does not handle the full possibility of parameter values.
 /// TODO replace/merge this with add_param/radd_param
 pub(crate) fn add_global_phase(phase: &Param, other: &Param) -> Param {
-    match [phase, other] {
+    // Promote any Param::Int into Param::Float for the purposes of adding a global phase.
+    let promote = |p: &Param| -> Param {
+        match p {
+            Param::Int(i) => Param::Float(*i as f64),
+            other => other.clone(),
+        }
+    };
+    let phase = promote(phase);
+    let other = promote(other);
+    match [&phase, &other] {
         [Param::Float(a), Param::Float(b)] => Param::Float(a + b),
         [Param::Float(a), Param::ParameterExpression(b)] => {
             Param::ParameterExpression(Arc::new(b.add(&ParameterExpression::from_f64(*a)).unwrap()))

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -192,6 +192,15 @@ impl DAGOpNode {
                         [Param::Float(float_a), Param::Float(float_b)] => {
                             relative_eq!(float_a, float_b, max_relative = 1e-10)
                         }
+                        [Param::Int(int_a), Param::Int(int_b)] => int_a == int_b,
+                        [Param::Float(float_a), Param::Int(int_b)] => {
+                            let int_b = *int_b as f64;
+                            relative_eq!(float_a, &int_b, max_relative = 1e-10)
+                        }
+                        [Param::Int(int_a), Param::Float(float_b)] => {
+                            let int_a = *int_a as f64;
+                            relative_eq!(&int_a, float_b, max_relative = 1e-10)
+                        }
                         [
                             Param::ParameterExpression(param_a),
                             Param::ParameterExpression(param_b),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -38,7 +38,7 @@ use smallvec::SmallVec;
 use numpy::{PyArray1, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyTuple};
+use pyo3::types::{IntoPyDict, PyBool, PyDict, PyFloat, PyInt, PyTuple};
 use pyo3::{IntoPyObjectExt, Python, intern};
 
 // This is a convenience re-export, since basically everywhere in Qiskit expects all the
@@ -49,6 +49,7 @@ pub use crate::standard_gate::*;
 pub enum Param {
     ParameterExpression(Arc<ParameterExpression>),
     Float(f64),
+    Int(i64),
     Obj(Py<PyAny>),
 }
 
@@ -60,6 +61,7 @@ impl<'py> IntoPyObject<'py> for &Param {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
             Param::Float(value) => value.into_bound_py_any(py),
+            Param::Int(value) => value.into_bound_py_any(py),
             Param::Obj(py_obj) => py_obj.into_bound_py_any(py),
             Param::ParameterExpression(expr) => {
                 let py_expr = PyParameterExpression::from(expr.as_ref().clone());
@@ -87,6 +89,15 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Param {
             Param::ParameterExpression(Arc::new(py_expr.inner))
         } else if b.is_instance_of::<PyArray1<i32>>() {
             Param::Obj(b.to_owned().unbind())
+        } else if b.is_instance_of::<PyInt>() && !b.is_instance_of::<PyBool>() {
+            // Python ints map to Param::Int. Booleans are excluded explicitly because
+            // `bool` is a subclass of `int`, and we keep them in the Obj fallback as
+            // before.
+            match b.extract::<i64>() {
+                Ok(val) => Param::Int(val),
+                // i64 overflow: fall back to keeping the python int as an Obj.
+                Err(_) => Param::Obj(b.to_owned().unbind()),
+            }
         } else if let Ok(val) = b.extract::<f64>() {
             // TODO: remove this branch when we raise the NumPy version to 2.4.
             Param::Float(val)
@@ -97,10 +108,11 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Param {
 }
 
 impl Param {
-    /// Get the float value, if one is stored.
+    /// Get the float value, if one is stored. Integer params are promoted to float.
     pub fn try_float(&self) -> Option<f64> {
         match self {
             Self::Float(f) => Some(*f),
+            Self::Int(i) => Some(*i as f64),
             _ => None,
         }
     }
@@ -119,12 +131,36 @@ impl Param {
             [Self::Float(_), Self::Obj(_)] => Ok(false),
             [Self::Obj(_a), Self::ParameterExpression(_b)] => Ok(false),
             [Self::ParameterExpression(_a), Self::Obj(_b)] => Ok(false),
+            // Int compared with itself: exact integer equality.
+            [Self::Int(a), Self::Int(b)] => Ok(a == b),
+            // Int <-> Float: promote and compare as floats.
+            [Self::Int(a), Self::Float(b)] => Ok((*a as f64) == *b),
+            [Self::Float(a), Self::Int(b)] => Ok(*a == (*b as f64)),
+            // Int <-> ParameterExpression: compare via int-valued expression.
+            [Self::Int(a), Self::ParameterExpression(b)] => {
+                Ok(&ParameterExpression::from_i64(*a) == b.as_ref())
+            }
+            [Self::ParameterExpression(a), Self::Int(b)] => {
+                Ok(a.as_ref() == &ParameterExpression::from_i64(*b))
+            }
+            // Int <-> Obj: cross-variant comparison is false (matches Float<->Obj).
+            [Self::Int(_), Self::Obj(_)] => Ok(false),
+            [Self::Obj(_), Self::Int(_)] => Ok(false),
         }
     }
 
     pub fn is_close(&self, other: &Param, max_relative: f64) -> PyResult<bool> {
         match [self, other] {
             [Self::Float(a), Self::Float(b)] => Ok(relative_eq!(a, b, max_relative = max_relative)),
+            [Self::Int(a), Self::Int(b)] => Ok(a == b),
+            [Self::Int(a), Self::Float(b)] => {
+                let a = *a as f64;
+                Ok(relative_eq!(&a, b, max_relative = max_relative))
+            }
+            [Self::Float(a), Self::Int(b)] => {
+                let b = *b as f64;
+                Ok(relative_eq!(a, &b, max_relative = max_relative))
+            }
             _ => self.eq(other),
         }
     }
@@ -135,6 +171,7 @@ impl Param {
     pub fn iter_parameters(&self) -> PyResult<Box<dyn Iterator<Item = Symbol> + '_>> {
         match self {
             Param::Float(_) => Ok(Box::new(::std::iter::empty())),
+            Param::Int(_) => Ok(Box::new(::std::iter::empty())),
             Param::ParameterExpression(expr) => Ok(Box::new(expr.iter_symbols().cloned())),
             Param::Obj(obj) => {
                 Python::attach(|py| -> PyResult<Box<dyn Iterator<Item = Symbol>>> {
@@ -181,9 +218,7 @@ impl Param {
                     if coerce_to_float {
                         Ok(Self::Float(i as f64)) // coerce integer to float
                     } else {
-                        // Int is not a param type and only comes from Python so dump it in
-                        // there until we support DT unit delay from C
-                        Python::attach(|py| Ok(Self::Obj(i.into_py_any(py)?)))
+                        Ok(Self::Int(i))
                     }
                 }
                 Value::Real(f) => Ok(Self::Float(f)),
@@ -208,10 +243,21 @@ impl Param {
     pub fn extract_no_coerce(ob: Borrowed<PyAny>) -> PyResult<Self> {
         Ok(if ob.is_instance_of::<PyFloat>() {
             Param::Float(ob.extract()?)
+        } else if ob.is_instance_of::<PyInt>() && !ob.is_instance_of::<PyBool>() {
+            // Python ints map to Param::Int. Booleans are excluded explicitly because
+            // `bool` is a subclass of `int` and historically falls into the Obj fallback.
+            Param::Int(ob.extract()?)
         } else if let Ok(py_expr) = PyParameterExpression::extract_coerce(ob) {
             // don't get confused by the `coerce` name here -- we promise to not coerce to
-            // Param::Float. But if it's an int or complex we need to store it as an Obj.
-            if Some(true) == py_expr.inner.is_int() || Some(true) == py_expr.inner.is_complex() {
+            // Param::Float. But if it's complex we need to store it as an Obj.
+            if Some(true) == py_expr.inner.is_int() {
+                // try_to_value returns Value::Int -- store as Param::Int.
+                if let Ok(Value::Int(i)) = py_expr.inner.try_to_value(true) {
+                    Param::Int(i)
+                } else {
+                    Param::Obj(ob.to_owned().unbind())
+                }
+            } else if Some(true) == py_expr.inner.is_complex() {
                 Param::Obj(ob.to_owned().unbind())
             } else {
                 Param::ParameterExpression(Arc::new(py_expr.inner))
@@ -226,6 +272,7 @@ impl Param {
         match self {
             Param::ParameterExpression(exp) => Param::ParameterExpression(exp.clone()),
             Param::Float(float) => Param::Float(*float),
+            Param::Int(int) => Param::Int(*int),
             Param::Obj(obj) => Param::Obj(obj.clone_ref(py)),
         }
     }
@@ -237,6 +284,7 @@ impl Param {
     ) -> PyResult<Self> {
         match self {
             Param::Float(f) => Ok(Param::Float(*f)),
+            Param::Int(i) => Ok(Param::Int(*i)),
             _ => imports::DEEPCOPY
                 .get_bound(py)
                 .call1((self.clone(), memo))?
@@ -260,6 +308,13 @@ impl AsRef<Param> for Param {
 impl From<f64> for Param {
     fn from(value: f64) -> Self {
         Param::Float(value)
+    }
+}
+
+// Conveniently converts an i64 into a `Param`.
+impl From<i64> for Param {
+    fn from(value: i64) -> Self {
+        Param::Int(value)
     }
 }
 
@@ -1165,6 +1220,7 @@ impl StandardInstruction {
 pub fn clone_param(param: &Param) -> Param {
     match param {
         Param::Float(theta) => Param::Float(*theta),
+        Param::Int(theta) => Param::Int(*theta),
         Param::ParameterExpression(theta) => Param::ParameterExpression(theta.clone()),
         Param::Obj(_) => unreachable!(),
     }
@@ -1174,6 +1230,7 @@ pub fn clone_param(param: &Param) -> Param {
 pub fn multiply_param(param: &Param, mult: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(theta * mult),
+        Param::Int(theta) => Param::Float((*theta as f64) * mult),
         Param::ParameterExpression(theta) => {
             // safe to unwrap as multiplication with float does not have name conflicts
             Param::ParameterExpression(Arc::new(
@@ -1188,8 +1245,11 @@ pub fn multiply_param(param: &Param, mult: f64) -> Param {
 pub fn multiply_params(param1: Param, param2: Param) -> Param {
     match (&param1, &param2) {
         (Param::Float(theta), Param::Float(lambda)) => Param::Float(theta * lambda),
+        (Param::Int(theta), Param::Int(lambda)) => Param::Float((*theta as f64) * (*lambda as f64)),
         (param, Param::Float(theta)) => multiply_param(param, *theta),
         (Param::Float(theta), param) => multiply_param(param, *theta),
+        (param, Param::Int(theta)) => multiply_param(param, *theta as f64),
+        (Param::Int(theta), param) => multiply_param(param, *theta as f64),
         (Param::ParameterExpression(p1), Param::ParameterExpression(p2)) => {
             // TODO we could properly propagate the error here
             Param::ParameterExpression(Arc::new(p1.mul(p2).expect("Name conflict during mul.")))
@@ -1201,6 +1261,7 @@ pub fn multiply_params(param1: Param, param2: Param) -> Param {
 pub fn add_param(param: &Param, summand: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(*theta + summand),
+        Param::Int(theta) => Param::Float((*theta as f64) + summand),
         Param::ParameterExpression(theta) => Param::ParameterExpression(
             // safe to unwrap as addition with float does not have name conflicts
             Arc::new(theta.add(&ParameterExpression::from_f64(summand)).unwrap()),
@@ -1212,8 +1273,17 @@ pub fn add_param(param: &Param, summand: f64) -> Param {
 pub fn radd_param(param1: Param, param2: Param) -> Param {
     match [&param1, &param2] {
         [Param::Float(theta), Param::Float(lambda)] => Param::Float(theta + lambda),
+        [Param::Int(theta), Param::Int(lambda)] => Param::Float((*theta as f64) + (*lambda as f64)),
+        [Param::Float(theta), Param::Int(lambda)] => Param::Float(theta + (*lambda as f64)),
+        [Param::Int(theta), Param::Float(lambda)] => Param::Float((*theta as f64) + lambda),
         [Param::Float(theta), Param::ParameterExpression(_lambda)] => add_param(&param2, *theta),
         [Param::ParameterExpression(_theta), Param::Float(lambda)] => add_param(&param1, *lambda),
+        [Param::Int(theta), Param::ParameterExpression(_lambda)] => {
+            add_param(&param2, *theta as f64)
+        }
+        [Param::ParameterExpression(_theta), Param::Int(lambda)] => {
+            add_param(&param1, *lambda as f64)
+        }
         [
             Param::ParameterExpression(theta),
             Param::ParameterExpression(lambda),
@@ -1684,9 +1754,7 @@ impl PauliProductRotation {
     /// For a [PauliProductRotation] gate with a floating-point angle return a tuple `(Tr(gate) / dim, dim)`.
     /// Return `None` if the angle is parameterized.
     pub fn rotation_trace_and_dim(&self) -> Option<(Complex64, f64)> {
-        let Param::Float(angle) = self.angle else {
-            return None;
-        };
+        let angle = self.angle.try_float()?;
 
         let num_qubits = self
             .z
@@ -1840,6 +1908,78 @@ mod test {
     use qiskit_util::complex::{C_ONE, C_ZERO, IM};
 
     use crate::operations::{Param, PauliProductRotation};
+
+    #[test]
+    fn test_param_int_try_float() {
+        assert_eq!(Param::Int(42).try_float(), Some(42.0));
+        assert_eq!(Param::Float(3.5).try_float(), Some(3.5));
+    }
+
+    #[test]
+    fn test_param_int_clone_ref() {
+        // clone_ref is the safe Python-aware clone; for Int it just copies the value.
+        pyo3::Python::attach(|py| {
+            let p = Param::Int(7);
+            let p2 = p.clone_ref(py);
+            match p2 {
+                Param::Int(v) => assert_eq!(v, 7),
+                _ => panic!("expected Param::Int"),
+            }
+        });
+    }
+
+    #[test]
+    fn test_param_int_eq_int_int() {
+        assert!(Param::Int(5).eq(&Param::Int(5)).unwrap());
+        assert!(!Param::Int(5).eq(&Param::Int(6)).unwrap());
+    }
+
+    #[test]
+    fn test_param_int_eq_int_float() {
+        assert!(Param::Int(5).eq(&Param::Float(5.0)).unwrap());
+        assert!(Param::Float(5.0).eq(&Param::Int(5)).unwrap());
+        assert!(!Param::Int(5).eq(&Param::Float(5.5)).unwrap());
+    }
+
+    #[test]
+    fn test_param_int_is_close() {
+        assert!(Param::Int(5).is_close(&Param::Float(5.0), 1e-10).unwrap());
+        assert!(Param::Int(5).is_close(&Param::Int(5), 1e-10).unwrap());
+        assert!(!Param::Int(5).is_close(&Param::Float(5.1), 1e-10).unwrap());
+    }
+
+    #[test]
+    fn test_param_int_iter_parameters_empty() {
+        let p = Param::Int(5);
+        let count = p.iter_parameters().unwrap().count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_param_int_from_i64() {
+        match Param::from(42i64) {
+            Param::Int(v) => assert_eq!(v, 42),
+            _ => panic!("expected Param::Int"),
+        }
+    }
+
+    #[test]
+    fn test_param_from_expr_int() {
+        use crate::parameter::parameter_expression::ParameterExpression;
+        let expr = ParameterExpression::from_i64(7);
+        // With coerce_to_float=true, expect Float.
+        let coerced = Param::from_expr(expr.clone(), true).unwrap();
+        match coerced {
+            Param::Float(f) => assert_eq!(f, 7.0),
+            _ => panic!("expected Param::Float when coercing"),
+        }
+        // With coerce_to_float=false, expect Int.
+        let preserved = Param::from_expr(expr, false).unwrap();
+        match preserved {
+            Param::Int(i) => assert_eq!(i, 7),
+            _ => panic!("expected Param::Int when not coercing"),
+        }
+    }
 
     #[test]
     fn test_ppr_matrix() {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -308,6 +308,14 @@ impl ParameterExpression {
         }
     }
 
+    /// Initialize from an i64.
+    pub fn from_i64(value: i64) -> Self {
+        Self {
+            expr: SymbolExpr::Value(Value::Int(value)),
+            name_map: HashMap::new(),
+        }
+    }
+
     /// Load from a sequence of [OPReplay]s. Used in serialization.
     pub fn from_qpy(replay: &[OPReplay]) -> Result<Self, ParameterError> {
         // the stack contains the latest lhs and rhs values

--- a/crates/circuit/src/standard_gate/convert.rs
+++ b/crates/circuit/src/standard_gate/convert.rs
@@ -15,6 +15,7 @@ use crate::operations::{Operation, Param};
 use qiskit_quantum_info::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 
 use nalgebra::{Quaternion, Unit};
+use smallvec::SmallVec;
 use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_2, FRAC_PI_4, FRAC_PI_8};
 
 const COS_FRAC_PI_8: f64 = 0.9238795325112867;
@@ -23,6 +24,15 @@ const SIN_FRAC_PI_8: f64 = 0.3826834323650898;
 /// Conversion logic of `StandardGate::versor_u2`.
 pub fn versor_u2(gate: StandardGate, params: &[Param]) -> Result<VersorU2, VersorU2Error> {
     debug_assert_eq!(params.len(), gate.num_params() as usize);
+    // Promote Param::Int to Param::Float so the existing pattern matches work.
+    let promoted: SmallVec<[Param; 4]> = params
+        .iter()
+        .map(|p| match p {
+            Param::Int(i) => Param::Float(*i as f64),
+            _ => p.clone(),
+        })
+        .collect();
+    let params = promoted.as_slice();
     match gate {
         StandardGate::GlobalPhase => {
             let &[Param::Float(phase)] = params else {

--- a/crates/circuit/src/standard_gate/mod.rs
+++ b/crates/circuit/src/standard_gate/mod.rs
@@ -317,6 +317,15 @@ impl StandardGate {
     }
 
     pub fn matrix(&self, params: &[Param]) -> Option<Array2<Complex64>> {
+        // Promote Param::Int to Param::Float so the existing pattern matches work.
+        let promoted: SmallVec<[Param; 4]> = params
+            .iter()
+            .map(|p| match p {
+                Param::Int(i) => Param::Float(*i as f64),
+                _ => p.clone(),
+            })
+            .collect();
+        let params = promoted.as_slice();
         match self {
             Self::GlobalPhase => match params {
                 [Param::Float(theta)] => {
@@ -551,6 +560,15 @@ impl StandardGate {
     }
 
     pub fn definition(&self, params: &[Param]) -> Option<CircuitData> {
+        // Promote Param::Int to Param::Float so the existing pattern matches work.
+        let promoted: SmallVec<[Param; 4]> = params
+            .iter()
+            .map(|p| match p {
+                Param::Int(i) => Param::Float(*i as f64),
+                _ => p.clone(),
+            })
+            .collect();
+        let params = promoted.as_slice();
         match self {
             Self::GlobalPhase => Some(
                 CircuitData::from_standard_gates(0, [], params[0].clone())
@@ -1588,6 +1606,15 @@ impl StandardGate {
     }
 
     pub fn matrix_as_static_1q(&self, params: &[Param]) -> Option<[[Complex64; 2]; 2]> {
+        // Promote Param::Int to Param::Float so the existing pattern matches work.
+        let promoted: SmallVec<[Param; 4]> = params
+            .iter()
+            .map(|p| match p {
+                Param::Int(i) => Param::Float(*i as f64),
+                _ => p.clone(),
+            })
+            .collect();
+        let params = promoted.as_slice();
         match self {
             Self::GlobalPhase => None,
             Self::H => match params {
@@ -1709,6 +1736,15 @@ impl StandardGate {
     }
 
     pub fn matrix_as_static_2q(&self, params: &[Param]) -> Option<[[Complex64; 4]; 4]> {
+        // Promote Param::Int to Param::Float so the existing pattern matches work.
+        let promoted: SmallVec<[Param; 4]> = params
+            .iter()
+            .map(|p| match p {
+                Param::Int(i) => Param::Float(*i as f64),
+                _ => p.clone(),
+            })
+            .collect();
+        let params = promoted.as_slice();
         match self {
             Self::GlobalPhase => None,
             Self::H => None,

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -59,6 +59,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
         .iter()
         .map(|p| match p {
             Param::Float(f) => *f,
+            Param::Int(i) => *i as f64,
             Param::ParameterExpression(_) => 1.0,
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
         })

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1178,8 +1178,10 @@ impl<'a> QASM3Builder {
         let param = &instr.params_view()[0];
         let duration: f64 = Python::attach(|py| match param {
             Param::Float(val) => *val,
+            Param::Int(val) => *val as f64,
             Param::ParameterExpression(p) => match p.try_to_value(true) {
                 Ok(symbol_expr::Value::Real(val)) => val,
+                Ok(symbol_expr::Value::Int(val)) => val as f64,
                 _ => {
                     panic!("Failed to parse parameter value")
                 }
@@ -1261,6 +1263,9 @@ impl<'a> QASM3Builder {
                     .iter()
                     .map(|param| match param {
                         Param::Float(val) => Expression::Parameter(Parameter {
+                            obj: val.to_string(),
+                        }),
+                        Param::Int(val) => Expression::Parameter(Parameter {
                             obj: val.to_string(),
                         }),
                         Param::ParameterExpression(p) => {

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -293,6 +293,7 @@ pub fn instruction_values_to_params(
             .map(|value| -> Result<_, QpyError> {
                 match value {
                     GenericValue::Float64(float) => Ok(Param::Float(float)),
+                    GenericValue::Int64(int) => Ok(Param::Int(int)),
                     GenericValue::ParameterExpression(exp) => Ok(Param::ParameterExpression(exp)),
                     GenericValue::ParameterExpressionSymbol(symbol) => {
                         Ok(Param::ParameterExpression(Arc::new(

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -622,6 +622,16 @@ pub(crate) fn pack_param_obj(
                 data: val.to_be_bytes().into(),
             },
         },
+        Param::Int(val) => match endian {
+            Endian::Little => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: val.to_le_bytes().into(),
+            },
+            Endian::Big => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: val.to_be_bytes().into(),
+            },
+        },
         Param::ParameterExpression(exp) => pack_param_expression(exp, qpy_data)?,
         Param::Obj(py_object) => {
             Python::attach(|py| py_pack_param(py_object.bind(py), qpy_data, endian))?
@@ -632,6 +642,7 @@ pub(crate) fn pack_param_obj(
 pub(crate) fn generic_value_to_param(value: &GenericValue) -> Result<Param, QpyError> {
     match value {
         GenericValue::Float64(float_val) => Ok(Param::Float(*float_val)),
+        GenericValue::Int64(int_val) => Ok(Param::Int(*int_val)),
         GenericValue::ParameterExpressionSymbol(symbol) => {
             let parameter_expression = ParameterExpression::from_symbol(symbol.clone());
             Ok(Param::ParameterExpression(Arc::new(parameter_expression)))

--- a/crates/synthesis/src/matrix/sim.rs
+++ b/crates/synthesis/src/matrix/sim.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use numpy::IntoPyArray;
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
-use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
+use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
 use qiskit_quantum_info::unitary_compose;
 
 use crate::QiskitError;
@@ -39,8 +39,8 @@ pub fn sim_unitary_circuit(circuit: &CircuitData) -> Result<Array2<Complex64>, S
     }
 
     // e^{i * global_phase}
-    let global_phase_exp: Complex64 = if let Param::Float(p) = circuit.global_phase() {
-        Complex64::new(0., *p).exp()
+    let global_phase_exp: Complex64 = if let Some(p) = circuit.global_phase().try_float() {
+        Complex64::new(0., p).exp()
     } else {
         return Err("Cannot simulate circuit involving non-float global phase.".to_string());
     };

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -876,7 +876,7 @@ fn map_rotation<'a>(
             // If the rotation angle is below the tolerance, the gate is assumed to
             // commute with everything, and we simply return the operation with the flag that
             // it commutes trivially.
-            if let Param::Float(angle) = params[0] {
+            if let Some(angle) = params[0].try_float() {
                 let (tr_over_dim, dim) = gate_metrics::rotation_trace_and_dim(*gate, angle)
                     .expect("All rotation should be covered at this point");
                 let gate_fidelity = tr_over_dim.abs().powi(2);

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -684,7 +684,7 @@ fn replace_node(
                 dag.add_global_phase(&param)
                     .map_err(|e| BasisTranslatorError::BasisDAGCircuitError(e.to_string()))
             }
-            Param::Float(_) => dag
+            Param::Float(_) | Param::Int(_) => dag
                 .add_global_phase(target_dag.global_phase())
                 .map_err(|e| BasisTranslatorError::BasisDAGCircuitError(e.to_string())),
             Param::Obj(_) => Ok(()),
@@ -707,6 +707,9 @@ fn param_expr_assignment(
             }
             Param::Float(val) => {
                 bind_map.insert(key, Value::Real(*val));
+            }
+            Param::Int(val) => {
+                bind_map.insert(key, Value::Int(*val));
             }
             Param::Obj(val) => {
                 let val = Python::attach(|py| val.extract::<Value>(py))

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -97,7 +97,7 @@ where
                 return Ok(Some(0.));
             }
             StandardGate::GlobalPhase => {
-                if let Param::Float(angle) = inst.params_view()[0] {
+                if let Some(angle) = inst.params_view()[0].try_float() {
                     return Ok(Some(angle));
                 } else {
                     // We cannot get here since we skip parameterized gates,
@@ -119,7 +119,7 @@ where
             | StandardGate::CRZ
             | StandardGate::CU1
             | StandardGate::CPhase => {
-                if let Param::Float(angle) = inst.params_view()[0] {
+                if let Some(angle) = inst.params_view()[0].try_float() {
                     let (tr_over_dim, dim) = rotation_trace_and_dim(gate, angle).expect(
                         "Since only supported rotation gates are given, the result is not None",
                     );

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -1114,7 +1114,7 @@ pub fn py_run_substitute_pi4_rotations(
             continue;
         }
 
-        let angle = if let Param::Float(angle) = inst.params_view()[0] {
+        let angle = if let Some(angle) = inst.params_view()[0].try_float() {
             angle
         } else {
             new_dag.push_back(inst.clone())?;

--- a/crates/transpiler/src/passes/synthesize_rz_rotations.rs
+++ b/crates/transpiler/src/passes/synthesize_rz_rotations.rs
@@ -143,7 +143,7 @@ pub fn py_run_synthesize_rz_rotations(
         .op_nodes(false)
         .filter_map(|(node_index, inst)| {
             if let OperationRef::StandardGate(StandardGate::RZ) = inst.op.view() {
-                if let Param::Float(angle) = inst.params_view()[0] {
+                if let Some(angle) = inst.params_view()[0].try_float() {
                     let (interval_index, canonical_angle) = canonicalize_angle(angle);
                     Some((node_index, canonical_angle, interval_index))
                 } else {

--- a/crates/transpiler/src/passes/wrap_angles.rs
+++ b/crates/transpiler/src/passes/wrap_angles.rs
@@ -18,7 +18,7 @@ use crate::angle_bound_registry::{PyWrapAngleRegistry, WrapAngleRegistry};
 use crate::target::Target;
 use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::operations::{Operation, Param};
+use qiskit_circuit::operations::Operation;
 
 #[pyfunction]
 #[pyo3(name = "wrap_angles")]
@@ -53,12 +53,7 @@ pub fn run_wrap_angles(
         let params: Vec<_> = inst
             .params_view()
             .iter()
-            .map(|param| {
-                let Param::Float(param) = param else {
-                    unreachable!()
-                };
-                *param
-            })
+            .map(|param| param.try_float().expect("only numeric params reach here"))
             .collect();
         if !target.gate_supported_angle_bound(inst.op.name(), &params) {
             let qargs: Vec<_> = dag

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -1407,14 +1407,13 @@ impl Target {
                 }
                 if check_angle_bounds
                     && self.has_angle_bounds()
-                    && parameters.iter().all(|x| matches!(x, Param::Float(_)))
+                    && parameters
+                        .iter()
+                        .all(|x| matches!(x, Param::Float(_) | Param::Int(_)))
                 {
                     let params: Vec<f64> = parameters
                         .iter()
-                        .map(|x| {
-                            let Param::Float(val) = x else { unreachable!() };
-                            *val
-                        })
+                        .map(|x| x.try_float().expect("checked above"))
                         .collect();
                     if self.angle_bounds.contains_key(operation_name)
                         && !self.gate_supported_angle_bound(operation_name, &params)
@@ -1542,11 +1541,9 @@ impl Target {
         let num_params = match operation {
             TargetOperation::Normal(op) => {
                 let params = op.params_view();
-                if params
-                    .iter()
-                    .zip(bounds)
-                    .any(|(param, bound)| bound.is_some() && matches!(param, Param::Float(_)))
-                {
+                if params.iter().zip(bounds).any(|(param, bound)| {
+                    bound.is_some() && matches!(param, Param::Float(_) | Param::Int(_))
+                }) {
                     return Err(TargetError::InvalidKey(
                         "Angle bound set on a fixed value".to_string(),
                     ));
@@ -1661,7 +1658,18 @@ fn check_obj_params(parameters: &[Param], obj: &NormalOperation) -> bool {
                     return false;
                 }
             }
+            (Param::Int(p1), Param::Int(p2)) => {
+                if p1 != p2 {
+                    return false;
+                }
+            }
+            (Param::Float(p1), Param::Int(p2)) | (Param::Int(p2), Param::Float(p1)) => {
+                if *p1 != (*p2 as f64) {
+                    return false;
+                }
+            }
             (&Param::ParameterExpression(_), Param::Float(_)) => return false,
+            (&Param::ParameterExpression(_), Param::Int(_)) => return false,
             (&Param::ParameterExpression(_), Param::Obj(_)) => return false,
             _ => continue,
         }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1146,12 +1146,42 @@ static int test_delay_instruction(void) {
     int result = Ok;
 
     QkExitCode delay_s_code;
+    QkCircuitInstruction inst;
 
     delay_s_code = qk_circuit_delay(qc, 0, 0.001, QkDelayUnit_S);
     if (delay_s_code != QkExitCode_Success) {
         result = RuntimeError;
         goto cleanup;
     }
+
+    // Append a dt-unit delay with an integer duration. Reading it back via
+    // qk_circuit_get_instruction must not panic and must round-trip the integer
+    // duration through qk_param_as_int.
+    QkExitCode delay_dt_code = qk_circuit_delay_dt(qc, 1, 100);
+    if (delay_dt_code != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    qk_circuit_get_instruction(qc, 1, &inst);
+    if (inst.num_params != 1) {
+        result = EqualityError;
+        qk_circuit_instruction_clear(&inst);
+        goto cleanup;
+    }
+    int64_t duration_int = qk_param_as_int(inst.params[0]);
+    if (duration_int != 100) {
+        result = EqualityError;
+        qk_circuit_instruction_clear(&inst);
+        goto cleanup;
+    }
+    double duration_real = qk_param_as_real(inst.params[0]);
+    if (duration_real != 100.0) {
+        result = EqualityError;
+        qk_circuit_instruction_clear(&inst);
+        goto cleanup;
+    }
+    qk_circuit_instruction_clear(&inst);
 
 cleanup:
     qk_circuit_free(qc);


### PR DESCRIPTION
This PR is one of three RFCs solving the same problem: dt-unit delays cannot round-trip through the C API because their integer duration is stored as `Param::Obj(PyAny)`, which `qk_circuit_get_instruction` does not accept.

This branch takes the most uniform fix. The `Param` enum gains an `Int(i64)` variant alongside `Float`, `ParameterExpression`, and `Obj`. `FromPyObject for Param` now sends every Python `int` to `Param::Int` (booleans excepted), so the dt-Delay duration carries integer-ness all the way through Rust, QPY, and the C API. The C side gets `qk_param_from_int`, `qk_param_as_int`, `CDelayUnit::DT`, and `qk_circuit_delay_dt`. QPY needs no format bump — the wire format already had an `Integer` type byte that previously round-tripped through `Param::Obj`.

The cost is breadth: every match site over `Param` needs a new arm. I handled the standard-gate pattern matches (~60 of them) by promoting `Int → Float` in a `SmallVec` at the entry of `matrix()`, `definition()`, and the static-1q/2q variants, so the existing patterns keep working without per-arm edits. Other call sites use `Param::try_float()`, which I extended to return `Some(i as f64)` for `Int`. `Param::eq` and `is_close` cross-compare `Int↔Float` by promotion.

The other two RFCs are #16226 (a smaller patch that gives up integer-ness) and `c-dt-delay-3` (an arena-based approach that's quite different and perhaps less scope).

Partially addresses https://github.com/Qiskit/qiskit/issues/16121.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
