### PR TITLE
Add rust short circuit to unitariy synthesis if no nodes to synthesize

### DIFF
--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -104,7 +104,9 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };
-    *circuit = CircuitData::from_dag_ref(&out_dag).unwrap();
+    if let Some(out_dag) = out_dag {
+        *circuit = CircuitData::from_dag_ref(&out_dag).unwrap();
+    }
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/transpiler/src/passes/unitary_synthesis/mod.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/mod.rs
@@ -311,7 +311,7 @@ pub fn run_unitary_synthesis(
     qubit_indices: &[PhysicalQubit],
     state: &mut UnitarySynthesisState,
     constraint: QpuConstraint,
-) -> PyResult<DAGCircuit> {
+) -> PyResult<Option<DAGCircuit>> {
     // This method is the actual distribution logic of unitary synthesis, but there are several
     // paths through it that return `Ok(false)`, meaning "no error and no synthesis needed", so the
     // caller is responsible for propagating the old instruction through to wherever is necessary.
@@ -334,6 +334,15 @@ pub fn run_unitary_synthesis(
             constraint,
         )
     };
+    let op_counts = dag.count_ops(true)?;
+    let gate_counts: usize = synth_gates
+        .iter()
+        .map(|name| op_counts.get(name).unwrap_or(&0usize))
+        .copied()
+        .sum();
+    if gate_counts == 0 {
+        return Ok(None);
+    }
 
     let mut out = dag
         .copy_empty_like(VarsMode::Alike, BlocksMode::Drop)?
@@ -352,21 +361,27 @@ pub fn run_unitary_synthesis(
         let blocks = cf
             .blocks()
             .into_iter()
-            .map(|block| {
+            .map(|orig_block| {
                 let qubit_indices = dag
                     .get_qargs(inst.qubits)
                     .iter()
                     .map(|q| qubit_indices[q.index()])
                     .collect::<Vec<_>>();
                 run_unitary_synthesis(
-                    block,
+                    orig_block,
                     synth_gates,
                     min_qubits,
                     &qubit_indices,
                     state,
                     constraint,
                 )
-                .map(|block| out.add_block(block))
+                .map(|block| {
+                    if let Some(block) = block {
+                        out.add_block(block)
+                    } else {
+                        out.add_block(orig_block.clone())
+                    }
+                })
             })
             .collect::<PyResult<_>>()?;
         out.push_back(PackedInstruction::from_control_flow(
@@ -377,7 +392,7 @@ pub fn run_unitary_synthesis(
             inst.label.as_deref().cloned(),
         ))?;
     }
-    Ok(out.build())
+    Ok(Some(out.build()))
 }
 
 /// Synthesise a matrix onto the DAG.
@@ -739,7 +754,7 @@ pub fn py_unitary_synthesis(
     approximation_degree: Option<f64>,
     natural_direction: Option<bool>,
     pulse_optimize: Option<bool>,
-) -> PyResult<DAGCircuit> {
+) -> PyResult<Option<DAGCircuit>> {
     let config = UnitarySynthesisConfig {
         approximation: Approximation::from_py_approximation_degree(approximation_degree),
         use_pulse_optimizer: UsePulseOptimizer::from_py_pulse_optimize(pulse_optimize),

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -64,14 +64,16 @@ fn unroll_3q_or_more(
     let physical_qubits = (0..target.num_qubits.unwrap_or(0))
         .map(PhysicalQubit::new)
         .collect::<Vec<_>>();
-    *dag = run_unitary_synthesis(
+    if let Some(out) = run_unitary_synthesis(
         dag,
         &["unitary", "swap"].map(String::from).into_iter().collect(),
         3,
         &physical_qubits,
         synthesis_state,
         target.into(),
-    )?;
+    )? {
+        *dag = out;
+    }
     run_unroll_3q_or_more(dag, Some(target))?;
     Ok(())
 }
@@ -307,14 +309,16 @@ pub fn translation_stage(
     let physical_qubits = (0..target.num_qubits.unwrap_or(0))
         .map(PhysicalQubit::new)
         .collect::<Vec<_>>();
-    *dag = run_unitary_synthesis(
+    if let Some(out) = run_unitary_synthesis(
         dag,
         &["unitary".to_string()].into_iter().collect(),
         0,
         &physical_qubits,
         synthesis_state,
         target.into(),
-    )?;
+    )? {
+        *dag = out;
+    }
     if let Some(out_dag) = run_basis_translator(dag, equiv_lib, 0, Some(target), None)? {
         *dag = out_dag;
     }
@@ -366,14 +370,16 @@ pub fn optimization_stage(
         }
     } else if optimization_level == OptimizationLevel::Level2 {
         run_consolidate_blocks(dag, false, approximation_degree, Some(target))?;
-        *dag = run_unitary_synthesis(
+        if let Some(out) = run_unitary_synthesis(
             dag,
             &["unitary".to_string()].into_iter().collect(),
             0,
             &physical_qubits,
             synthesis_state,
             target.into(),
-        )?;
+        )? {
+            *dag = out;
+        }
         new_depth = Some(dag.depth(false)?);
         new_size = Some(dag.size(false)?);
         while new_depth != depth || new_size != size {
@@ -394,14 +400,16 @@ pub fn optimization_stage(
 
         while continue_loop {
             run_consolidate_blocks(dag, false, approximation_degree, Some(target))?;
-            *dag = run_unitary_synthesis(
+            if let Some(out) = run_unitary_synthesis(
                 dag,
                 &["unitary"].into_iter().map(|x| x.to_string()).collect(),
                 0,
                 &physical_qubits,
                 synthesis_state,
                 target.into(),
-            )?;
+            )? {
+                *dag = out
+            }
             run_remove_identity_equiv(dag, approximation_degree, Some(target))?;
             run_optimize_1q_gates_decomposition(dag, Some(target), None, None)?;
             cancel_commutations(dag, commutation_checker, None, 1.0)?;

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -195,7 +195,10 @@ class UnitarySynthesis(TransformationPass):
                 self._natural_direction,
                 self._pulse_optimize,
             )
-            return out
+            if out is None:
+                return dag
+            else:
+                return out
 
         if self.plugins:
             plugin_method = self.plugins.ext_plugins[self.method].obj


### PR DESCRIPTION
The unitary synthesis pass is a no-op if there are no gates to synthesize in the circuit. The dag maintains a count of all the operations it contains so it is trivial to check if there are any operations to synthesize up front before running the pass. This check existed in the python code for the Python version of the pass. But it was missing from the rust code which means when the pass is run from C, either as a standalone function or as part of the C transpiler, we were not doing this short circuit. This adds the skip logic ot the Rust code for the pass so that C can benefit from the performance benefit of not iterating over and reconstructing the dag if it's not necessary. The python short circuit is left in place because the python pass may not call the rust code (if a unitary synthesis plugin is called).

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
