### PR TITLE
Fix vtable slot regression introduced by #15783.

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -353,7 +353,6 @@ mod transpiler {
 
         static FUNCTIONS_PASSES: ExportedFunctions = ExportedFunctions::leaves(50, || {
             vec![
-                export_fn!(basis_translator::qk_transpiler_pass_basis_translator),
                 export_fn!(elide_permutations::qk_transpiler_pass_elide_permutations),
                 export_fn!(gate_direction::qk_transpiler_pass_check_gate_direction),
                 export_fn!(gate_direction::qk_transpiler_pass_gate_direction),
@@ -361,6 +360,7 @@ mod transpiler {
                 export_fn!(remove_diagonal_gates_before_measure::qk_transpiler_pass_remove_diagonal_gates_before_measure),
                 export_fn!(remove_identity_equiv::qk_transpiler_pass_remove_identity_equivalent),
                 export_fn!(split_2q_unitaries::qk_transpiler_pass_split_2q_unitaries),
+                export_fn!(basis_translator::qk_transpiler_pass_basis_translator),
             ]
         });
         static FUNCTIONS_STANDALONE: ExportedFunctions = ExportedFunctions::leaves(50, || {


### PR DESCRIPTION
Fix vtable slot regression introduced by #15783.

`qk_transpiler_pass_basis_translator` was prepended to the `FUNCTIONS_PASSES` table in `cext-vtable`, shifting the slot numbers of every subsequent pass forward by one. Since vtable slots are stable public API (see the `WARNING` comment in `cext-vtable/src/lib.rs`), this is a breaking change for any consumer that had already linked against a build containing the previous assignments.

The fix moves `qk_transpiler_pass_basis_translator` to the end of the table, restoring the original slot assignments for all
existing passes.

I used the following tool to help write this PR description: Claude Code