### PR TITLE
Initialize ConstrainedReschedule.target unconditionally

### DIFF
--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -78,9 +78,9 @@ class ConstrainedReschedule(AnalysisPass):
         super().__init__()
         self.acquire_align = acquire_alignment
         self.pulse_align = pulse_alignment
+        self.target = target
         if target is not None:
             self.durations = target.durations()
-            self.target = target
             self.acquire_align = target.acquire_alignment
             self.pulse_align = target.pulse_alignment
 

--- a/releasenotes/notes/fix-constrained-reschedule-no-target-f27c1d813b78b8cc.yaml
+++ b/releasenotes/notes/fix-constrained-reschedule-no-target-f27c1d813b78b8cc.yaml
@@ -1,10 +1,6 @@
 ---
 fixes:
   - |
-    Fixed :class:`.ConstrainedReschedule` raising
-    ``AttributeError("'ConstrainedReschedule' object has no attribute 'target'")``
-    when constructed without a ``target=`` argument (the alignment-only path
-    that the pass's docstring still advertises).  ``self.target`` is now
-    initialised unconditionally in the constructor, so the pass works for both
-    the alignment-only and the :class:`.Target`-based call patterns.  See
+    :class:`.ConstrainedReschedule` will no longer raise :exc:`AttributeError`
+    if the optional ``target`` argument is not provided.  See
     `#16245 <https://github.com/Qiskit/qiskit/issues/16245>`__.

--- a/releasenotes/notes/fix-constrained-reschedule-no-target-f27c1d813b78b8cc.yaml
+++ b/releasenotes/notes/fix-constrained-reschedule-no-target-f27c1d813b78b8cc.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed :class:`.ConstrainedReschedule` raising
+    ``AttributeError("'ConstrainedReschedule' object has no attribute 'target'")``
+    when constructed without a ``target=`` argument (the alignment-only path
+    that the pass's docstring still advertises).  ``self.target`` is now
+    initialised unconditionally in the constructor, so the pass works for both
+    the alignment-only and the :class:`.Target`-based call patterns.  See
+    `#16245 <https://github.com/Qiskit/qiskit/issues/16245>`__.

--- a/test/python/transpiler/test_constrained_reschedule.py
+++ b/test/python/transpiler/test_constrained_reschedule.py
@@ -16,7 +16,7 @@ import unittest
 
 from qiskit import QuantumCircuit
 from qiskit.transpiler import InstructionDurations
-from qiskit.transpiler.passes import ALAPScheduleAnalysis, ConstrainedReschedule
+from qiskit.transpiler.passes import ASAPScheduleAnalysis, ConstrainedReschedule
 from qiskit.transpiler.passmanager import PassManager
 
 from test import QiskitTestCase
@@ -26,24 +26,30 @@ class TestConstrainedReschedule(QiskitTestCase):
     """Tests for the :class:`.ConstrainedReschedule` pass."""
 
     def test_alignment_only_construction(self):
-        """Regression test for #16245: constructing :class:`.ConstrainedReschedule`
-        without a ``target=`` (the alignment-only path, the way the docstring
-        still advertises) must not raise ``AttributeError`` when the pass is
-        run.  Previously ``self.target`` was only assigned inside the
-        ``if target is not None`` branch of ``__init__``.
-        """
-        durations = InstructionDurations([("cx", [0, 1], 100, "dt")], dt=2.22e-10)
+        """Regression test of #16245."""
+        # Test contributed with assistance from Claude Opus 4.7 (Claude Code).
+        durations = InstructionDurations(
+            [("x", 0, 160, "dt"), ("measure", 0, 1000, "dt")], dt=2.22e-10
+        )
 
-        qc = QuantumCircuit(2)
-        qc.cx(0, 1)
+        # ``x`` starts at t=0 (aligned to any pulse_alignment), ``measure``
+        # starts at t=160 which is a multiple of acquire_alignment=16, so the
+        # pass should not need to shift anything; it just has to run.
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
 
         pm = PassManager(
             [
-                ALAPScheduleAnalysis(durations),
+                ASAPScheduleAnalysis(durations),
                 ConstrainedReschedule(acquire_alignment=16, pulse_alignment=1),
             ]
         )
-        pm.run(qc)  # would raise AttributeError on the buggy code path
+        pm.run(qc)
+
+        node_start_time = pm.property_set["node_start_time"]
+        starts_by_name = {node.op.name: time for node, time in node_start_time.items()}
+        self.assertEqual(starts_by_name, {"x": 0, "measure": 160})
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_constrained_reschedule.py
+++ b/test/python/transpiler/test_constrained_reschedule.py
@@ -1,0 +1,50 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the ConstrainedReschedule pass."""
+
+import unittest
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler import InstructionDurations
+from qiskit.transpiler.passes import ALAPScheduleAnalysis, ConstrainedReschedule
+from qiskit.transpiler.passmanager import PassManager
+
+from test import QiskitTestCase
+
+
+class TestConstrainedReschedule(QiskitTestCase):
+    """Tests for the :class:`.ConstrainedReschedule` pass."""
+
+    def test_alignment_only_construction(self):
+        """Regression test for #16245: constructing :class:`.ConstrainedReschedule`
+        without a ``target=`` (the alignment-only path, the way the docstring
+        still advertises) must not raise ``AttributeError`` when the pass is
+        run.  Previously ``self.target`` was only assigned inside the
+        ``if target is not None`` branch of ``__init__``.
+        """
+        durations = InstructionDurations([("cx", [0, 1], 100, "dt")], dt=2.22e-10)
+
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+
+        pm = PassManager(
+            [
+                ALAPScheduleAnalysis(durations),
+                ConstrainedReschedule(acquire_alignment=16, pulse_alignment=1),
+            ]
+        )
+        pm.run(qc)  # would raise AttributeError on the buggy code path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #16245.

`ConstrainedReschedule.__init__` only assigned `self.target` inside the `if target is not None` branch. When the pass was constructed without a `target=` argument — the alignment-only path the docstring still advertises — `run()` raised:

```
AttributeError: 'ConstrainedReschedule' object has no attribute 'target'
```

at the call into the Rust `constrained_reschedule` helper. The Rust function's `target` parameter is `Option<&Target>`, so passing `None` is supported; `self.target` simply needed to be initialised.

## What changed

`qiskit/transpiler/passes/scheduling/alignments/reschedule.py`:

```diff
         super().__init__()
         self.acquire_align = acquire_alignment
         self.pulse_align = pulse_alignment
+        self.target = target
         if target is not None:
             self.durations = target.durations()
-            self.target = target
             self.acquire_align = target.acquire_alignment
             self.pulse_align = target.pulse_alignment
```

## Reproduction (from #16245)

```python
from qiskit import QuantumCircuit
from qiskit.transpiler import PassManager, InstructionDurations
from qiskit.transpiler.passes import ALAPScheduleAnalysis, ConstrainedReschedule

durations = InstructionDurations([('cx', [0, 1], 100, 'dt')], dt=2.22e-10)

qc = QuantumCircuit(2)
qc.cx(0, 1)

PassManager([
    ALAPScheduleAnalysis(durations),
    ConstrainedReschedule(acquire_alignment=16, pulse_alignment=1),  # no target=
]).run(qc)
# before: AttributeError: 'ConstrainedReschedule' object has no attribute 'target'
# after:  runs cleanly
```

## Test plan

- [x] New `test/python/transpiler/test_constrained_reschedule.py::TestConstrainedReschedule::test_alignment_only_construction` exercises the failing path and passes.
- [x] Verified the new test **fails** against the original code (`AttributeError`) and **passes** with the fix.
- [x] Full `test/python/transpiler/test_scheduling_padding_pass.py` (14 tests) still passes — no regression in adjacent scheduling behaviour.
- [x] `ruff check` and `black --check` (project-pinned `black~=25.1`) clean.

## Notes

I noticed this regression while investigating #16135 and flagged it in the PR description of my (closed) #16235.  Filed it as #16245 and submitting the fix here.

## AI tool disclosure

Per the Qiskit contribution policy: this change was prepared with assistance from Claude Opus 4.7 (1M context, via Claude Code). I reviewed every diff and verified all results locally; the model did not introduce any change I did not validate.