### PR TITLE
test: implement lazy initialization for GenericBackendV2 in test suites (#16017)

### DIFF
--- a/test/python/primitives/test_backend_estimator_v2.py
+++ b/test/python/primitives/test_backend_estimator_v2.py
@@ -34,14 +34,35 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.utils import optionals
 from ..legacy_cmaps import LAGOS_CMAP
 
-BACKENDS = [
-    BasicSimulator(),
-    GenericBackendV2(
+
+def _basic_simulator():
+    return BasicSimulator()
+
+
+def _generic_backend_v2():
+    return GenericBackendV2(
         num_qubits=7,
         basis_gates=["id", "rz", "sx", "x", "cx", "reset"],
         coupling_map=LAGOS_CMAP,
         seed=42,
-    ),
+    )
+
+
+class _BackendFactory:
+    def __init__(self, name, factory):
+        self.__name__ = name
+        self._factory = factory
+
+    def __call__(self):
+        return self._factory()
+
+    def __repr__(self):
+        return self.__name__
+
+
+BACKENDS = [
+    _BackendFactory("basic_simulator", _basic_simulator),
+    _BackendFactory("generic_backend_v2", _generic_backend_v2),
 ]
 
 
@@ -89,6 +110,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_estimator_run(self, backend, abelian_grouping):
         """Test Estimator.run()"""
+        backend = backend()
         psi1, psi2 = self.psi
         hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
         theta1, theta2, theta3 = self.theta
@@ -136,6 +158,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_estimator_with_pub(self, backend, abelian_grouping):
         """Test estimator with explicit EstimatorPubs."""
+        backend = backend()
         psi1, psi2 = self.psi
         hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
         theta1, theta2, theta3 = self.theta
@@ -162,6 +185,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_estimator_run_no_params(self, backend, abelian_grouping):
         """test for estimator without parameters"""
+        backend = backend()
         circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
         circuit = pm.run(circuit)
@@ -174,6 +198,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_run_single_circuit_observable(self, backend, abelian_grouping):
         """Test for single circuit and single observable case."""
+        backend = backend()
         est = BackendEstimatorV2(backend=backend, options=self._options)
         est.options.abelian_grouping = abelian_grouping
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
@@ -232,6 +257,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_run_1qubit(self, backend, abelian_grouping):
         """Test for 1-qubit cases"""
+        backend = backend()
         qc = QuantumCircuit(1)
         qc2 = QuantumCircuit(1)
         qc2.x(0)
@@ -262,6 +288,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_run_2qubits(self, backend, abelian_grouping):
         """Test for 2-qubit cases (to check endian)"""
+        backend = backend()
         qc = QuantumCircuit(2)
         qc2 = QuantumCircuit(2)
         qc2.x(0)
@@ -301,6 +328,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_run_errors(self, backend, abelian_grouping):
         """Test for errors"""
+        backend = backend()
         qc = QuantumCircuit(1)
         qc2 = QuantumCircuit(2)
 
@@ -338,6 +366,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_run_numpy_params(self, backend, abelian_grouping):
         """Test for numpy array as parameter values"""
+        backend = backend()
         qc = QuantumCircuit(2)
         qc.append(real_amplitudes(num_qubits=2, reps=2), [0, 1])
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
@@ -367,6 +396,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_precision(self, backend, abelian_grouping):
         """Test for precision"""
+        backend = backend()
         estimator = BackendEstimatorV2(backend=backend, options=self._options)
         estimator.options.abelian_grouping = abelian_grouping
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
@@ -389,6 +419,7 @@ class TestBackendEstimatorV2(QiskitTestCase):
     @combine(backend=BACKENDS, abelian_grouping=[True, False])
     def test_diff_precision(self, backend, abelian_grouping):
         """Test for running different precisions at once"""
+        backend = backend()
         estimator = BackendEstimatorV2(backend=backend, options=self._options)
         estimator.options.abelian_grouping = abelian_grouping
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -38,14 +38,35 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.utils import optionals
 from ..legacy_cmaps import LAGOS_CMAP
 
-BACKENDS = [
-    BasicSimulator(),
-    GenericBackendV2(
+
+def _basic_simulator():
+    return BasicSimulator()
+
+
+def _generic_backend_v2():
+    return GenericBackendV2(
         num_qubits=7,
         basis_gates=["id", "rz", "sx", "x", "cx", "reset"],
         coupling_map=LAGOS_CMAP,
         seed=42,
-    ),
+    )
+
+
+class _BackendFactory:
+    def __init__(self, name, factory):
+        self.__name__ = name
+        self._factory = factory
+
+    def __call__(self):
+        return self._factory()
+
+    def __repr__(self):
+        return self.__name__
+
+
+BACKENDS = [
+    _BackendFactory("basic_simulator", _basic_simulator),
+    _BackendFactory("generic_backend_v2", _generic_backend_v2),
 ]
 
 
@@ -159,6 +180,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_sampler_run(self, backend):
         """Test run()."""
+        backend = backend()
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
 
         with self.subTest("single"):
@@ -210,6 +232,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_sampler_run_multiple_times(self, backend):
         """Test run() returns the same results if the same input is given."""
+        backend = backend()
         bell, _, _ = self._cases[1]
         sampler = BackendSamplerV2(backend=backend, options=self._options)
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
@@ -223,6 +246,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_sample_run_multiple_circuits(self, backend):
         """Test run() with multiple circuits."""
+        backend = backend()
         bell, _, target = self._cases[1]
         sampler = BackendSamplerV2(backend=backend, options=self._options)
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
@@ -236,6 +260,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_1qubit(self, backend):
         """test for 1-qubit cases"""
+        backend = backend()
         qc = QuantumCircuit(1)
         qc.measure_all()
         qc2 = QuantumCircuit(1)
@@ -253,6 +278,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_2qubit(self, backend):
         """test for 2-qubit cases"""
+        backend = backend()
         qc0 = QuantumCircuit(2)
         qc0.measure_all()
         qc1 = QuantumCircuit(2)
@@ -276,6 +302,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_single_circuit(self, backend):
         """Test for single circuit case."""
+        backend = backend()
         sampler = BackendSamplerV2(backend=backend, options=self._options)
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
 
@@ -334,6 +361,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_reverse_meas_order(self, backend):
         """test for sampler with reverse measurement order"""
+        backend = backend()
         x = Parameter("x")
         y = Parameter("y")
 
@@ -361,6 +389,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_errors(self, backend):
         """Test for errors with run method"""
+        backend = backend()
         qc1 = QuantumCircuit(1)
         qc1.measure_all()
         qc2 = QuantumCircuit(2)
@@ -414,6 +443,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_empty_parameter(self, backend):
         """Test for empty parameter"""
+        backend = backend()
         n = 5
         qc = QuantumCircuit(n, n - 1)
         qc.measure(range(n - 1), range(n - 1))
@@ -434,6 +464,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_numpy_params(self, backend):
         """Test for numpy array as parameter values"""
+        backend = backend()
         qc = QuantumCircuit(2)
         qc.append(real_amplitudes(num_qubits=2, reps=2), [0, 1])
         qc.measure_all()
@@ -465,6 +496,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_with_shots_option(self, backend):
         """test with shots option."""
+        backend = backend()
         bell, _, _ = self._cases[1]
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
         bell = pm.run(bell)
@@ -529,6 +561,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_shots_result_size(self, backend):
         """test with shots option to validate the result size"""
+        backend = backend()
         n = 7  # should be less than or equal to the number of qubits of backend
         qc = QuantumCircuit(n)
         qc.h(range(n))
@@ -593,6 +626,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_primitive_job_status_done(self, backend):
         """test primitive job's status"""
+        backend = backend()
         bell, _, _ = self._cases[1]
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
         bell = pm.run(bell)
@@ -604,6 +638,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_circuit_with_unitary(self, backend):
         """Test for circuit with unitary gate."""
+        backend = backend()
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
 
         with self.subTest("identity"):
@@ -635,6 +670,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_circuit_with_multiple_cregs(self, backend):
         """Test for circuit with multiple classical registers."""
+        backend = backend()
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
         cases = []
 
@@ -760,6 +796,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_no_cregs(self, backend):
         """Test that the sampler works when there are no classical register in the circuit."""
+        backend = backend()
         qc = QuantumCircuit(2)
         sampler = BackendSamplerV2(backend=backend, options=self._options)
         with self.assertWarns(UserWarning):
@@ -771,6 +808,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_empty_creg(self, backend):
         """Test that the sampler works if provided a classical register with no bits."""
+        backend = backend()
         # Test case for issue #12043
         q = QuantumRegister(1, "q")
         c1 = ClassicalRegister(0, "c1")
@@ -786,6 +824,7 @@ class TestBackendSamplerV2(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_diff_shots(self, backend):
         """Test of pubs with different shots"""
+        backend = backend()
         pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
 
         bell, _, target = self._cases[1]

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -27,10 +27,13 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from test import QiskitTestCase, combine
 
 
-BACKENDS = []
-for n in [5, 7, 16, 20, 27, 65, 127]:
-    cmap = CouplingMap.from_ring(n)
-    BACKENDS.append(GenericBackendV2(num_qubits=n, coupling_map=cmap, seed=42))
+BACKEND_NUM_QUBITS = (5, 7, 16, 20, 27, 65, 127)
+
+
+def _generic_backend(num_qubits):
+    return GenericBackendV2(
+        num_qubits=num_qubits, coupling_map=CouplingMap.from_ring(num_qubits), seed=42
+    )
 
 
 @ddt
@@ -231,12 +234,13 @@ class TestGenericBackendV2(QiskitTestCase):
         self.assertEqual(ref_backend.dt * 2, double_dt_backend.dt)
 
     @combine(
-        backend=BACKENDS,
+        num_qubits=BACKEND_NUM_QUBITS,
         optimization_level=[0, 1, 2, 3],
     )
-    def test_circuit_on_generic_backend_v2(self, backend, optimization_level):
+    def test_circuit_on_generic_backend_v2(self, num_qubits, optimization_level):
         """Test run method."""
 
+        backend = _generic_backend(num_qubits)
         if not optionals.HAS_AER and backend.num_qubits > 20:
             self.skipTest(f"Unable to run generic backend {backend.name} without qiskit-aer")
         job = backend.run(
@@ -250,18 +254,20 @@ class TestGenericBackendV2(QiskitTestCase):
         max_count = max(counts.items(), key=operator.itemgetter(1))[0]
         self.assertEqual(max_count, "11")
 
-    @data(*BACKENDS)
-    def test_backend_v2_dt(self, backend):
+    @data(*BACKEND_NUM_QUBITS)
+    def test_backend_v2_dt(self, num_qubits):
         """Test default dt value is consistent with legacy fake backends."""
 
+        backend = _generic_backend(num_qubits)
         target = backend.target
         if target.dt is not None:
             self.assertLess(target.dt, 1e-6)
 
-    @data(*BACKENDS)
-    def test_backend_v2_dtm(self, backend):
+    @data(*BACKEND_NUM_QUBITS)
+    def test_backend_v2_dtm(self, num_qubits):
         """Test default dtm value is consistent with legacy fake backends."""
 
+        backend = _generic_backend(num_qubits)
         if backend.dtm:
             self.assertLess(backend.dtm, 1e-6)
 

--- a/test/python/transpiler/test_1q.py
+++ b/test/python/transpiler/test_1q.py
@@ -22,9 +22,11 @@ from qiskit.transpiler import TranspilerError
 from test import combine
 from test import QiskitTestCase
 
-Fake1QV2 = GenericBackendV2(
-    num_qubits=1, basis_gates=["u1", "u2", "u3"], coupling_map=None, dtm=1.3333, seed=42
-)
+
+def fake_1q_v2():
+    return GenericBackendV2(
+        num_qubits=1, basis_gates=["u1", "u2", "u3"], coupling_map=None, dtm=1.3333, seed=42
+    )
 
 
 def emptycircuit():
@@ -54,7 +56,7 @@ class Test1QV2Failing(QiskitTestCase):
     def test(self, circuit, level):
         """All the levels with all the 1Q backendV2"""
         with self.assertRaises(TranspilerError):
-            transpile(circuit(), backend=Fake1QV2, optimization_level=level, seed_transpiler=42)
+            transpile(circuit(), backend=fake_1q_v2(), optimization_level=level, seed_transpiler=42)
 
 
 @ddt
@@ -87,6 +89,6 @@ class Test1QV2Working(QiskitTestCase):
     def test_device(self, circuit, level):
         """All the levels with all the 1Q backendV2"""
         result = transpile(
-            circuit(), backend=Fake1QV2, optimization_level=level, seed_transpiler=42
+            circuit(), backend=fake_1q_v2(), optimization_level=level, seed_transpiler=42
         )
         self.assertIsInstance(result, QuantumCircuit)

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -356,29 +356,35 @@ class TestPresetPassManager(QiskitTestCase):
 class TestTranspileLevels(QiskitTestCase):
     """Test transpiler on fake backend"""
 
+    BACKEND_CONFIGS = {
+        "bogota": (5, BOGOTA_CMAP),
+        "tokyo": (20, TOKYO_CMAP),
+        "none": None,
+    }
+
+    @staticmethod
+    def _backend_from_name(name):
+        config = TestTranspileLevels.BACKEND_CONFIGS[name]
+        if config is None:
+            return None
+        num_qubits, coupling_map = config
+        return GenericBackendV2(
+            num_qubits=num_qubits,
+            coupling_map=coupling_map,
+            basis_gates=["id", "u1", "u2", "u3", "cx"],
+            seed=42,
+        )
+
     @combine(
         circuit=[emptycircuit, circuit_2532],
         level=[0, 1, 2, 3],
-        backend=[
-            GenericBackendV2(
-                num_qubits=5,
-                coupling_map=BOGOTA_CMAP,
-                basis_gates=["id", "u1", "u2", "u3", "cx"],
-                seed=42,
-            ),
-            GenericBackendV2(
-                num_qubits=20,
-                coupling_map=TOKYO_CMAP,
-                basis_gates=["id", "u1", "u2", "u3", "cx"],
-                seed=42,
-            ),
-            None,
-        ],
+        backend=BACKEND_CONFIGS,
         dsc="Transpiler {circuit.__name__} on {backend} backend at level {level}",
         name="{circuit.__name__}_{backend}_level{level}",
     )
     def test(self, circuit, level, backend):
         """All the levels with all the backends"""
+        backend = self._backend_from_name(backend)
         result = transpile(circuit(), backend=backend, optimization_level=level, seed_transpiler=42)
         self.assertIsInstance(result, QuantumCircuit)
 

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -41,17 +41,19 @@ if optionals.HAS_PIL:
 class TestGateMap(QiskitVisualizationTestCase):
     """visual tests for plot_gate_map"""
 
-    backends = [
-        GenericBackendV2(num_qubits=5, coupling_map=YORKTOWN_CMAP, seed=0),
-        GenericBackendV2(num_qubits=20, coupling_map=ALMADEN_CMAP, seed=0),
-        GenericBackendV2(num_qubits=7, coupling_map=LAGOS_CMAP, seed=0),
-    ]
+    backend_configs = {
+        "yorktown": (5, YORKTOWN_CMAP),
+        "almaden": (20, ALMADEN_CMAP),
+        "lagos": (7, LAGOS_CMAP),
+    }
 
-    @data(*backends)
+    @data(*backend_configs)
     @unittest.skipIf(not optionals.HAS_MATPLOTLIB, "matplotlib not available.")
     @unittest.skipUnless(optionals.HAS_GRAPHVIZ, "Graphviz not installed")
-    def test_plot_gate_map(self, backend):
+    def test_plot_gate_map(self, backend_name):
         """tests plotting of gate map of a device (20 qubit, 7 qubit, and 5 qubit)"""
+        n, coupling_map = self.backend_configs[backend_name]
+        backend = GenericBackendV2(num_qubits=n, coupling_map=coupling_map, seed=0)
         n = backend.num_qubits
         img_ref = path_to_diagram_reference(str(n) + "bit_quantum_computer.png")
         fig = plot_gate_map(backend)
@@ -61,11 +63,13 @@ class TestGateMap(QiskitVisualizationTestCase):
             self.assertImagesAreEqual(Image.open(img_buffer), img_ref, 0.1)
         plt.close(fig)
 
-    @data(*backends)
+    @data(*backend_configs)
     @unittest.skipIf(not optionals.HAS_MATPLOTLIB, "matplotlib not available.")
     @unittest.skipUnless(optionals.HAS_GRAPHVIZ, "Graphviz not installed")
-    def test_plot_circuit_layout(self, backend):
+    def test_plot_circuit_layout(self, backend_name):
         """tests plot_circuit_layout for each device"""
+        n, coupling_map = self.backend_configs[backend_name]
+        backend = GenericBackendV2(num_qubits=n, coupling_map=coupling_map, seed=0)
         layout_length = int(backend.num_qubits / 2)
         qr = QuantumRegister(layout_length, "qr")
         circuit = QuantumCircuit(qr)

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -162,29 +162,33 @@ backend_needs_durations = _strtobool(
 )
 
 
-mock_backends = [
-    GenericBackendV2(num_qubits=5, seed=0),
-    GenericBackendV2(num_qubits=5, seed=2),
-    GenericBackendV2(num_qubits=20, coupling_map=ALMADEN_CMAP, seed=5),
-    GenericBackendV2(num_qubits=127, coupling_map=KYOTO_CMAP, seed=42),
+mock_backend_configs = [
+    {"num_qubits": 5, "seed": 0},
+    {"num_qubits": 5, "seed": 2},
+    {"num_qubits": 20, "coupling_map": ALMADEN_CMAP, "seed": 5},
+    {"num_qubits": 127, "coupling_map": KYOTO_CMAP, "seed": 42},
 ]
 
-mock_backends_with_scheduling = mock_backends
+mock_backend_configs_with_scheduling = mock_backend_configs
+
+
+def _mock_backend(config):
+    return GenericBackendV2(**config)
 
 
 @st.composite
 def transpiler_conf(draw):
     """Composite search strategy to pick a valid transpiler config."""
-    all_backends = st.one_of(st.none(), st.sampled_from(mock_backends))
-    scheduling_backends = st.sampled_from(mock_backends_with_scheduling)
+    all_backend_configs = st.one_of(st.none(), st.sampled_from(mock_backend_configs))
+    scheduling_backend_configs = st.sampled_from(mock_backend_configs_with_scheduling)
     scheduling_method = draw(st.sampled_from(scheduling_methods))
-    backend = (
-        draw(scheduling_backends)
+    backend_config = (
+        draw(scheduling_backend_configs)
         if scheduling_method or backend_needs_durations
-        else draw(all_backends)
+        else draw(all_backend_configs)
     )
     return {
-        "backend": backend,
+        "backend": None if backend_config is None else _mock_backend(backend_config),
         "optimization_level": draw(st.integers(min_value=0, max_value=3)),
         "layout_method": draw(st.sampled_from(layout_methods)),
         "routing_method": draw(st.sampled_from(routing_methods)),


### PR DESCRIPTION
### Summary
This PR addresses issue #16017 by deferring the heavy initialization of `GenericBackendV2` instances within multiple test suites. Instead of constructing the backends globally or during modules import phase, they are now lazily initialized when the specific tests actually require them.

### Details & Fixes
- **Problem:** Heavy components like `GenericBackendV2` were being instantiated during the test collection phase or unconditionally at the module level. This caused noticeable delays in the test collection phase and triggered unwanted breakpoints even when running isolated, unrelated tests.
- **Solution:** Refactored the test suites to utilize lazy initialization/construction for `GenericBackendV2` instances. The backends are now built on-demand inside the test methods or setup methods.
- **Impact:** Accelerated test execution setup and resolved debugging/breakpoint interference across the test suites.

### Changed Files
The optimization has been applied to the following 7 test modules:
1. `test/python/providers/fake_provider/test_generic_backend_v2.py`
2. `test/python/transpiler/test_1q.py`
3. `test/python/visualization/test_gate_map.py`
4. `test/python/randomized/test_transpiler_equivalence.py`
5. `test/python/transpiler/test_preset_passmanagers.py`
6. `test/python/primitives/test_backend_estimator_v2.py`
7. `test/python/primitives/test_backend_sampler_v2.py`

### Verification
- Verified using `ast` checks and syntax verification (`py_compile`).
- Checked code compliance via `git diff --check`.
- Ran the affected test suites locally; all 20+ core tests and 28 `TestTranspileLevels` passed successfully.

Fixes #16017 

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description(gemini 3.1 pro)
- [ ] I used the following tool to generate or modify code.
