### PR TITLE
Fix import order of `circuit` and `synthesis`

### DIFF
--- a/qiskit/circuit/library/arithmetic/adders/cdkm_ripple_carry_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/cdkm_ripple_carry_adder.py
@@ -12,7 +12,6 @@
 
 """Compute the sum of two qubit registers using ripple-carry approach."""
 
-from qiskit.synthesis.arithmetic import adder_ripple_c04
 from .adder import Adder
 
 
@@ -116,6 +115,8 @@ class CDKMRippleCarryAdder(Adder):
         Raises:
             ValueError: If ``num_state_qubits`` is lower than 1.
         """
+        from qiskit.synthesis.arithmetic import adder_ripple_c04
+
         super().__init__(num_state_qubits, name=name)
         circuit = adder_ripple_c04(num_state_qubits, kind)
 

--- a/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
@@ -13,7 +13,6 @@
 """Compute the sum of two qubit registers using Classical Addition."""
 
 from __future__ import annotations
-from qiskit.synthesis.arithmetic import adder_ripple_v95
 from .adder import Adder
 
 
@@ -88,6 +87,8 @@ class VBERippleCarryAdder(Adder):
         Raises:
             ValueError: If ``num_state_qubits`` is lower than 1.
         """
+        from qiskit.synthesis.arithmetic import adder_ripple_v95
+
         super().__init__(num_state_qubits, name=name)
         circuit = adder_ripple_v95(num_state_qubits, kind)
 

--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -17,10 +17,6 @@ from __future__ import annotations
 
 from qiskit.circuit import QuantumRegister, AncillaRegister, Gate
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.synthesis.arithmetic.comparators import (
-    synth_integer_comparator_2s,
-    synth_integer_comparator_greedy,
-)
 from ..blueprintcircuit import BlueprintCircuit
 
 
@@ -159,6 +155,8 @@ class IntegerComparator(BlueprintCircuit):
 
     def _build(self) -> None:
         """If not already built, build the circuit."""
+        from qiskit.synthesis.arithmetic.comparators import synth_integer_comparator_2s
+
         if self._is_built:
             return
 
@@ -196,4 +194,6 @@ class IntegerComparatorGate(Gate):
         self.geq = geq
 
     def _define(self):
+        from qiskit.synthesis.arithmetic.comparators import synth_integer_comparator_greedy
+
         self.definition = synth_integer_comparator_greedy(self.num_qubits - 1, self.value, self.geq)

--- a/qiskit/circuit/library/bit_flip_oracle.py
+++ b/qiskit/circuit/library/bit_flip_oracle.py
@@ -14,9 +14,12 @@
 
 from __future__ import annotations
 
+import typing
+
 from qiskit.circuit import Gate
 
-from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+if typing.TYPE_CHECKING:
+    from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
 
 
 class BitFlipOracleGate(Gate):
@@ -64,6 +67,8 @@ class BitFlipOracleGate(Gate):
             label: A label for the gate to display in visualizations. Per default, the label is
                 set to display the textual representation of the boolean expression (truncated if needed)
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+
         if label is None:
             if isinstance(expression, str):
                 label = (expression[:15] + "...") if len(expression) > 15 else expression
@@ -130,5 +135,7 @@ class BitFlipOracleGate(Gate):
         Returns:
             BitFlipOracleGate: A quantum gate with a bit-flip oracle.
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+
         expr = BooleanExpression.from_dimacs_file(filename)
         return cls(expr)

--- a/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
@@ -20,6 +20,8 @@ import warnings
 import itertools
 import numpy as np
 
+
+from qiskit.circuit.library.hamiltonian_gate import HamiltonianGate
 from qiskit.circuit.library.pauli_evolution import PauliEvolutionGate
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parametervector import ParameterVector
@@ -27,7 +29,6 @@ from qiskit.circuit import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp, SparseObservable
 from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.synthesis.evolution.product_formula import real_or_fail
 
 from qiskit._accelerate.circuit_library import pauli_evolution
 
@@ -90,6 +91,9 @@ def evolved_operator_ansatz(
             layers of gate objects. Setting this to ``False`` is significantly less performant,
             especially for parameter binding, but can be desirable for a cleaner visualization.
     """
+    from qiskit.synthesis.evolution import LieTrotter
+    from qiskit.synthesis.evolution.product_formula import real_or_fail
+
     if reps < 0:
         raise ValueError("reps must be a non-negative integer.")
 
@@ -153,13 +157,9 @@ def evolved_operator_ansatz(
 
     # slower, Python-path
     if evolution is None:
-        from qiskit.synthesis.evolution import LieTrotter
-
         evolution = LieTrotter(insert_barriers=insert_barriers)
 
     circuit = QuantumCircuit(num_qubits, name=name)
-
-    from qiskit.circuit.library.hamiltonian_gate import HamiltonianGate
 
     for rep in range(reps):
         for i, op in enumerate(operators):
@@ -431,8 +431,6 @@ class EvolvedOperatorAnsatz(NLocal):
             return np.zeros(self.reps * len(self.operators), dtype=float)
 
     def _evolve_operator(self, operator, time):
-
-        from qiskit.circuit.library.hamiltonian_gate import HamiltonianGate
 
         # if the operator is specified as matrix use exact matrix exponentiation
         if isinstance(operator, Operator):

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -14,10 +14,13 @@
 
 from __future__ import annotations
 
-from qiskit.circuit import QuantumCircuit, Gate
+import typing
 
-from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.utils.deprecation import deprecate_func
+
+if typing.TYPE_CHECKING:
+    from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
 
 
 class PhaseOracle(QuantumCircuit):
@@ -66,6 +69,7 @@ class PhaseOracle(QuantumCircuit):
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
 
         if isinstance(expression, str):
             expression = BooleanExpression(expression, var_order=var_order)
@@ -134,6 +138,8 @@ class PhaseOracle(QuantumCircuit):
         Returns:
             PhaseOracle: A quantum circuit with a phase oracle.
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+
         expr = BooleanExpression.from_dimacs_file(filename)
         return cls(expr)
 
@@ -182,6 +188,8 @@ class PhaseOracleGate(Gate):
             label: A label for the gate to display in visualizations. Per default, the label is
                 set to display the textual representation of the boolean expression (truncated if needed)
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+
         if label is None:
             if isinstance(expression, str):
                 label = (expression[:15] + "...") if len(expression) > 15 else expression
@@ -248,5 +256,7 @@ class PhaseOracleGate(Gate):
         Returns:
             PhaseOracleGate: A quantum circuit with a phase oracle.
         """
+        from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
+
         expr = BooleanExpression.from_dimacs_file(filename)
         return cls(expr)


### PR DESCRIPTION
Synthesis is a higher-level concept than the descriptions of the library gates themselves.  While `qiskit.synthesis` is frequently used to provide the "default" synthesis of various library gates (the `Instruction.definition` field), those should be runtime-resolved imports, and it should be possible to completely resolve the `qiskit.circuit` module import before starting the import of `qiskit.synthesis`.

Being stricter about intended import order makes the logical separation of concerns clearer, but also lets us write our packages and imports using a proper public-interface setup.  If we're lax, we end up having so many files importing hyper-specific imports that make it unnecessarily hard to refactor later, and make annoying import cycles when modifying code.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
