### PR TITLE
Fix MultiplierGate._define() to pass num_result_qubits to multiplier_qft_r17

### DIFF
--- a/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
@@ -198,4 +198,4 @@ class MultiplierGate(Gate):
         # This particular decomposition does not use any ancilla qubits.
         # Note that the transpiler may choose a different decomposition
         # based on the number of ancilla qubits available.
-        self.definition = multiplier_qft_r17(self.num_state_qubits)
+        self.definition = multiplier_qft_r17(self.num_state_qubits, self.num_result_qubits)


### PR DESCRIPTION
## Summary

Fixes #16168

`MultiplierGate._define()` was calling `multiplier_qft_r17(self.num_state_qubits)` without passing `self.num_result_qubits`, causing the decomposition to always use the default `2 * num_state_qubits` width. This caused a `DAGCircuitError` when decomposing truncated MultiplierGate instances.

## Bug

`MultiplierGate(1, 1)` reports `num_qubits = 3` (two 1-qubit inputs + one 1-qubit result), but the decomposition creates a 4-qubit circuit (two 1-qubit inputs + two 1-qubit result), causing:

```
DAGCircuitError: bit mapping invalid: expected 3, got 4
```

## Fix

Pass `self.num_result_qubits` to `multiplier_qft_r17` in `_define()`:

```python
# Before:
self.definition = multiplier_qft_r17(self.num_state_qubits)

# After:
self.definition = multiplier_qft_r17(self.num_state_qubits, self.num_result_qubits)
```

The `multiplier_qft_r17` function already accepts `num_result_qubits` as an optional parameter (defaults to `2 * num_state_qubits`), so this is a minimal, surgical change.

## Reproducer

```python
from qiskit import QuantumCircuit
from qiskit.circuit.library import MultiplierGate

n, t = 1, 1
gate = MultiplierGate(n, t)
qc = QuantumCircuit(gate.num_qubits)
qc.append(gate, range(gate.num_qubits))
qc.decompose()  # Previously raised DAGCircuitError
```

Closes #16168
