### PR TITLE
Add slot-listing command to `bindgen-cli`

### DIFF
--- a/crates/bindgen-cli/README.md
+++ b/crates/bindgen-cli/README.md
@@ -78,7 +78,7 @@ You can specify more than one attribute by separating them with commas.
 Use the `show-slots` command, such as
 
 ```bash
-cargo run -p qiskit-bindgen-c -- show-slots
+cargo run -p qiskit-bindgen-cli -- show-slots
 ```
 
 This prints out a complete listing of the exported slots in terms of the function names.

--- a/crates/bindgen-cli/README.md
+++ b/crates/bindgen-cli/README.md
@@ -71,3 +71,14 @@ generated documentation. The available "rules" within the list are:
   export a function in more than one vtable).
 
 You can specify more than one attribute by separating them with commas.
+
+
+## Viewing the concrete vtable
+
+Use the `show-slots` command, such as
+
+```bash
+cargo run -p qiskit-bindgen-c -- show-slots
+```
+
+This prints out a complete listing of the exported slots in terms of the function names.

--- a/crates/bindgen-cli/src/abi.rs
+++ b/crates/bindgen-cli/src/abi.rs
@@ -10,10 +10,56 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::fmt;
+
+use anyhow::anyhow;
 use indexmap::IndexMap;
 use qiskit_cext_vtable::ExportedFunction;
 
+/// The minimal semver components extracted from a version that might also have suffixes.
+#[derive(Clone, Debug)]
+pub struct Version {
+    major: usize,
+    minor: usize,
+    patch: usize,
+    suffix: Option<String>,
+}
+impl Version {
+    /// Parse a version out of a `<major>.<minor>.<patch>(-<suffix>)?` form.
+    fn try_parse(val: &str) -> anyhow::Result<Version> {
+        let (val, suffix) = match val.split_once("-") {
+            Some((val, suffix)) => (val, Some(suffix.to_owned())),
+            None => (val, None),
+        };
+        let mut parts = val.split(".");
+        let mut part = || -> anyhow::Result<usize> {
+            Ok(parts
+                .next()
+                .ok_or_else(|| anyhow!("not enough version parts"))?
+                .parse()?)
+        };
+        Ok(Version {
+            major: part()?,
+            minor: part()?,
+            patch: part()?,
+            suffix,
+        })
+    }
+}
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
+        if let Some(suffix) = self.suffix.as_ref() {
+            write!(f, "-{suffix}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Complete set of exported slots and version for comparison.
 pub struct SlotsLists {
+    pub api_version: Version,
+    /// Association of names to concrete vtables.
     pub slots: IndexMap<String, SlotsList>,
 }
 impl SlotsLists {
@@ -28,6 +74,8 @@ impl SlotsLists {
             )
         };
         Self {
+            api_version: Version::try_parse(env!("CARGO_PKG_VERSION"))
+                .expect("our version should be valid"),
             slots: [
                 ("circuit", &qiskit_cext_vtable::FUNCTIONS_CIRCUIT),
                 ("transpile", &qiskit_cext_vtable::FUNCTIONS_TRANSPILE),
@@ -39,7 +87,17 @@ impl SlotsLists {
         }
     }
 }
+impl fmt::Display for SlotsLists {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "__version__ = \"{}\"", &self.api_version)?;
+        for (name, slots) in self.slots.iter() {
+            writeln!(f, "{name} = {slots}")?;
+        }
+        Ok(())
+    }
+}
 
+/// An individual concrete vtable, but written in terms of the function name instead of a pointer.
 pub struct SlotsList(Vec<Option<String>>);
 impl SlotsList {
     /// Iterate over the slot indices and the name stored there in order.
@@ -48,5 +106,21 @@ impl SlotsList {
             .iter()
             .enumerate()
             .filter_map(|(i, fname)| fname.as_deref().map(|fname| (i, fname)))
+    }
+}
+impl fmt::Display for SlotsList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // This is meant to be easy both to parse back in, and to be read by humans.  As written,
+        // this `impl` also produces a valid Python list of strings that can be read by
+        // `ast.literal_eval`.
+        if self.0.is_empty() {
+            write!(f, "[]")
+        } else {
+            writeln!(f, "[")?;
+            for slot in self.0.iter() {
+                writeln!(f, "    \"{}\",", slot.as_deref().unwrap_or_default())?;
+            }
+            write!(f, "]")
+        }
     }
 }

--- a/crates/bindgen-cli/src/main.rs
+++ b/crates/bindgen-cli/src/main.rs
@@ -37,6 +37,8 @@ enum Command {
         #[arg(short, long)]
         output_path: PathBuf,
     },
+    /// Print out a representation of all the slots in use.
+    ShowSlots,
     /// Check for correctness between the slots tables and the list of exported functions for the
     /// current version of Qiskit.
     LintSlots {
@@ -63,6 +65,11 @@ fn main() -> anyhow::Result<()> {
         } => {
             let mut bindings = qiskit_bindgen::generate_bindings(cext_path)?;
             qiskit_bindgen::install_c_headers(&mut bindings, output_path)?;
+            Ok(())
+        }
+        #[allow(clippy::print_stdout)]
+        Command::ShowSlots => {
+            println!("{}", SlotsLists::ours());
             Ok(())
         }
         Command::LintSlots { cext_path } => {

--- a/releasenotes/notes/bindgen-cli-show-slots-201d55078df0422f.yaml
+++ b/releasenotes/notes/bindgen-cli-show-slots-201d55078df0422f.yaml
@@ -1,0 +1,5 @@
+---
+build:
+  - |
+    ``qiskit-bindgen-cli`` gained the ``show-slots`` command, which outputs a list of the slot
+    assignments for runtime linking to the C API (such as via the Python-space Qiskit package).


### PR DESCRIPTION
At first this is just a manual audit tool for outputting the slots in a way we can read them out completely line-by-line.  This will form the base of tooling that then lets us lint the slot assignments for breakage compared to previous versions of Qiskit; we can save the text file into the repository and compare it to a newly generated one.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
