### PR TITLE
Fix panic on `1.0` error in `VF2Layout`

### DIFF
--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -446,11 +446,19 @@ impl<T> VirtualInteractions<T> {
     }
 }
 
+/// Calculate a safe version of `-ln(1 - e)`, where the result is guaranteed to be finite.
+///
+/// This treats `nan` as `0.0`, and clamps errors to the `[0.0, 1.0]` interval.  An error of `1.0`
+/// should arguably have an infinite cost, but we use `f64::MAX` instead so the score is guaranteed
+/// to be finite, and safe to multiply by any other floating-point value.
 fn neg_log_fidelity(error: f64) -> f64 {
     if error.is_nan() || error <= 0. {
         0.0
     } else if error >= 1. {
-        f64::INFINITY
+        // Logically this would be cleaner as `INFINITY`, but it's better to allow the downstream
+        // scoring to rely on this value being finite, so we don't have to branch in inner-loop
+        // scoring code.
+        f64::MAX
     } else {
         -((-error).ln_1p())
     }

--- a/releasenotes/notes/vf2-infinity-nan-04c7d5822d9079be.yaml
+++ b/releasenotes/notes/vf2-infinity-nan-04c7d5822d9079be.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.VF2Layout` and :class:`.VF2PostLayout` will no longer panic saying
+    "float scores must not return nan" when encountering instructions with errors
+    reported as ``1.0``.

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -22,8 +22,9 @@ import numpy
 import rustworkx
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
-from qiskit.circuit import ControlFlowOp, Qubit
+from qiskit.circuit import ControlFlowOp, Qubit, library as lib, Parameter
 from qiskit.transpiler import CouplingMap, Target, TranspilerError
+from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes.layout.vf2_layout import VF2Layout, VF2LayoutStopReason
 from qiskit._accelerate.error_map import ErrorMap
 from qiskit.converters import circuit_to_dag
@@ -654,6 +655,47 @@ class TestVF2LayoutOther(LayoutTestCase):
         self.assertEqual(
             vf2_pass.property_set["VF2Layout_stop_reason"], VF2LayoutStopReason.SOLUTION_FOUND
         )
+
+    def test_error_clipping(self):
+        """Out-of-range errors should clip to 0.0 and 1.0, and be safely usable."""
+        target = Target(3)
+        props_1q = {
+            # Too low.
+            (0,): InstructionProperties(error=-1e-15),
+            # Too high.
+            (1,): InstructionProperties(error=1 + 1e-15),
+            # Juuuuust right.
+            (2,): InstructionProperties(error=1e-5),
+        }
+        # Set the same 1q on both types of 1q operation because we don't want any averaging to mess
+        # with our clipping.
+        target.add_instruction(lib.SXGate(), props_1q)
+        target.add_instruction(lib.RZGate(Parameter("a")), props_1q)
+        target.add_instruction(
+            lib.CXGate(),
+            {
+                (0, 1): InstructionProperties(error=-1e-15),
+                (1, 2): InstructionProperties(error=1 + 1e-15),
+                (2, 0): InstructionProperties(error=1e-5),
+            },
+        )
+
+        # This circuit has a symmetric interaction graph, but we break the degeneracy by weighting
+        # each edge and node by different amounts, so the resulting layout will be deterministic.
+        # One qubit deliberately doesn't have any instructions so we test the zero-weighted path
+        # with all the types of clipped error too.
+        qc = QuantumCircuit(3)
+        qc.cx(1, 0)
+        qc.cx(2, 1)
+        qc.cx(2, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 2)
+        qc.cx(0, 2)
+        qc.sx(1)
+        qc.sx(2)
+
+        qc = PassManager([VF2Layout(target=target), ApplyLayout()]).run(qc)
+        self.assertEqual(qc.layout.initial_index_layout(), [1, 2, 0])
 
 
 class TestMultipleTrials(QiskitTestCase):

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -431,7 +431,7 @@ class TestVF2PostLayout(QiskitTestCase):
             {
                 (0, 1): InstructionProperties(error=-1e-15),
                 (1, 2): InstructionProperties(error=1 + 1e-15),
-                (2, 0): InstructionProperties(error=1e-5),
+                (2, 0): InstructionProperties(error=1e-3),
             },
         )
 
@@ -440,10 +440,7 @@ class TestVF2PostLayout(QiskitTestCase):
         # One qubit deliberately doesn't have any instructions so we test the zero-weighted path
         # with all the types of clipped error too.
         qc = QuantumCircuit(3)
-        qc.cx(1, 0)
         qc.cx(2, 1)
-        qc.cx(2, 1)
-        qc.cx(0, 2)
         qc.cx(0, 2)
         qc.cx(0, 2)
         qc.sx(1)
@@ -460,7 +457,7 @@ class TestVF2PostLayout(QiskitTestCase):
         # If not `strict_direction`, then we can align the really high-cost 1q and 2q physical parts
         # with the least used virtual ones.  If `strict_direction`, then we can only align one, and
         # it's better to align the 2q.
-        expected = [0, 2, 1] if strict_direction else [1, 2, 0]
+        expected = [2, 1, 0] if strict_direction else [1, 2, 0]
         self.assertEqual(qc.layout.initial_index_layout(), expected)
 
 

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -17,6 +17,7 @@ import ddt
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import ControlFlowOp, Parameter, library as lib
 from qiskit.transpiler import Layout, TranspilerError, PassManager, passes
+from qiskit.transpiler.passes import TrivialLayout, ApplyLayout
 from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayout, VF2PostLayoutStopReason
 from qiskit.converters import circuit_to_dag
 from qiskit.providers.fake_provider import GenericBackendV2
@@ -409,6 +410,58 @@ class TestVF2PostLayout(QiskitTestCase):
         pass_(qc)
         layout = pass_.property_set["post_layout"]
         self.assertEqual(layout, Layout(dict(zip(qc.qubits, [4, 3, 2, 1, 0]))))
+
+    @ddt.data(False, True)
+    def test_error_clipping(self, strict_direction):
+        target = Target(3)
+        props_1q = {
+            # Too low.
+            (0,): InstructionProperties(error=-1e-15),
+            # Too high.
+            (1,): InstructionProperties(error=1 + 1e-15),
+            # Juuuuust right.
+            (2,): InstructionProperties(error=1e-5),
+        }
+        # Set the same 1q on both types of 1q operation because we don't want any averaging to mess
+        # with our clipping.
+        target.add_instruction(lib.SXGate(), props_1q)
+        target.add_instruction(lib.RZGate(Parameter("a")), props_1q)
+        target.add_instruction(
+            lib.CXGate(),
+            {
+                (0, 1): InstructionProperties(error=-1e-15),
+                (1, 2): InstructionProperties(error=1 + 1e-15),
+                (2, 0): InstructionProperties(error=1e-5),
+            },
+        )
+
+        # This circuit has a symmetric interaction graph, but we break the degeneracy by weighting
+        # each edge and node by different amounts, so the resulting layout will be deterministic.
+        # One qubit deliberately doesn't have any instructions so we test the zero-weighted path
+        # with all the types of clipped error too.
+        qc = QuantumCircuit(3)
+        qc.cx(1, 0)
+        qc.cx(2, 1)
+        qc.cx(2, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 2)
+        qc.cx(0, 2)
+        qc.sx(1)
+        qc.sx(2)
+
+        qc = PassManager(
+            [
+                TrivialLayout(target),
+                ApplyLayout(),
+                VF2PostLayout(target=target, strict_direction=strict_direction),
+                ApplyLayout(),
+            ]
+        ).run(qc)
+        # If not `strict_direction`, then we can align the really high-cost 1q and 2q physical parts
+        # with the least used virtual ones.  If `strict_direction`, then we can only align one, and
+        # it's better to align the 2q.
+        expected = [0, 2, 1] if strict_direction else [1, 2, 0]
+        self.assertEqual(qc.layout.initial_index_layout(), expected)
 
 
 class TestVF2PostLayoutUndirected(QiskitTestCase):


### PR DESCRIPTION
`VF2Layout` and `VF2PostLayout` internally use an `f64` to represent their score, and they're supposed to be allowed to treat this as fully ordered by validating that `nan` never enters as an error rate.  This overlooked that `0 * inf` is `nan`, which was a reachable scoring path if an error rate was reported as `1.0` (since we actually score using $\sum -\ln(1 - e)$ and normalise this with $e = 1$ to $\infty$) on a single-qubit node but didn't use any 1q operations on it.

See https://github.com/Qiskit/qiskit/issues/16267#issuecomment-4546992780.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
