### PR TITLE
RFC3: Move Delay value storage to a typed arena

### DIFF
--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
-use qiskit_circuit::operations::{DelayUnit, Operation, OperationRef, Param, StandardInstruction};
+use qiskit_circuit::operations::{DelayUnit, Operation, OperationRef, StandardInstruction};
 
 use qiskit_transpiler::target::Target;
 
@@ -40,37 +40,39 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                         qubits.iter().map(|x| PhysicalQubit::new(x.0)).collect();
 
                     if let OperationRef::StandardInstruction(op) = inst.op.view() {
-                        if let StandardInstruction::Delay(unit) = op {
-                            let dur = &inst.params_view()[0];
-                            return if unit == DelayUnit::DT {
-                                if let Some(dt) = dt {
-                                    match dur {
-                                        Param::Float(val) => Ok(val * dt),
-                                        Param::Obj(val) => Python::attach(|py| {
-                                            let dur_float: f64 = val.extract(py)?;
-                                            Ok(dur_float * dt)
-                                        }),
-                                        Param::ParameterExpression(_) => Err(QiskitError::new_err(
-                                            "Circuit contains parameterized delays, can't compute a duration estimate with this circuit",
+                        if let StandardInstruction::Delay(handle) = op {
+                            return handle.with(|unit, data| -> PyResult<f64> {
+                                use qiskit_circuit::delay_arena::DelayDuration;
+                                if unit == DelayUnit::DT {
+                                    if let Some(dt) = dt {
+                                        match data {
+                                            DelayDuration::Int(i) => Ok(*i as f64 * dt),
+                                            DelayDuration::Float(f) => Ok(f * dt),
+                                            DelayDuration::Expr(_) | DelayDuration::PyObj(_) => {
+                                                Err(QiskitError::new_err(
+                                                    "Circuit contains parameterized delays, can't compute a duration estimate with this circuit",
+                                                ))
+                                            }
+                                        }
+                                    } else {
+                                        Err(QiskitError::new_err(
+                                            "Circuit contains delays in dt but the target doesn't specify dt",
+                                        ))
+                                    }
+                                } else if unit == DelayUnit::S {
+                                    match data {
+                                        DelayDuration::Float(f) => Ok(*f),
+                                        DelayDuration::Int(i) => Ok(*i as f64),
+                                        _ => Err(QiskitError::new_err(
+                                            "Invalid type for parameter value for delay in circuit",
                                         )),
                                     }
                                 } else {
                                     Err(QiskitError::new_err(
-                                        "Circuit contains delays in dt but the target doesn't specify dt",
+                                        "Circuit contains delays in units other then seconds or dt, the circuit is not scheduled.",
                                     ))
                                 }
-                            } else if unit == DelayUnit::S {
-                                match dur {
-                                    Param::Float(val) => Ok(*val),
-                                    _ => Err(QiskitError::new_err(
-                                        "Invalid type for parameter value for delay in circuit",
-                                    )),
-                                }
-                            } else {
-                                Err(QiskitError::new_err(
-                                    "Circuit contains delays in units other then seconds or dt, the circuit is not scheduled.",
-                                ))
-                            };
+                            });
                         } else if let StandardInstruction::Barrier(_) = op {
                             return Ok(0.);
                         }

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -80,6 +80,8 @@ mod circuit {
             export_fn!(qk_circuit_instruction_clear),
             export_fn!(qk_opcounts_clear),
             export_fn!(qk_circuit_delay),
+            export_fn!(qk_circuit_delay_dt),
+            export_fn!(qk_circuit_get_delay),
             export_fn!(qk_circuit_to_dag),
             export_fn!(qk_circuit_copy_empty_like),
             export_fn!(qk_circuit_num_param_symbols),

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1909,29 +1909,41 @@ pub enum CDelayUnit {
     NS = 3,
     /// Picoseconds.
     PS = 4,
+    /// Number of dt sample periods.  Use [`qk_circuit_delay_dt`] to construct dt
+    /// delays from C; the duration is an integer number of samples in that case
+    /// rather than a `double`.
+    DT = 5,
 }
 
-impl From<CDelayUnit> for DelayUnit {
-    fn from(value: CDelayUnit) -> Self {
-        match value {
+impl TryFrom<CDelayUnit> for DelayUnit {
+    type Error = ExitCode;
+    fn try_from(value: CDelayUnit) -> Result<Self, Self::Error> {
+        Ok(match value {
             CDelayUnit::S => DelayUnit::S,
             CDelayUnit::MS => DelayUnit::MS,
             CDelayUnit::US => DelayUnit::US,
             CDelayUnit::NS => DelayUnit::NS,
             CDelayUnit::PS => DelayUnit::PS,
-        }
+            CDelayUnit::DT => DelayUnit::DT,
+        })
     }
 }
 
 /// @ingroup QkCircuit
 /// Append a delay instruction to the circuit.
 ///
+/// For ``dt`` durations, use ``qk_circuit_delay_dt`` instead — that function takes an
+/// ``int64_t`` duration to preserve the integer-vs-float distinction the Python
+/// data model enforces.
+///
 /// @param circuit A pointer to the circuit to add the delay to.
 /// @param qubit The ``uint32_t`` index of the qubit to apply the delay to.
 /// @param duration The duration of the delay.
-/// @param unit An enum representing the unit of the duration.
+/// @param unit An enum representing the unit of the duration.  Must not be
+///     ``QkDelayUnit_DT``; use ``qk_circuit_delay_dt`` for that.
 ///
-/// @return An exit code.
+/// @return An exit code.  ``QkExitCode_CInputError`` if ``unit`` is
+///     ``QkDelayUnit_DT``.
 ///
 /// # Example
 /// ```c
@@ -1949,25 +1961,188 @@ pub unsafe extern "C" fn qk_circuit_delay(
     duration: f64,
     unit: CDelayUnit,
 ) -> ExitCode {
+    if matches!(unit, CDelayUnit::DT) {
+        return ExitCode::CInputError;
+    }
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
 
-    let delay_unit_variant = unit.into();
+    let delay_unit_variant: DelayUnit = match unit.try_into() {
+        Ok(u) => u,
+        Err(e) => return e,
+    };
 
-    let duration_param: Param = duration.into();
-    let delay_instruction = StandardInstruction::Delay(delay_unit_variant);
+    let handle = qiskit_circuit::delay_arena::DelayHandle::new(
+        delay_unit_variant,
+        qiskit_circuit::delay_arena::DelayDuration::Float(duration),
+    );
+    let delay_instruction = StandardInstruction::Delay(handle);
 
-    let params = Parameters::Params(smallvec![duration_param]);
     circuit
         .push_packed_operation(
             PackedOperation::from_standard_instruction(delay_instruction),
-            Some(params),
+            None,
             &[Qubit(qubit)],
             &[],
         )
         .unwrap();
 
     ExitCode::Success
+}
+
+/// @ingroup QkCircuit
+/// Append a ``dt``-unit delay instruction to the circuit.
+///
+/// The ``dt`` unit measures duration in integer numbers of the backend's sample
+/// period.  The Python data model rejects non-integer (and negative) ``dt``
+/// durations; this function returns ``QkExitCode_CInputError`` for negative
+/// values to mirror that contract.
+///
+/// @param circuit A pointer to the circuit to add the delay to.
+/// @param qubit The ``uint32_t`` index of the qubit to apply the delay to.
+/// @param duration The duration of the delay, in dt samples.  Must be non-negative.
+///
+/// @return An exit code.
+///
+/// # Example
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(1, 0);
+///     qk_circuit_delay_dt(qc, 0, 100);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_delay_dt(
+    circuit: *mut CircuitData,
+    qubit: u32,
+    duration: i64,
+) -> ExitCode {
+    if duration < 0 {
+        return ExitCode::CInputError;
+    }
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { mut_ptr_as_ref(circuit) };
+
+    let handle = qiskit_circuit::delay_arena::DelayHandle::new(
+        DelayUnit::DT,
+        qiskit_circuit::delay_arena::DelayDuration::Int(duration),
+    );
+    let delay_instruction = StandardInstruction::Delay(handle);
+
+    circuit
+        .push_packed_operation(
+            PackedOperation::from_standard_instruction(delay_instruction),
+            None,
+            &[Qubit(qubit)],
+            &[],
+        )
+        .unwrap();
+
+    ExitCode::Success
+}
+
+/// @ingroup QkCircuit
+///
+/// Tag identifying which payload field of [`QkDelayDuration`] is populated.
+#[repr(u8)]
+pub enum CDelayDurationKind {
+    /// `value_int` is populated.
+    Int = 0,
+    /// `value_float` is populated.
+    Float = 1,
+    /// The duration is symbolic; no scalar value is exposed.
+    Expr = 2,
+}
+
+/// @ingroup QkCircuit
+/// Read back the unit and duration of a delay instruction in the circuit.
+///
+/// On success, ``unit_out``, ``kind_out``, and one of ``value_int_out`` /
+/// ``value_float_out`` (depending on ``kind_out``) are populated.  When
+/// ``kind_out`` is ``QkDelayDurationKind_Expr`` neither ``value_int_out`` nor
+/// ``value_float_out`` is written; symbolic delay durations are not exposed
+/// through this accessor.
+///
+/// @param circuit A pointer to the circuit.
+/// @param index The instruction index in the circuit.
+/// @param unit_out Output pointer for the unit.
+/// @param kind_out Output pointer for the duration kind discriminator.
+/// @param value_int_out Output pointer for the duration value when the kind is
+///     ``Int``.  May be NULL only if the caller already knows the kind cannot be
+///     ``Int``.
+/// @param value_float_out Output pointer for the duration value when the kind is
+///     ``Float``.  May be NULL only if the caller already knows the kind cannot
+///     be ``Float``.
+///
+/// @return ``QkExitCode_Success`` if the instruction is a delay; otherwise an
+///     error code.
+///
+/// # Safety
+///
+/// All output pointers must be non-NULL when the corresponding kind is
+/// produced.  The circuit pointer must be valid and aligned.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_get_delay(
+    circuit: *const CircuitData,
+    index: usize,
+    unit_out: *mut CDelayUnit,
+    kind_out: *mut CDelayDurationKind,
+    value_int_out: *mut i64,
+    value_float_out: *mut f64,
+) -> ExitCode {
+    // SAFETY: per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    let Some(inst) = circuit.data().get(index) else {
+        return ExitCode::IndexError;
+    };
+    let qiskit_circuit::operations::OperationRef::StandardInstruction(StandardInstruction::Delay(
+        handle,
+    )) = inst.op.view()
+    else {
+        return ExitCode::CInputError;
+    };
+    handle.with(|unit, data| {
+        let c_unit = match unit {
+            DelayUnit::S => CDelayUnit::S,
+            DelayUnit::MS => CDelayUnit::MS,
+            DelayUnit::US => CDelayUnit::US,
+            DelayUnit::NS => CDelayUnit::NS,
+            DelayUnit::PS => CDelayUnit::PS,
+            DelayUnit::DT => CDelayUnit::DT,
+            DelayUnit::EXPR => {
+                // EXPR-unit delays correspond to classical-Expr durations; we
+                // surface the kind as Expr and don't expose a scalar.  We still
+                // need to write *something* into `unit_out`, but there is no
+                // matching `CDelayUnit` variant — fall back to `S` and rely on
+                // `kind_out == Expr` to signal "no scalar".
+                // SAFETY: caller-supplied pointers are valid per docs.
+                unsafe {
+                    *unit_out = CDelayUnit::S;
+                    *kind_out = CDelayDurationKind::Expr;
+                }
+                return ExitCode::Success;
+            }
+        };
+        // SAFETY: caller-supplied pointer is valid per docs.
+        unsafe { *unit_out = c_unit };
+        match data {
+            qiskit_circuit::delay_arena::DelayDuration::Int(i) => unsafe {
+                *kind_out = CDelayDurationKind::Int;
+                *value_int_out = *i;
+            },
+            qiskit_circuit::delay_arena::DelayDuration::Float(f) => unsafe {
+                *kind_out = CDelayDurationKind::Float;
+                *value_float_out = *f;
+            },
+            qiskit_circuit::delay_arena::DelayDuration::Expr(_)
+            | qiskit_circuit::delay_arena::DelayDuration::PyObj(_) => unsafe {
+                *kind_out = CDelayDurationKind::Expr;
+            },
+        };
+        ExitCode::Success
+    })
 }
 
 /// The configuration options for the ``qk_circuit_draw`` function.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -30,7 +30,7 @@ use crate::interner::{Interned, InternedMap, Interner};
 use crate::object_registry::{self, ObjectRegistry};
 use crate::operations::{
     ControlFlow, ControlFlowView, Operation, OperationRef, Param, PauliBased, PyOperationTypes,
-    PythonOperation, StandardGate,
+    PythonOperation, StandardGate, StandardInstruction,
 };
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::parameter::parameter_expression::{ParameterError, ParameterExpression};
@@ -879,6 +879,24 @@ impl CircuitData {
         instruction_index: usize,
     ) -> Result<(), CircuitDataError> {
         let instr = &self.data[instruction_index];
+        // Delay instructions store their duration off the params list, in the global
+        // delay arena.  Track parameters on the duration explicitly here.
+        if let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) =
+            instr.op.view()
+        {
+            handle.with(|_unit, data| -> Result<(), CircuitDataError> {
+                if let crate::delay_arena::DelayDuration::Expr(expr) = data {
+                    let usage = ParameterUse::DelayDuration {
+                        instruction: instruction_index,
+                    };
+                    for symbol in expr.iter_symbols() {
+                        self.param_table.track(symbol, Some(usage))?;
+                    }
+                }
+                Ok(())
+            })?;
+            return Ok(());
+        }
         let Some(parameters) = self.data[instruction_index].params.as_deref() else {
             return Ok(());
         };
@@ -916,6 +934,23 @@ impl CircuitData {
         instruction_index: usize,
     ) -> Result<(), CircuitDataError> {
         let instr = &self.data[instruction_index];
+        // Mirror `track_instruction_parameters`'s Delay branch.
+        if let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) =
+            instr.op.view()
+        {
+            handle.with(|_unit, data| -> Result<(), CircuitDataError> {
+                if let crate::delay_arena::DelayDuration::Expr(expr) = data {
+                    let usage = ParameterUse::DelayDuration {
+                        instruction: instruction_index,
+                    };
+                    for symbol in expr.iter_symbols() {
+                        self.param_table.untrack(symbol, usage)?;
+                    }
+                }
+                Ok(())
+            })?;
+            return Ok(());
+        }
         let Some(parameters) = self.data[instruction_index].params.as_deref() else {
             return Ok(());
         };
@@ -1436,6 +1471,94 @@ impl CircuitData {
                                 }
                                 Ok(())
                             })?;
+                        }
+                    }
+                    ParameterUse::DelayDuration { instruction } => {
+                        // Substitute `symbol -> value` inside the Delay's duration
+                        // expression, validate against the Python `Delay`'s rules
+                        // (e.g. `dt` durations must be non-negative integers), allocate
+                        // a fresh `DelayHandle` for the result, and replace the
+                        // instruction's `PackedOperation`.  The old operation drops,
+                        // releasing one rc unit on the previous arena slot.
+                        let previous_op = &self.data[instruction].op;
+                        let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) =
+                            previous_op.view()
+                        else {
+                            inconsistent()
+                        };
+                        let (unit, new_data) = handle.with(|unit, data| -> Result<_, CircuitDataError> {
+                            let crate::delay_arena::DelayDuration::Expr(expr) = data else {
+                                inconsistent()
+                            };
+                            // Reuse `bind_expr`'s machinery, then re-classify the
+                            // result back into a `DelayDuration`.  We pass
+                            // `coerce=false` so an integer assignment to a `dt`
+                            // delay survives as `Param::Obj` (carrying an int).
+                            let bound = bind_expr(expr, &symbol, value.as_ref(), false)?;
+                            // Run the Python-side validator to catch unit-specific
+                            // constraints (e.g. negative or fractional `dt`
+                            // durations).  Construct a fresh `Delay(duration, unit)`
+                            // — its constructor invokes `validate_parameter`.
+                            let validated_data = Python::attach(|py| -> PyResult<_> {
+                                let delay_cls = crate::imports::DELAY.get_bound(py);
+                                let validated_dur =
+                                    match &bound {
+                                        Param::Float(f) => f.into_py_any(py)?,
+                                        Param::ParameterExpression(e) => {
+                                            crate::parameter::parameter_expression::PyParameterExpression::from(e.as_ref().clone())
+                                                .coerce_into_py(py)?
+                                        }
+                                        Param::Obj(obj) => obj.clone_ref(py),
+                                    };
+                                let validated_delay = delay_cls
+                                    .call1((validated_dur, unit.to_string()))?;
+                                let validated_dur = validated_delay
+                                    .getattr(intern!(py, "duration"))?;
+                                // Re-classify the validated Python value back into a
+                                // `DelayDuration`.  This handles the case where the
+                                // validator coerced (e.g.) a fully-bound expression
+                                // down to an `int`.
+                                crate::circuit_instruction::extract_delay_duration(
+                                    validated_dur.as_borrowed(),
+                                )
+                            })?;
+                            Ok((unit, validated_data))
+                        })?;
+                        let new_handle = crate::delay_arena::DelayHandle::new(unit, new_data);
+                        let previous = &mut self.data[instruction];
+                        previous.op = PackedOperation::from_standard_instruction(
+                            StandardInstruction::Delay(new_handle),
+                        );
+                        #[cfg(feature = "cache_pygates")]
+                        {
+                            previous.py_op.take();
+                        }
+                        // Re-track any unbound symbols that survived in the new
+                        // expression — note that bind_expr may collapse to a value,
+                        // in which case there are no symbols to add a use for.
+                        for uuid in uuids.iter() {
+                            // Only re-add the uuid if its symbol still appears in
+                            // the duration; the `track` above already pre-recorded
+                            // the symbol as known but with no usages.
+                            let new_op = &self.data[instruction].op;
+                            if let OperationRef::StandardInstruction(StandardInstruction::Delay(
+                                h,
+                            )) = new_op.view()
+                            {
+                                let still_used = h.with(|_unit, data| {
+                                    if let crate::delay_arena::DelayDuration::Expr(expr) = data {
+                                        expr.iter_symbols().any(|s| {
+                                            crate::parameter_table::ParameterUuid::from_symbol(s)
+                                                == *uuid
+                                        })
+                                    } else {
+                                        false
+                                    }
+                                });
+                                if still_used {
+                                    self.param_table.add_use(*uuid, usage)?;
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -12,6 +12,7 @@
 
 use crate::bit::{ClassicalRegister, ShareableClbit, ShareableQubit};
 use crate::circuit_data::CircuitData;
+use crate::delay_arena::DelayDuration;
 use crate::operations::{Operation, OperationRef, Param, StandardGate, StandardInstruction};
 use crate::packed_instruction::PackedInstruction;
 use crate::{Clbit, Qubit};
@@ -830,28 +831,21 @@ impl TextDrawer {
 
     fn get_label(instruction: &PackedInstruction) -> String {
         match instruction.op.view() {
-            OperationRef::StandardInstruction(std_instruction) => {
-                match std_instruction {
-                    StandardInstruction::Measure => "M".to_string(),
-                    StandardInstruction::Reset => "|0>".to_string(),
-                    StandardInstruction::Barrier(_) => BARRIER.to_string(),
-                    StandardInstruction::Delay(delay_unit) => {
-                        match instruction.params_view().first().unwrap() {
-                            Param::Float(duration) => {
-                                format!(
-                                    "Delay({}[{}])",
-                                    F64UiFormatter::new(5).format(*duration),
-                                    delay_unit
-                                )
-                            }
-                            Param::ParameterExpression(expr) => {
-                                format!("Delay({}[{}])", expr, delay_unit)
-                            }
-                            Param::Obj(obj) => format!("Delay({:?}[{}])", obj, delay_unit), // TODO: extract the int
-                        }
+            OperationRef::StandardInstruction(std_instruction) => match std_instruction {
+                StandardInstruction::Measure => "M".to_string(),
+                StandardInstruction::Reset => "|0>".to_string(),
+                StandardInstruction::Barrier(_) => BARRIER.to_string(),
+                StandardInstruction::Delay(handle) => handle.with(|unit, data| match data {
+                    DelayDuration::Int(i) => format!("Delay({i}[{unit}])"),
+                    DelayDuration::Float(f) => {
+                        format!("Delay({}[{}])", F64UiFormatter::new(5).format(*f), unit)
                     }
-                }
-            }
+                    DelayDuration::Expr(expr) => format!("Delay({}[{}])", expr, unit),
+                    DelayDuration::PyObj(obj) => {
+                        format!("Delay({:?}[{}])", obj, unit)
+                    }
+                }),
+            },
             OperationRef::StandardGate(standard_gate) => {
                 static STANDARD_GATE_LABELS: [&str; crate::operations::STANDARD_GATE_SIZE] = [
                     "", "H", "I", "X", "Y", "Z", "P", "R", "Rx", "Ry", "Rz", "S", "Sdg", "√X",
@@ -1506,13 +1500,11 @@ pub fn format_float_pi(f: f64) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use ndarray::Array2;
-    use smallvec::smallvec;
     use std::f64::consts::PI;
     use std::sync::Arc;
 
     use super::*;
     use crate::bit::{ClassicalRegister, QuantumRegister, ShareableClbit, ShareableQubit};
-    use crate::instruction::Parameters;
     use crate::operations::{
         ArrayType, DelayUnit, PauliBased, PauliProductMeasurement, PauliProductRotation,
         STANDARD_GATE_SIZE, StandardInstruction, UnitaryGate,
@@ -2164,12 +2156,15 @@ q_1: ┤1        ├┤1           ├┤1        ├
                 DelayUnit::MS,
                 DelayUnit::S,
             ] {
-                let param = Param::Float(2.1);
+                let handle = crate::delay_arena::DelayHandle::new(
+                    unit,
+                    crate::delay_arena::DelayDuration::Float(2.1),
+                );
                 let inst = PackedInstruction {
-                    op: StandardInstruction::Delay(unit).into(),
+                    op: StandardInstruction::Delay(handle).into(),
                     qubits: circuit.add_qargs(&[Qubit::new(i)]),
                     clbits: circuit.cargs_interner().get_default(),
-                    params: Some(Box::new(Parameters::Params(smallvec![param]))),
+                    params: None,
                     label: None,
                     #[cfg(feature = "cache_pygates")]
                     py_op: OnceLock::new(),

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -212,6 +212,24 @@ impl CircuitInstruction {
 
     #[getter]
     pub fn get_params(&self, py: Python) -> PyResult<Py<PyAny>> {
+        // `Delay.params` keeps lying about being a one-element list at the Python
+        // boundary even though the Rust storage is empty (the duration lives in
+        // the global delay arena).  Synthesize the list here on read.
+        if let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) =
+            self.operation.view()
+        {
+            return handle.with(|_unit, data| -> PyResult<Py<PyAny>> {
+                let duration = match data {
+                    DelayDuration::Int(i) => i.into_py_any(py)?,
+                    DelayDuration::Float(f) => f.into_py_any(py)?,
+                    DelayDuration::Expr(expr) => {
+                        PyParameterExpression::from(expr.as_ref().clone()).coerce_into_py(py)?
+                    }
+                    DelayDuration::PyObj(obj) => obj.clone_ref(py),
+                };
+                Ok(PyList::new(py, [duration])?.into_any().unbind())
+            });
+        }
         if self.params.is_none() {
             return Ok(PyList::empty(py).into_any().unbind());
         };

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -24,16 +24,18 @@ use pyo3::{PyResult, intern};
 
 use crate::circuit_data::{CircuitData, PyCircuitData};
 use crate::dag_circuit::DAGCircuit;
+use crate::delay_arena::{DelayDuration, DelayHandle};
 use crate::duration::Duration;
 use crate::imports::{CONTROLLED_GATE, GATE, INSTRUCTION, OPERATION, WARNINGS_WARN};
 use crate::instruction::{Instruction, Parameters, create_py_op};
 use crate::operations::{
-    ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, Operation,
-    OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation, PyInstruction,
-    PyOperationTypes, StandardGate, StandardInstruction, StandardInstructionType, UnitaryGate,
+    ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, DelayUnit,
+    Operation, OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation,
+    PyInstruction, PyOperationTypes, StandardGate, StandardInstruction, StandardInstructionType,
+    UnitaryGate,
 };
 use crate::packed_instruction::PackedOperation;
-use crate::parameter::parameter_expression::ParameterExpression;
+use crate::parameter::parameter_expression::{ParameterExpression, PyParameterExpression};
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
 use smallvec::{SmallVec, smallvec};
@@ -703,8 +705,13 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
                     StandardInstruction::Barrier(num_qubits)
                 }
                 StandardInstructionType::Delay => {
-                    let unit = ob.getattr(intern!(py, "unit"))?.extract()?;
-                    StandardInstruction::Delay(unit)
+                    // The duration lives in the global delay arena rather than on the
+                    // params list (see `delay_arena`).  Read both unit and duration
+                    // here so the resulting `DelayHandle` is fully populated.
+                    let unit: DelayUnit = ob.getattr(intern!(py, "unit"))?.extract()?;
+                    let duration_obj = ob.getattr(intern!(py, "duration"))?;
+                    let duration = extract_delay_duration(duration_obj.as_borrowed())?;
+                    StandardInstruction::Delay(DelayHandle::new(unit, duration))
                 }
                 StandardInstructionType::Measure => StandardInstruction::Measure,
                 StandardInstructionType::Reset => StandardInstruction::Reset,
@@ -975,6 +982,53 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
     }
 }
 
+/// Classify a Python-space delay duration value into a [`DelayDuration`].
+///
+/// This mirrors what `qiskit.circuit.delay.Delay.validate_parameter` produces:
+/// non-negative ints (only valid for `dt`), floats (for time units), or a
+/// `ParameterExpression`.  We do not re-validate against the unit here — the
+/// Python `Delay` constructor has already done that — we just classify.
+pub(crate) fn extract_delay_duration(ob: Borrowed<PyAny>) -> PyResult<DelayDuration> {
+    let py = ob.py();
+    // Bool is a subclass of int in Python; reject it explicitly to avoid `True == 1`
+    // surprises.  `ParameterExpression` is checked before `int`/`float` because the
+    // numeric extractors would not match a parameter object.
+    if ob.is_instance_of::<pyo3::types::PyBool>() {
+        return Err(PyTypeError::new_err(
+            "Delay duration must be int, float, or ParameterExpression",
+        ));
+    }
+    if let Ok(py_expr) = PyParameterExpression::extract_coerce(ob) {
+        // `extract_coerce` accepts plain ints/floats too, so we have to disambiguate
+        // by inspecting the inner expression.  An expression that is a fully-bound
+        // value collapses to Int/Float here; anything else is a true symbolic Expr.
+        let inner = py_expr.inner;
+        if let Ok(value) = inner.try_to_value(true) {
+            return match value {
+                crate::parameter::symbol_expr::Value::Int(i) => Ok(DelayDuration::Int(i)),
+                crate::parameter::symbol_expr::Value::Real(f) => Ok(DelayDuration::Float(f)),
+                crate::parameter::symbol_expr::Value::Complex(_) => Err(PyTypeError::new_err(
+                    "Delay duration must be a real number or ParameterExpression",
+                )),
+            };
+        }
+        return Ok(DelayDuration::Expr(std::sync::Arc::new(inner)));
+    }
+    // Fall back to plain numeric extraction.  Prefer int over float so a Python `int`
+    // is preserved as `DelayDuration::Int` (this is what the rejected previous attempt
+    // got wrong by coercing through `Param::Float`).
+    let _ = py;
+    if let Ok(i) = ob.extract::<i64>() {
+        return Ok(DelayDuration::Int(i));
+    }
+    if let Ok(f) = ob.extract::<f64>() {
+        return Ok(DelayDuration::Float(f));
+    }
+    // Anything else (e.g. a classical `expr.Expr` for a Box-style duration) is held
+    // opaquely and round-tripped through Python.
+    Ok(DelayDuration::PyObj(ob.to_owned().unbind()))
+}
+
 /// Extracts a Python-space params list into an optional [Parameters] list, given
 /// the corresponding operation reference.
 pub fn extract_params<T: CircuitBlock>(
@@ -1022,16 +1076,11 @@ pub fn extract_params<T: CircuitBlock>(
         OperationRef::StandardInstruction(i) => {
             match &i {
                 StandardInstruction::Barrier(_) => None,
-                StandardInstruction::Delay(_) => {
-                    // If the delay's duration is a Python int, we preserve it rather than
-                    // coercing it to a float (e.g. when unit is 'dt').
-                    Some(Parameters::Params(
-                        params
-                            .try_iter()?
-                            .map(|p| Param::extract_no_coerce(p?.as_borrowed()))
-                            .collect::<PyResult<_>>()?,
-                    ))
-                }
+                // Delay's duration is stored in the global delay arena, not as a
+                // Param.  The `.params` boundary on the Python side synthesizes a
+                // single-element list from the handle on read; see
+                // `synthesize_delay_params` and `Delay`'s Python class.
+                StandardInstruction::Delay(_) => None,
                 StandardInstruction::Measure => None,
                 StandardInstruction::Reset => None,
             }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2305,13 +2305,13 @@ impl DAGCircuit {
                                         StandardInstruction::Barrier(n2),
                                     ] => n1 == n2,
                                     [
-                                        StandardInstruction::Delay(unit1),
-                                        StandardInstruction::Delay(unit2),
-                                    ] => {
-                                        let duration1 = &inst1.params_view()[0];
-                                        let duration2 = &inst2.params_view()[0];
-                                        unit1 == unit2 && duration1.is_close(duration2, 1e-10)?
-                                    }
+                                        StandardInstruction::Delay(handle1),
+                                        StandardInstruction::Delay(handle2),
+                                    ] => handle1.with(|unit1, dur1| {
+                                        handle2.with(|unit2, dur2| {
+                                            unit1 == unit2 && dur1.is_close(dur2, 1e-10)
+                                        })
+                                    }),
                                     [
                                         StandardInstruction::Measure,
                                         StandardInstruction::Measure,

--- a/crates/circuit/src/delay_arena.rs
+++ b/crates/circuit/src/delay_arena.rs
@@ -1,0 +1,425 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! Reference-counted typed storage for `Delay` instruction durations.
+//!
+//! `StandardInstruction::Delay` carries a 4-byte [`DelayHandle`] into a process-global
+//! arena of `(DelayUnit, DelayDuration)` slots.  Cloning a handle bumps an atomic
+//! refcount on its slot; dropping a handle decrements that refcount and returns the
+//! slot to a freelist when the count hits zero.
+//!
+//! The arena exists because Python's `Delay` data model distinguishes `int` durations
+//! (only valid for the `dt` unit) from `float` durations (valid for time units).
+//! Storing the duration in `Param::Float` would silently coerce ints to floats and
+//! lose that invariant; storing the duration as a typed `DelayDuration` next to the
+//! instruction's `DelayUnit` keeps the Rust- and Python-side data models aligned.
+//!
+//! # Thread safety
+//!
+//! All public operations are safe to call concurrently:
+//!
+//! * Allocation (`DelayHandle::new`) and final-drop (rc reaches zero) take a write
+//!   guard on the arena's `slots` vector.
+//! * Clone, non-final drop, and `with` closures take only a read guard plus an
+//!   atomic refcount op.
+//!
+//! Slot addresses are stable (`Vec<Box<Slot>>`), so a handle that has snapshotted
+//! a slot pointer can read it after releasing the read guard, as long as the
+//! handle itself is still live.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
+
+use pyo3::prelude::*;
+
+use crate::operations::DelayUnit;
+use crate::parameter::parameter_expression::ParameterExpression;
+
+/// The duration value of a `Delay` instruction.
+///
+/// Variants mirror the shapes that `Delay._validate_arguments` produces in Python:
+///
+/// * `Int(i64)` — `dt` unit only.  The Python validator rejects `dt` durations that
+///   are not non-negative integers.
+/// * `Float(f64)` — for time units (`s`, `ms`, `us`, `ns`, `ps`).
+/// * `Expr(Arc<ParameterExpression>)` — `ParameterExpression`-typed durations, valid
+///   for any unit.
+/// * `PyObj(Py<PyAny>)` — a fallback for opaque Python-typed durations, used for
+///   classical `expr.Expr` durations under the `expr` unit (and as a catch-all for
+///   anything we couldn't classify on the way in).  We round-trip these through
+///   Python rather than try to inspect them in Rust.
+#[derive(Clone, Debug)]
+pub enum DelayDuration {
+    Int(i64),
+    Float(f64),
+    Expr(Arc<ParameterExpression>),
+    PyObj(Py<PyAny>),
+}
+
+impl PartialEq for DelayDuration {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Int(a), Self::Int(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => a.to_bits() == b.to_bits(),
+            (Self::Expr(a), Self::Expr(b)) => a == b,
+            // PyObj equality is conservative: only same Python identity counts.
+            // The DAG isomorphism path that needs richer comparison goes through
+            // `is_close`, which delegates to Python.
+            (Self::PyObj(a), Self::PyObj(b)) => Python::attach(|py| a.is(b.bind(py))),
+            _ => false,
+        }
+    }
+}
+
+impl DelayDuration {
+    /// Approximate equality, used by DAG isomorphism comparisons.
+    ///
+    /// Float-vs-int and float-vs-float are compared with relative tolerance `eps`;
+    /// expressions are compared structurally; any cross-variant comparison returns
+    /// `false`.
+    pub fn is_close(&self, other: &Self, eps: f64) -> bool {
+        let approx = |a: f64, b: f64| {
+            let diff = (a - b).abs();
+            let max = a.abs().max(b.abs()).max(1.0);
+            diff <= eps * max
+        };
+        match (self, other) {
+            (Self::Int(a), Self::Int(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => approx(*a, *b),
+            (Self::Int(a), Self::Float(b)) | (Self::Float(b), Self::Int(a)) => {
+                approx(*a as f64, *b)
+            }
+            (Self::Expr(a), Self::Expr(b)) => a == b,
+            (Self::PyObj(a), Self::PyObj(b)) => {
+                Python::attach(|py| a.bind(py).eq(b).unwrap_or(false))
+            }
+            _ => false,
+        }
+    }
+}
+
+/// A heap-allocated arena slot.  The `Box` indirection in [`Arena::slots`] keeps each
+/// slot's address stable across arena growth, which is what lets [`DelayHandle::with`]
+/// release the read guard before deref'ing the slot.
+struct Slot {
+    rc: AtomicU32,
+    unit: DelayUnit,
+    data: DelayDuration,
+}
+
+struct Arena {
+    /// Heap-stable slot storage.  Indexed by [`DelayHandle`].  We mutate a slot's
+    /// `unit`/`data` only by *replacing* the entire `Box<Slot>` under the write lock;
+    /// that path runs only when the slot is on the freelist (rc == 0) or freshly
+    /// pushed, so it never aliases a live handle's view.
+    ///
+    /// The `Box` indirection is *load-bearing*: `DelayHandle::with` snapshots a
+    /// `*const Slot` while holding only the read guard, then releases the guard
+    /// before deref'ing the pointer.  That is sound only because the `Box`
+    /// keeps each `Slot`'s address stable even when the outer `Vec` grows.
+    /// `clippy::vec_box` doesn't know about this requirement.
+    #[allow(clippy::vec_box)]
+    slots: RwLock<Vec<Box<Slot>>>,
+    /// Indices of slots whose rc has reached zero and may be reused on the next
+    /// allocation.  Held under a separate mutex so the drop hot path doesn't have to
+    /// take the slots' write guard.
+    freelist: Mutex<Vec<u32>>,
+}
+
+static ARENA: LazyLock<Arena> = LazyLock::new(|| Arena {
+    slots: RwLock::new(Vec::new()),
+    freelist: Mutex::new(Vec::new()),
+});
+
+/// 4-byte handle into the global delay arena.
+///
+/// `StandardInstruction::Delay` carries one of these as its sole payload.
+/// `Clone` bumps the slot's refcount; `Drop` decrements it and returns the slot to
+/// the freelist when the count hits zero.
+#[derive(Debug)]
+pub struct DelayHandle(u32);
+
+impl DelayHandle {
+    /// Allocate a new slot in the global arena and return a handle to it.
+    pub fn new(unit: DelayUnit, data: DelayDuration) -> Self {
+        let slot = Box::new(Slot {
+            rc: AtomicU32::new(1),
+            unit,
+            data,
+        });
+        // Try to reuse a slot from the freelist before growing.
+        let reused = ARENA
+            .freelist
+            .lock()
+            .expect("delay arena freelist poisoned")
+            .pop();
+        match reused {
+            Some(idx) => {
+                let mut guard = ARENA.slots.write().expect("delay arena slots poisoned");
+                // The freelist promised this slot has rc == 0 and is unreferenced;
+                // replacing the Box drops the old Slot, which is what we want.
+                guard[idx as usize] = slot;
+                Self(idx)
+            }
+            None => {
+                let mut guard = ARENA.slots.write().expect("delay arena slots poisoned");
+                let idx = guard
+                    .len()
+                    .try_into()
+                    .expect("delay arena exceeded u32::MAX live + previously-live slots");
+                if idx == u32::MAX {
+                    // u32::MAX is reserved as a sentinel.
+                    panic!("delay arena exceeded u32::MAX live + previously-live slots");
+                }
+                guard.push(slot);
+                Self(idx)
+            }
+        }
+    }
+
+    /// Return the unit of this handle's slot.
+    pub fn unit(&self) -> DelayUnit {
+        self.with(|unit, _| unit)
+    }
+
+    /// Construct a handle from an existing live slot index, incrementing the slot's
+    /// refcount.  Used by code that decodes a packed `DelayHandle` from an external
+    /// representation (e.g. `PackedOperation`'s bitfield) and wants an owned handle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is out of range for the arena.  In normal use this is only
+    /// called with indices the arena previously emitted from [`Self::new`].
+    pub fn clone_from_index(idx: u32) -> Self {
+        let guard = ARENA.slots.read().expect("delay arena slots poisoned");
+        guard[idx as usize].rc.fetch_add(1, Ordering::Relaxed);
+        Self(idx)
+    }
+
+    /// Consume this handle and return its raw slot index *without* decrementing the
+    /// refcount.  The caller takes responsibility for ensuring the rc unit this
+    /// handle owned is accounted for elsewhere (e.g. by storing the index in a
+    /// packed bit field that will later be released via [`Self::release_by_index`]).
+    pub fn forget_into_index(self) -> u32 {
+        let idx = self.0;
+        std::mem::forget(self);
+        idx
+    }
+
+    /// Get this handle's raw slot index without consuming it.
+    #[inline]
+    pub fn index(&self) -> u32 {
+        self.0
+    }
+
+    /// Release one rc unit on the slot at `idx`, freeing it if this was the last
+    /// reference.  Mirrors [`Self::drop`] but operates directly on a u32 index, which
+    /// is the form a `PackedOperation` carries.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `idx` is associated with a refcount unit that has
+    /// not yet been released (e.g. obtained from a previous [`Self::forget_into_index`]
+    /// or [`Self::clone_from_index`]).  Releasing the same unit twice corrupts the
+    /// arena.
+    pub unsafe fn release_by_index(idx: u32) {
+        let guard = ARENA.slots.read().expect("delay arena slots poisoned");
+        let prev = guard[idx as usize].rc.fetch_sub(1, Ordering::AcqRel);
+        drop(guard);
+        if prev == 1 {
+            ARENA
+                .freelist
+                .lock()
+                .expect("delay arena freelist poisoned")
+                .push(idx);
+        }
+    }
+
+    /// Run a closure with read access to this handle's `(unit, duration)`.
+    ///
+    /// The closure runs without the arena's read guard held, so it may itself perform
+    /// arena operations (clone, allocate new handles, etc.).
+    pub fn with<R>(&self, f: impl FnOnce(DelayUnit, &DelayDuration) -> R) -> R {
+        // SAFETY: holding `self` proves the slot's rc >= 1, so `with_by_index` is
+        // safe (see safety contract there).
+        unsafe { with_by_index(self.0, f) }
+    }
+}
+
+/// Run a closure with read access to the `(unit, duration)` of the slot at `idx`,
+/// without holding any owned handle.
+///
+/// This is the lookup path used by code that has a raw slot index from a packed
+/// representation but does not want to incur the cost of a rc++ on each read.
+///
+/// # Safety
+///
+/// The caller must ensure that some live handle (or other rc unit) keeps the slot
+/// at `idx` from being recycled for the duration of this call.  Typical usage:
+/// pass an index that was extracted from a `PackedOperation`'s bitfield, where the
+/// `PackedOperation` itself owns the rc unit.
+pub unsafe fn with_by_index<R>(idx: u32, f: impl FnOnce(DelayUnit, &DelayDuration) -> R) -> R {
+    let guard = ARENA.slots.read().expect("delay arena slots poisoned");
+    // See safety argument on `DelayHandle::with`: the caller's contract here mirrors
+    // it, replacing "self handle is live" with "some external rc unit is live".
+    let slot_ptr: *const Slot = &*guard[idx as usize];
+    drop(guard);
+    let slot = unsafe { &*slot_ptr };
+    f(slot.unit, &slot.data)
+}
+
+impl Clone for DelayHandle {
+    fn clone(&self) -> Self {
+        let guard = ARENA.slots.read().expect("delay arena slots poisoned");
+        // `Relaxed` matches the `Arc::clone` pattern: we already have a handle (so the
+        // slot is not going away), and the new handle's data dependency on the old rc
+        // value is established by program order.
+        guard[self.0 as usize].rc.fetch_add(1, Ordering::Relaxed);
+        Self(self.0)
+    }
+}
+
+impl Drop for DelayHandle {
+    fn drop(&mut self) {
+        let guard = ARENA.slots.read().expect("delay arena slots poisoned");
+        // `AcqRel` matches `Arc::drop`: the final decrementer needs to synchronize
+        // with all prior increments (Acquire) and release this thread's writes to the
+        // slot for any future allocator that reuses it (Release).
+        let prev = guard[self.0 as usize].rc.fetch_sub(1, Ordering::AcqRel);
+        let idx = self.0;
+        drop(guard);
+        if prev == 1 {
+            // We were the last handle.  Push to the freelist so a future
+            // `DelayHandle::new` can reuse this index (and replace the Box's contents).
+            ARENA
+                .freelist
+                .lock()
+                .expect("delay arena freelist poisoned")
+                .push(idx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Read the rc of `handle`'s slot for testing.  Acquires the read guard the same
+    /// way the production paths do.
+    fn slot_rc(handle: &DelayHandle) -> u32 {
+        let guard = ARENA.slots.read().unwrap();
+        guard[handle.0 as usize].rc.load(Ordering::Acquire)
+    }
+
+    #[test]
+    fn test_alloc_and_with() {
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(100));
+        h.with(|unit, data| {
+            assert_eq!(unit, DelayUnit::DT);
+            assert_eq!(data, &DelayDuration::Int(100));
+        });
+        assert_eq!(h.unit(), DelayUnit::DT);
+    }
+
+    #[test]
+    fn test_alloc_each_unit_kind() {
+        let int_h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(7));
+        let float_h = DelayHandle::new(DelayUnit::NS, DelayDuration::Float(1.5));
+        int_h.with(|u, d| {
+            assert_eq!(u, DelayUnit::DT);
+            assert_eq!(d, &DelayDuration::Int(7));
+        });
+        float_h.with(|u, d| {
+            assert_eq!(u, DelayUnit::NS);
+            assert_eq!(d, &DelayDuration::Float(1.5));
+        });
+    }
+
+    #[test]
+    fn test_clone_increments_rc() {
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(5));
+        assert_eq!(slot_rc(&h), 1);
+        let h2 = h.clone();
+        assert_eq!(slot_rc(&h), 2);
+        assert_eq!(slot_rc(&h2), 2);
+        // Both handles see the same payload.
+        h.with(|_, d| assert_eq!(d, &DelayDuration::Int(5)));
+        h2.with(|_, d| assert_eq!(d, &DelayDuration::Int(5)));
+    }
+
+    #[test]
+    fn test_drop_decrements_rc() {
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(99));
+        let h2 = h.clone();
+        assert_eq!(slot_rc(&h), 2);
+        drop(h2);
+        assert_eq!(slot_rc(&h), 1);
+        h.with(|_, d| assert_eq!(d, &DelayDuration::Int(99)));
+    }
+
+    #[test]
+    fn test_slot_reuse_via_freelist() {
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(1));
+        let idx = h.0;
+        drop(h);
+        // The next allocation should reuse the freed index.
+        let h2 = DelayHandle::new(DelayUnit::S, DelayDuration::Float(2.0));
+        assert_eq!(
+            h2.0, idx,
+            "freelist should reuse the most recently freed index"
+        );
+        h2.with(|u, d| {
+            assert_eq!(u, DelayUnit::S);
+            assert_eq!(d, &DelayDuration::Float(2.0));
+        });
+    }
+
+    #[test]
+    fn test_concurrent_clone_drop() {
+        use std::thread;
+
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(42));
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let h_t = h.clone();
+            threads.push(thread::spawn(move || {
+                for _ in 0..1000 {
+                    let h2 = h_t.clone();
+                    h2.with(|_, d| {
+                        assert_eq!(d, &DelayDuration::Int(42));
+                    });
+                    drop(h2);
+                }
+            }));
+        }
+        for t in threads {
+            t.join().unwrap();
+        }
+        // Original handle survives.
+        assert_eq!(slot_rc(&h), 1);
+        h.with(|_, d| assert_eq!(d, &DelayDuration::Int(42)));
+    }
+
+    #[test]
+    fn test_with_closure_on_expr() {
+        // Smoke-test that DelayDuration::Expr storage works.  Building a real
+        // ParameterExpression from inside a Rust unit test requires Python state
+        // we don't have here, so we use Arc::default-style construction via a
+        // manually-constructed expression if available; otherwise just check Int+Float
+        // round-trip (the Expr arm is exercised by Python integration tests).
+        let h = DelayHandle::new(DelayUnit::DT, DelayDuration::Int(3));
+        h.with(|u, d| {
+            assert_eq!(u, DelayUnit::DT);
+            assert!(matches!(d, DelayDuration::Int(3)));
+        });
+    }
+}

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -21,6 +21,7 @@ pub mod classical;
 pub mod converters;
 pub mod dag_circuit;
 pub mod dag_node;
+pub mod delay_arena;
 mod dot_utils;
 pub mod duration;
 pub mod error;

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -21,6 +21,7 @@ use std::{fmt, vec};
 use crate::bit::{ClassicalRegister, ShareableClbit};
 use crate::circuit_data::{CircuitData, PyCircuitData};
 use crate::classical::expr;
+use crate::delay_arena::{DelayDuration, DelayHandle};
 use crate::duration::Duration;
 use crate::packed_instruction::PackedInstruction;
 use crate::parameter::parameter_expression::{
@@ -1069,12 +1070,32 @@ impl FromStr for StandardInstructionType {
     }
 }
 
-#[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
+/// A "standard" (Rust-native) instruction.
+///
+/// Note: this enum is *not* `Copy` because the `Delay` arm carries a
+/// reference-counted [`DelayHandle`] into the global delay arena.  Cloning a
+/// `StandardInstruction` therefore involves an atomic refcount bump on the slot
+/// when it is a `Delay`.  See `delay_arena` for details.
+#[derive(Clone, Debug)]
 pub enum StandardInstruction {
     Barrier(u32),
-    Delay(DelayUnit),
+    Delay(DelayHandle),
     Measure,
     Reset,
+}
+
+impl PartialEq for StandardInstruction {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Barrier(a), Self::Barrier(b)) => a == b,
+            (Self::Measure, Self::Measure) => true,
+            (Self::Reset, Self::Reset) => true,
+            (Self::Delay(a), Self::Delay(b)) => a.with(|a_unit, a_data| {
+                b.with(|b_unit, b_data| a_unit == b_unit && a_data == b_data)
+            }),
+            _ => false,
+        }
+    }
 }
 
 // This must be kept up-to-date with `StandardInstruction` when adding or removing
@@ -1113,10 +1134,11 @@ impl Operation for StandardInstruction {
     }
 
     fn num_params(&self) -> u32 {
-        match self {
-            StandardInstruction::Delay(_) => 1,
-            _ => 0,
-        }
+        // Delay's duration is now stored in the delay arena (see `delay_arena`)
+        // rather than the params list, so all standard instructions have 0 params
+        // from the Rust side.  The Python `.params` accessor synthesizes a one-element
+        // list at the boundary; see `circuit_instruction.rs`.
+        0
     }
 
     fn directive(&self) -> bool {
@@ -1136,7 +1158,8 @@ impl StandardInstruction {
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<&str>,
     ) -> PyResult<Py<PyAny>> {
-        let mut params = params.into_iter().flatten();
+        // Note: for Delay, `params` is unused — the duration lives in the delay arena.
+        let _ = params;
         let kwargs = label
             .map(|label| [("label", label.into_py_any(py)?)].into_py_dict(py))
             .transpose()?;
@@ -1144,11 +1167,22 @@ impl StandardInstruction {
             StandardInstruction::Barrier(num_qubits) => imports::BARRIER
                 .get_bound(py)
                 .call((num_qubits,), kwargs.as_ref())?,
-            StandardInstruction::Delay(unit) => {
-                let duration = params.next().unwrap();
+            StandardInstruction::Delay(handle) => {
+                let (duration_obj, unit_str) = handle.with(|unit, data| -> PyResult<_> {
+                    let duration = match data {
+                        DelayDuration::Int(i) => i.into_py_any(py)?,
+                        DelayDuration::Float(f) => f.into_py_any(py)?,
+                        DelayDuration::Expr(expr) => {
+                            let py_expr = PyParameterExpression::from(expr.as_ref().clone());
+                            py_expr.coerce_into_py(py)?
+                        }
+                        DelayDuration::PyObj(obj) => obj.clone_ref(py),
+                    };
+                    Ok((duration, unit.to_string()))
+                })?;
                 imports::DELAY
                     .get_bound(py)
-                    .call1((duration.into_py_any(py)?, unit.to_string()))?
+                    .call1((duration_obj, unit_str))?
             }
             StandardInstruction::Measure => {
                 imports::MEASURE.get_bound(py).call((), kwargs.as_ref())?

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -280,6 +280,7 @@ mod standard_gate {
 
 /// A private module to encapsulate the encoding of [StandardInstruction].
 mod standard_instruction {
+    use crate::delay_arena::DelayHandle;
     use crate::operations::{StandardInstruction, StandardInstructionType};
     use crate::packed_instruction::{PackedOperation, PackedOperationType};
     use bitfield_struct::bitfield;
@@ -289,7 +290,7 @@ mod standard_instruction {
     /// NOTE: this _looks_ like a named struct, but the `bitfield` attribute macro
     /// turns it into a transparent wrapper around a `u64`.
     #[bitfield(u64)]
-    struct StandardInstructionBits {
+    pub(super) struct StandardInstructionBits {
         #[bits(3)]
         discriminant: u8,
         #[bits(5)]
@@ -298,6 +299,8 @@ mod standard_instruction {
         standard_instruction: u8,
         #[bits(16)]
         _pad1: u32,
+        /// 32-bit variant payload: number of qubits for `Barrier`, raw delay-arena
+        /// index for `Delay` (see [`DelayHandle`]), or unused for `Measure`/`Reset`.
         #[bits(32)]
         payload: u32,
     }
@@ -311,9 +314,12 @@ mod standard_instruction {
                     StandardInstruction::Barrier(bits) => packed
                         .with_standard_instruction(bytemuck::cast(StandardInstructionType::Barrier))
                         .with_payload(bits),
-                    StandardInstruction::Delay(unit) => packed
+                    StandardInstruction::Delay(handle) => packed
                         .with_standard_instruction(bytemuck::cast(StandardInstructionType::Delay))
-                        .with_payload(unit as u32),
+                        // Consume the handle into a raw index without dropping its rc unit;
+                        // the unit is now owned by the packed bitfield.  The matching `Drop`
+                        // for `PackedOperation` releases it (see `packed_instruction.rs`).
+                        .with_payload(handle.forget_into_index()),
                     StandardInstruction::Measure => packed.with_standard_instruction(
                         bytemuck::cast(StandardInstructionType::Measure),
                     ),
@@ -339,9 +345,13 @@ mod standard_instruction {
                         StandardInstructionType::Barrier => {
                             StandardInstruction::Barrier(bits.payload())
                         }
-                        StandardInstructionType::Delay => StandardInstruction::Delay(
-                            bytemuck::checked::cast(bits.payload() as u8),
-                        ),
+                        StandardInstructionType::Delay => {
+                            // Produce an owned handle (rc++) so the returned
+                            // `StandardInstruction` is independent of `value`'s lifetime.
+                            StandardInstruction::Delay(DelayHandle::clone_from_index(
+                                bits.payload(),
+                            ))
+                        }
                         StandardInstructionType::Measure => StandardInstruction::Measure,
                         StandardInstructionType::Reset => StandardInstruction::Reset,
                     })
@@ -349,6 +359,15 @@ mod standard_instruction {
                 _ => Err("not a standard instruction!"),
             }
         }
+    }
+
+    /// Read the raw `(StandardInstructionType, payload)` from a packed operation
+    /// without producing a `StandardInstruction`.  Useful in the `Drop` path where
+    /// we need the discriminant + payload but cannot afford to clone the handle.
+    pub(super) fn raw_payload(value: &PackedOperation) -> (StandardInstructionType, u32) {
+        let bits = StandardInstructionBits::from_bits(value.0.as_u64());
+        let ty: StandardInstructionType = bytemuck::checked::cast(bits.standard_instruction());
+        (ty, bits.payload())
     }
 }
 
@@ -769,9 +788,24 @@ impl Clone for PackedOperation {
 
 impl Drop for PackedOperation {
     fn drop(&mut self) {
+        use crate::delay_arena::DelayHandle;
+        use crate::operations::StandardInstructionType;
         use crate::packed_instruction::pointer::PackablePointer;
+        use crate::packed_instruction::standard_instruction::raw_payload;
         match self.discriminant() {
-            PackedOperationType::StandardGate | PackedOperationType::StandardInstruction => (),
+            PackedOperationType::StandardGate => (),
+            PackedOperationType::StandardInstruction => {
+                // Most standard instruction variants own no heap state, but `Delay`
+                // carries an rc unit on the global delay arena (see `delay_arena`).
+                let (ty, payload) = raw_payload(self);
+                if let StandardInstructionType::Delay = ty {
+                    // SAFETY: this `PackedOperation` was constructed by encoding a
+                    // `DelayHandle` via `forget_into_index`, which transferred one rc
+                    // unit to the bitfield.  We are about to be dropped, so we
+                    // release exactly that unit, once.
+                    unsafe { DelayHandle::release_by_index(payload) };
+                }
+            }
             PackedOperationType::PyOperationTypes => PyOperationTypes::drop_packed(self),
             PackedOperationType::UnitaryGate => UnitaryGate::drop_packed(self),
             PackedOperationType::PauliBased => PauliBased::drop_packed(self),

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -53,8 +53,18 @@ impl From<ParameterTableError> for PyErr {
 /// A single use of a symbolic parameter.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum ParameterUse {
-    Index { instruction: usize, parameter: u32 },
+    Index {
+        instruction: usize,
+        parameter: u32,
+    },
     GlobalPhase,
+    /// A symbol appearing in a `Delay` instruction's duration.  The duration lives
+    /// in the global delay arena rather than the params list (see `delay_arena`),
+    /// so it gets its own variant: there is no `parameter` index — every Delay has
+    /// at most one symbolic duration.
+    DelayDuration {
+        instruction: usize,
+    },
 }
 
 /// Tracked data tied to each parameter's UUID in the table.
@@ -329,6 +339,11 @@ impl ParameterTable {
                     instruction,
                     parameter,
                 } => out.add((*instruction, *parameter))?,
+                ParameterUse::DelayDuration { instruction } => {
+                    // Mirror the `Index` shape but use Python `None` for the parameter
+                    // slot, since delay durations have no parameter index.
+                    out.add((*instruction, py.None()))?
+                }
             }
         }
         Ok(out.unbind())

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1168,34 +1168,35 @@ impl<'a> QASM3Builder {
 
     fn build_delay(&self, instr: &PackedInstruction) -> ExporterResult<Delay> {
         let standard_instr = instr.op.standard_instruction();
-        let delay_unit = if let StandardInstruction::Delay(delay) = standard_instr {
-            delay
-        } else {
+        let StandardInstruction::Delay(handle) = standard_instr else {
             return Err(QASM3ExporterError::Error(
                 "Expected Delay instruction, but got wrong instruction".to_string(),
             ));
         };
-        let param = &instr.params_view()[0];
-        let duration: f64 = Python::attach(|py| match param {
-            Param::Float(val) => *val,
-            Param::ParameterExpression(p) => match p.try_to_value(true) {
-                Ok(symbol_expr::Value::Real(val)) => val,
-                _ => {
-                    panic!("Failed to parse parameter value")
-                }
-            },
-            Param::Obj(obj) => {
-                let py_obj = obj.bind(py);
-                let py_str = py_obj.str().expect("Failed to call str() on Parameter");
-                let name = py_str
-                    .str()
-                    .expect("Failed to convert PyString to &str")
-                    .to_string();
-                match name.parse::<f64>() {
-                    Ok(val) => val,
-                    Err(_) => panic!("Failed to parse parameter value"),
-                }
-            }
+        // Pull the unit + numeric duration from the delay arena.
+        let (delay_unit, duration) = handle.with(|unit, data| {
+            let value: f64 = match data {
+                qiskit_circuit::delay_arena::DelayDuration::Int(i) => *i as f64,
+                qiskit_circuit::delay_arena::DelayDuration::Float(f) => *f,
+                qiskit_circuit::delay_arena::DelayDuration::Expr(p) => match p.try_to_value(true) {
+                    Ok(symbol_expr::Value::Real(val)) => val,
+                    Ok(symbol_expr::Value::Int(i)) => i as f64,
+                    _ => panic!("Failed to parse parameter value"),
+                },
+                qiskit_circuit::delay_arena::DelayDuration::PyObj(obj) => Python::attach(|py| {
+                    let py_str = obj
+                        .bind(py)
+                        .str()
+                        .expect("Failed to call str() on Delay duration");
+                    let s = py_str
+                        .str()
+                        .expect("Failed to convert PyString to &str")
+                        .to_string();
+                    s.parse::<f64>()
+                        .unwrap_or_else(|_| panic!("Failed to parse parameter value"))
+                }),
+            };
+            (unit, value)
         });
 
         let mut map = HashMap::new();

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -107,42 +107,65 @@ pub enum InstructionType {
 
 fn deserialize_standard_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
-) -> Option<StandardInstruction> {
-    match instruction.gate_class_name.as_str() {
+    qpy_data: &mut QPYReadData,
+) -> Result<Option<StandardInstruction>, QpyError> {
+    Ok(match instruction.gate_class_name.as_str() {
         "Barrier" => Some(StandardInstruction::Barrier(instruction.num_qargs)),
         "Measure" => Some(StandardInstruction::Measure),
         "Reset" => Some(StandardInstruction::Reset),
-        // TODO it seems currently delays are not treated correctly, and the unit is not stored
-        // even in Python QPY. We need to fix the writer to correctly store the delay unit as second parameter
+        // TODO: the existing QPY format does not encode the delay unit as a separate
+        // field — the writer's behavior pre-dates this PR.  The new in-memory
+        // representation moves the duration off the `Param` list and into the global
+        // delay arena, which we must now populate even for legacy QPY payloads.
+        // For now we apply the same heuristic the previous reader used (DT for
+        // numeric, EXPR for symbolic), and read the duration from params[0].
         "Delay" => {
+            use qiskit_circuit::delay_arena::{DelayDuration, DelayHandle};
+            use qiskit_circuit::operations::DelayUnit;
+
             let unit = if !instruction.params.is_empty() {
-                if instruction.params.len() >= 2 {
-                    // both duration and unit params; extract the unit param
-                    // TODO: for now returning default value; this should be fixed as part of the fix mentioned above
-                    qiskit_circuit::operations::DelayUnit::DT
+                if [
+                    ValueType::Expression,
+                    ValueType::ParameterExpression,
+                    ValueType::Parameter,
+                    ValueType::ParameterVector,
+                ]
+                .contains(&instruction.params[0].type_key)
+                {
+                    DelayUnit::EXPR
                 } else {
-                    // only duration; check whether it's an expression
-                    if [
-                        ValueType::Expression,
-                        ValueType::ParameterExpression,
-                        ValueType::Parameter,
-                        ValueType::ParameterVector,
-                    ]
-                    .contains(&instruction.params[0].type_key)
-                    {
-                        qiskit_circuit::operations::DelayUnit::EXPR
-                    } else {
-                        qiskit_circuit::operations::DelayUnit::DT
-                    }
+                    DelayUnit::DT
                 }
             } else {
-                // default case
-                qiskit_circuit::operations::DelayUnit::DT
+                DelayUnit::DT
             };
-            Some(StandardInstruction::Delay(unit))
+            let data = if instruction.params.is_empty() {
+                DelayDuration::Int(0)
+            } else {
+                let value = unpack_generic_value(&instruction.params[0], qpy_data, Endian::Little)?;
+                match value {
+                    GenericValue::Int64(i) => DelayDuration::Int(i),
+                    GenericValue::Float64(f) => DelayDuration::Float(f),
+                    GenericValue::ParameterExpression(exp) => DelayDuration::Expr(exp),
+                    GenericValue::ParameterExpressionSymbol(symbol) => {
+                        DelayDuration::Expr(Arc::new(ParameterExpression::from_symbol(symbol)))
+                    }
+                    GenericValue::ParameterExpressionVectorSymbol(symbol) => {
+                        DelayDuration::Expr(Arc::new(ParameterExpression::from_symbol(symbol)))
+                    }
+                    // Anything else (notably classical `expr::Expr` durations under
+                    // the `expr` unit) round-trips as an opaque Python object.
+                    other => Python::attach(|py| -> Result<_, QpyError> {
+                        let py_obj = py_convert_from_generic_value(&other)?;
+                        let _ = py;
+                        Ok(DelayDuration::PyObj(py_obj))
+                    })?,
+                }
+            };
+            Some(StandardInstruction::Delay(DelayHandle::new(unit, data)))
         }
         _ => None,
-    }
+    })
 }
 
 fn unpack_condition(
@@ -405,16 +428,23 @@ fn unpack_standard_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
     qpy_data: &mut QPYReadData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
-    let op = if let Some(std_instruction) = deserialize_standard_instruction(instruction) {
-        // TODO: can we avoid this call? {
-        PackedOperation::from_standard_instruction(std_instruction)
+    let std_instruction =
+        deserialize_standard_instruction(instruction, qpy_data)?.ok_or_else(|| {
+            QpyError::InvalidInstruction(format!(
+                "Unrecognized standard gate {}",
+                instruction.gate_class_name
+            ))
+        })?;
+    let is_delay = matches!(std_instruction, StandardInstruction::Delay(_));
+    let op = PackedOperation::from_standard_instruction(std_instruction);
+    // For delays, the duration has already been consumed into the `DelayHandle`
+    // inside `deserialize_standard_instruction`, so we drop the QPY-supplied
+    // params here.
+    let param_values = if is_delay {
+        Vec::new()
     } else {
-        return Err(QpyError::InvalidInstruction(format!(
-            "Unrecognized standard gate {}",
-            instruction.gate_class_name
-        )));
+        get_instruction_values(instruction, qpy_data, Endian::Little)?
     };
-    let param_values = get_instruction_values(instruction, qpy_data, Endian::Little)?;
     Ok((op, param_values))
 }
 

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -306,7 +306,14 @@ fn pack_standard_instruction(
     instruction: &PackedInstruction,
     qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
-    let params = pack_instruction_params(instruction, qpy_data)?;
+    // For Delay instructions, the duration lives in the global delay arena rather
+    // than the params list (see `qiskit_circuit::delay_arena`).  Synthesize a
+    // duration param at the QPY boundary so the format is unchanged.
+    let params = if let StandardInstruction::Delay(handle) = inst {
+        pack_delay_params(handle, qpy_data)?
+    } else {
+        pack_instruction_params(instruction, qpy_data)?
+    };
     Ok(formats::CircuitInstructionV2Pack {
         num_qargs: inst.num_qubits(),
         num_cargs: inst.num_clbits(),
@@ -319,6 +326,29 @@ fn pack_standard_instruction(
         bit_data: Default::default(),
         params,
         annotations: None,
+    })
+}
+
+/// Pack a delay's duration into a single QPY param value, classifying by the
+/// arena's typed `DelayDuration` variant rather than going through `Param`.  This
+/// ensures `dt`-unit integer durations survive the round trip as ints.
+fn pack_delay_params(
+    handle: &qiskit_circuit::delay_arena::DelayHandle,
+    qpy_data: &mut QPYWriteData,
+) -> Result<Vec<formats::GenericDataPack>, QpyError> {
+    use qiskit_circuit::delay_arena::DelayDuration;
+    use qiskit_circuit::operations::Param;
+
+    handle.with(|_unit, data| {
+        let param = match data {
+            DelayDuration::Int(i) => Python::attach(|py| -> Result<Param, QpyError> {
+                Ok(Param::Obj(pyo3::IntoPyObjectExt::into_py_any(*i, py)?))
+            })?,
+            DelayDuration::Float(f) => Param::Float(*f),
+            DelayDuration::Expr(expr) => Param::ParameterExpression(expr.clone()),
+            DelayDuration::PyObj(obj) => Python::attach(|py| Param::Obj(obj.clone_ref(py))),
+        };
+        Ok(vec![pack_param_obj(&param, qpy_data, Endian::Little)?])
     })
 }
 

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -177,7 +177,10 @@ fn name_to_packed_operation(name: &str, num_qubits: u32) -> Option<PackedOperati
     } else if STD_INST_SET.contains(&name) {
         let inst = match name {
             "barrier" => StandardInstruction::Barrier(num_qubits),
-            "delay" => StandardInstruction::Delay(qiskit_circuit::operations::DelayUnit::DT),
+            "delay" => StandardInstruction::Delay(qiskit_circuit::delay_arena::DelayHandle::new(
+                qiskit_circuit::operations::DelayUnit::DT,
+                qiskit_circuit::delay_arena::DelayDuration::Int(0),
+            )),
             "measure" => StandardInstruction::Measure,
             "reset" => StandardInstruction::Reset,
             _ => unreachable!(),

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -21,7 +21,6 @@ use pyo3::prelude::*;
 use pyo3::{Bound, PyResult, pyfunction, wrap_pyfunction};
 use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
-use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
@@ -118,24 +117,20 @@ fn push_node_back(
             .collect();
         let duration = target.get_duration(op.op.name(), &qargs).unwrap_or(0.0);
         this_t0 + duration as u64
-    } else if matches!(
-        op_view,
-        OperationRef::StandardInstruction(StandardInstruction::Delay(_))
-    ) {
-        let params = op.params_view();
-        let param = params
-            .first()
-            .ok_or_else(|| PyValueError::new_err("Delay instruction missing duration parameter"))?;
-        let duration = match param {
-            Param::Obj(val) => {
-                // Try to extract as different numeric types
-                Python::attach(|py| val.bind(py).extract::<u64>())
+    } else if let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) = &op_view {
+        // Pull the dt-sample duration directly from the delay arena.
+        let duration = handle.with(|_unit, data| -> Result<u64, PyErr> {
+            use qiskit_circuit::delay_arena::DelayDuration;
+            match data {
+                DelayDuration::Int(i) => u64::try_from(*i).map_err(|_| {
+                    TranspilerError::new_err("The provided Delay duration is not in terms of dt.")
+                }),
+                DelayDuration::Float(f) => Ok(*f as u64),
+                DelayDuration::Expr(_) | DelayDuration::PyObj(_) => Err(TranspilerError::new_err(
+                    "The provided Delay duration is not in terms of dt.",
+                )),
             }
-            Param::Float(f) => Ok(*f as u64),
-            _ => Err(TranspilerError::new_err(
-                "The provided Delay duration is not in terms of dt.",
-            )),
-        }?;
+        })?;
 
         this_t0 + duration
     } else {

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -11,11 +11,9 @@
 // that they have been altered from the originals.
 
 use crate::TranspilerError;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{DelayUnit, OperationRef, StandardInstruction};
 
 /// Run duration validation passes.
@@ -32,7 +30,7 @@ use qiskit_circuit::operations::{DelayUnit, OperationRef, StandardInstruction};
 #[pyfunction]
 #[pyo3(signature=(dag, acquire_align, pulse_align))]
 pub fn run_instruction_duration_check(
-    py: Python,
+    _py: Python,
     dag: &DAGCircuit,
     acquire_align: u32,
     pulse_align: u32,
@@ -46,27 +44,33 @@ pub fn run_instruction_duration_check(
 
     // Check delay durations
     for (_, packed_op) in dag.op_nodes(false) {
-        if let OperationRef::StandardInstruction(StandardInstruction::Delay(unit)) =
+        if let OperationRef::StandardInstruction(StandardInstruction::Delay(handle)) =
             packed_op.op.view()
         {
-            let params = packed_op.params_view();
-            let param = params.first().ok_or_else(|| {
-                PyValueError::new_err("Delay instruction missing duration parameter")
-            })?;
-
-            if unit != DelayUnit::DT {
-                return Err(TranspilerError::new_err(
-                    "Delay duration must have dt unit for checking alignment.",
-                ));
-            }
-            let duration = match param {
-                Param::Obj(val) => val.bind(py).extract::<u32>(),
-                _ => Err(TranspilerError::new_err(
-                    "The provided Delay duration is not in terms of dt.",
-                )),
-            }?;
-
-            if !(duration % acquire_align == 0 || duration % pulse_align == 0) {
+            // The duration now lives in the delay arena; pull `(unit, value)`
+            // directly rather than re-routing through `params_view`.
+            let result: Result<bool, PyErr> = handle.with(|unit, data| {
+                if unit != DelayUnit::DT {
+                    return Err(TranspilerError::new_err(
+                        "Delay duration must have dt unit for checking alignment.",
+                    ));
+                }
+                let duration: u32 = match data {
+                    qiskit_circuit::delay_arena::DelayDuration::Int(i) => u32::try_from(*i)
+                        .map_err(|_| {
+                            TranspilerError::new_err(
+                                "The provided Delay duration is not in terms of dt.",
+                            )
+                        })?,
+                    _ => {
+                        return Err(TranspilerError::new_err(
+                            "The provided Delay duration is not in terms of dt.",
+                        ));
+                    }
+                };
+                Ok(!(duration % acquire_align == 0 || duration % pulse_align == 0))
+            });
+            if result? {
                 return Ok(true);
             }
         }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1176,8 +1176,8 @@ static int test_delay_instruction(void) {
     QkCDelayDurationKind kind_out;
     int64_t value_int_out = 0;
     double value_float_out = 0.0;
-    if (qk_circuit_get_delay(qc, 1, &unit_out, &kind_out, &value_int_out, &value_float_out)
-        != QkExitCode_Success) {
+    if (qk_circuit_get_delay(qc, 1, &unit_out, &kind_out, &value_int_out, &value_float_out) !=
+        QkExitCode_Success) {
         result = RuntimeError;
         goto cleanup;
     }
@@ -1195,8 +1195,8 @@ static int test_delay_instruction(void) {
     }
 
     // And the s-unit delay at index 0.
-    if (qk_circuit_get_delay(qc, 0, &unit_out, &kind_out, &value_int_out, &value_float_out)
-        != QkExitCode_Success) {
+    if (qk_circuit_get_delay(qc, 0, &unit_out, &kind_out, &value_int_out, &value_float_out) !=
+        QkExitCode_Success) {
         result = RuntimeError;
         goto cleanup;
     }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1153,6 +1153,66 @@ static int test_delay_instruction(void) {
         goto cleanup;
     }
 
+    // qk_circuit_delay must reject the DT unit; use qk_circuit_delay_dt instead.
+    if (qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_DT) != QkExitCode_CInputError) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    // qk_circuit_delay_dt accepts non-negative integer durations.
+    if (qk_circuit_delay_dt(qc, 0, 100) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    // and rejects negative durations to mirror the Python validator.
+    if (qk_circuit_delay_dt(qc, 0, -1) != QkExitCode_CInputError) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    // Read back the dt-unit delay we just added at index 1.
+    QkDelayUnit unit_out;
+    QkCDelayDurationKind kind_out;
+    int64_t value_int_out = 0;
+    double value_float_out = 0.0;
+    if (qk_circuit_get_delay(qc, 1, &unit_out, &kind_out, &value_int_out, &value_float_out)
+        != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (unit_out != QkDelayUnit_DT) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (kind_out != QkCDelayDurationKind_Int) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (value_int_out != 100) {
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    // And the s-unit delay at index 0.
+    if (qk_circuit_get_delay(qc, 0, &unit_out, &kind_out, &value_int_out, &value_float_out)
+        != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (unit_out != QkDelayUnit_S) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (kind_out != QkCDelayDurationKind_Float) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (value_float_out != 0.001) {
+        result = EqualityError;
+        goto cleanup;
+    }
+
 cleanup:
     qk_circuit_free(qc);
     return result;


### PR DESCRIPTION
This PR is one of three RFCs solving the same problem: dt-unit delays panic in `qk_circuit_get_instruction` because their integer duration is stored as `Param::Obj(PyAny)`.

This branch takes the most surgical fix. Delay durations leave the `Param` list entirely and move into a typed global arena (`crates/circuit/src/delay_arena.rs`). The arena holds a `DelayDuration` enum (`Int`, `Float`, `Expr`, `PyObj`) inside refcounted `Slot`s, and `StandardInstruction::Delay(DelayHandle)` replaces `StandardInstruction::Delay(DelayUnit)`. Standard gates and other instructions are untouched — only the Delay variant knows about durations now.

The C API gets `qk_circuit_delay_dt(qubit, i64)` and `qk_circuit_get_delay(idx, *unit, *kind, *vi, *vf)` with a `CDelayDurationKind` enum that distinguishes integer, float, and expression durations. QPY format is unchanged — the writer synthesizes a duration `Param` from the handle when it serializes a Delay, and the reader builds a fresh handle from `param[0]` on read.

The trade-off is implementation complexity. `StandardInstruction` loses `Copy` and gets a manual `PartialEq`. `PackedOperation::clone` and `drop` special-case the Delay case to bump and release the refcount. The `Box<Slot>` indirection in the arena is load-bearing — `with()` snapshots a `*const Slot` then drops the read guard. There's a new `ParameterUse::DelayDuration` variant for symbolic durations that the parameter table needs to track separately.

The other two RFCs are #16226 (a minimal `int → float` coercion patch) and #16241 (a uniform `Param::Int` variant that touches every match over `Param`).

Partially addresses #16121.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
