### PR TITLE
Revert "Add DAG-based variant of BasisTranslator transpiler pass in C API"

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -353,7 +353,6 @@ mod transpiler {
 
         static FUNCTIONS_PASSES: ExportedFunctions = ExportedFunctions::leaves(50, || {
             vec![
-                export_fn!(basis_translator::qk_transpiler_pass_basis_translator),
                 export_fn!(elide_permutations::qk_transpiler_pass_elide_permutations),
                 export_fn!(gate_direction::qk_transpiler_pass_check_gate_direction),
                 export_fn!(gate_direction::qk_transpiler_pass_gate_direction),

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -20,7 +20,8 @@ use qiskit_transpiler::target::Target;
 /// @ingroup QkTranspilerPassesStandalone
 /// Run the BasisTranslator transpiler pass on a circuit.
 ///
-/// Refer to the ``qk_transpiler_pass_basis_translator`` function for more details about the pass.
+/// The BasisTranslator transpiler pass translates gates to a target basis by
+/// searching for a set of translations from the standard EquivalenceLibrary.
 ///
 /// @param circuit A pointer to the circuit to run BasisTranslator on.
 /// The circuit will be mutated in-place, unless the circuit is already
@@ -28,6 +29,29 @@ use qiskit_transpiler::target::Target;
 /// @param target The target where we will obtain basis gates from.
 /// @param min_qubits The minimum number of qubits for operations in the input
 /// circuit to translate.
+///
+/// # Example
+///
+/// ```c
+///    #include <qiskit.h>
+///
+///    QkCircuit *circuit = qk_circuit_new(3, 0);
+///    qk_circuit_gate(circuit, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL);
+///
+///    // Create a Target with global properties.
+///    QkTarget *target = qk_target_new(3);
+///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
+///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
+///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
+///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
+///
+///    // Run pass
+///    qk_transpiler_pass_standalone_basis_translator(circuit, target, 0);
+///
+///    // Free the circuit and target pointers once you're done
+///    qk_circuit_free(circuit);
+///    qk_target_free(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -58,68 +82,4 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_basis_translator(
     let result_circ =
         CircuitData::from_dag_ref(&result_dag).expect("DAG to Circuit conversion failed");
     *circ_from_ptr = result_circ;
-}
-
-/// @ingroup QkTranspilerPasses
-/// Run the BasisTranslator transpiler pass on a DAG circuit.
-///
-/// The BasisTranslator transpiler pass translates gates to a target basis by
-/// searching for a set of translations from the standard EquivalenceLibrary.
-/// The DAG will be mutated in-place, unless the DAG is already in the target
-/// basis, in which case the DAG remains unchanged.
-///
-/// @param dag A pointer to the DAG to run BasisTranslator on.
-/// @param target The target where we will obtain basis gates from.
-/// @param min_qubits The minimum number of qubits for operations in the input
-/// DAG to translate.
-///
-/// # Example
-///
-/// ```c
-/// QkDag *dag = qk_dag_new();
-/// QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
-/// qk_dag_add_quantum_register(dag, qr);
-/// uint32_t qargs[3] = {0, 1, 2};
-/// qk_dag_apply_gate(dag, QkGate_CCX, qargs, NULL, false);
-///
-/// // Create a Target with global properties.
-/// QkTarget *target = qk_target_new(3);
-/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
-/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
-/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
-/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
-///
-/// // Run pass
-/// qk_transpiler_pass_basis_translator(dag, target, 0);
-///
-/// // Free the DAG and target pointers once you're done
-/// qk_quantum_register_free(qr);
-/// qk_dag_free(dag);
-/// qk_target_free(target);
-/// ```
-///
-/// # Safety
-///
-/// Behavior is undefined if ``dag`` and/or ``target`` are not valid, non-null
-/// pointers to a ``QkDag`` or ``QkTarget``.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_transpiler_pass_basis_translator(
-    dag: *mut DAGCircuit,
-    target: *const Target,
-    min_qubits: usize,
-) {
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let dag = unsafe { mut_ptr_as_ref(dag) };
-    // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let target = unsafe { const_ptr_as_ref(target) };
-
-    let mut equiv_lib = generate_standard_equivalence_library();
-
-    let result_dag = match run_basis_translator(dag, &mut equiv_lib, min_qubits, Some(target), None)
-    {
-        Ok(Some(result)) => result,
-        Ok(None) => return,
-        Err(e) => panic!("{}", e),
-    };
-    *dag = result_dag;
 }

--- a/releasenotes/notes/basis-translator-dag-pass-capi-e7b6a796d4185f9a.yaml
+++ b/releasenotes/notes/basis-translator-dag-pass-capi-e7b6a796d4185f9a.yaml
@@ -1,7 +1,0 @@
----
-features_c:
-  - |
-    Added :c:func:`qk_transpiler_pass_basis_translator`, a DAG-based variant of the
-    BasisTranslator transpiler pass in the C API. This function operates directly on
-    a :c:struct:`QkDag` object instead of a :c:struct:`QkCircuit`, avoiding the overhead
-    of circuit-to-DAG and DAG-to-circuit conversions when chaining multiple passes together.

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -152,104 +152,11 @@ cleanup:
     return result;
 }
 
-static int test_dag_in_basis(void) {
-    int result = Ok;
-    QkDag *dag = qk_dag_new();
-    QkQuantumRegister *qr = qk_quantum_register_new(2, "qr");
-    qk_dag_add_quantum_register(dag, qr);
-    qk_dag_apply_gate(dag, QkGate_H, (uint32_t[1]){0}, NULL, false);
-    qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[2]){0, 1}, NULL, false);
-
-    // Create Target already compatible with the DAG.
-    QkTarget *target = qk_target_new(1);
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
-
-    // Run pass
-    qk_transpiler_pass_basis_translator(dag, target, 0);
-
-    size_t num_ops = qk_dag_num_op_nodes(dag);
-    if (num_ops != 2) {
-        result = EqualityError;
-        printf(
-            "The number of gates resulting from the translation is incorrect. Expected 2, got %zu",
-            num_ops);
-    }
-
-    qk_dag_free(dag);
-    qk_quantum_register_free(qr);
-    qk_target_free(target);
-    return result;
-}
-
-static int test_basic_dag_basis_translator(void) {
-    int result = Ok;
-    QkDag *dag = qk_dag_new();
-    QkQuantumRegister *qr = qk_quantum_register_new(1, "qr");
-    qk_dag_add_quantum_register(dag, qr);
-    qk_dag_apply_gate(dag, QkGate_H, (uint32_t[1]){0}, NULL, false);
-
-    // Create Target compatible with only U gates, with global props.
-    QkTarget *target = qk_target_new(1);
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_U));
-
-    // Run pass
-    qk_transpiler_pass_basis_translator(dag, target, 0);
-
-    size_t num_ops = qk_dag_num_op_nodes(dag);
-    if (num_ops != 1) {
-        result = EqualityError;
-        printf(
-            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
-            num_ops);
-    }
-
-    qk_dag_free(dag);
-    qk_quantum_register_free(qr);
-    qk_target_free(target);
-    return result;
-}
-
-static int test_toffoli_dag_basis_translator(void) {
-    int result = Ok;
-    QkDag *dag = qk_dag_new();
-    QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
-    qk_dag_add_quantum_register(dag, qr);
-    qk_dag_apply_gate(dag, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL, false);
-
-    // Create Target compatible with H, T, Tdg, CX gates, with global props.
-    QkTarget *target = qk_target_new(3);
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
-    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
-
-    // Run pass
-    qk_transpiler_pass_basis_translator(dag, target, 0);
-
-    size_t num_ops = qk_dag_num_op_nodes(dag);
-    // CCX decomposes into 6 CX + 4 T + 3 Tdg + 2 H = 15 gates
-    if (num_ops != 15) {
-        result = EqualityError;
-        printf(
-            "The number of gates resulting from the translation is incorrect. Expected 15, got %zu",
-            num_ops);
-    }
-
-    qk_dag_free(dag);
-    qk_quantum_register_free(qr);
-    qk_target_free(target);
-    return result;
-}
-
 int test_basis_translator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_circuit_in_basis);
     num_failed += RUN_TEST(test_basic_basis_translator);
     num_failed += RUN_TEST(test_toffoli_basis_translator);
-    num_failed += RUN_TEST(test_dag_in_basis);
-    num_failed += RUN_TEST(test_basic_dag_basis_translator);
-    num_failed += RUN_TEST(test_toffoli_dag_basis_translator);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
This PR reverts Qiskit/qiskit#15783, based on [this comment](https://github.com/Qiskit/qiskit/pull/15783#issuecomment-4520076621):
>1. `qk_transpiler_pass_basis_translator` was added to the beginning of the `FUNCTION_PASSES table`, effectively changing the slot numbers of the subsequent functions.
> 2. We have the `generate_standard_equivalence_library() call inside the "run" function of the pass now. Thinking about a custom stage use-case where this pass might run in a loop, I think a better API would be to take the equivalence library from the outside.

We could have gone with fixing the vtable to address the ABI issue and then hold a discussion about the API change mentioned in point 2. However, since we are only several days away from feature freeze and the API discussion might take time, likely ending up with a function signature change, I think it's better to revert this and open a new PR to address both points in the comment, without the pressure of the imminent feature freeze. 