### PR TITLE
Add tools/check_slots.bash to the tox lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
         description: Python version to test.
         type: string
         required: true
-      runner: 
+      runner:
         description: Runner image to use.
         type: string
         required: true
@@ -35,5 +35,4 @@ jobs:
           # package. The exact command isn't important, it should just be cheap and update the lock.
           cargo metadata --format-version=1 --locked >/dev/null
           make cformat
-          tools/check_slots.bash
           tox -e lint

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ setenv =
 [testenv:lint]
 basepython = python3
 package = editable
-allowlist_externals = cargo
+allowlist_externals = cargo, bash
 dependency_groups =
   lint
 commands =
@@ -55,6 +55,7 @@ commands =
   cargo fmt --check
   ruff check qiskit test tools setup.py
   cargo clippy --all-targets -- -D warnings
+  bash {toxinidir}/tools/check_slots.bash
   python {toxinidir}/tools/verify_headers.py qiskit test tools crates
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py


### PR DESCRIPTION
We are currently running the tools/check_slots.bash lint script as part of the CI lint job to validate the vtable contains entries for all the C API functions. However, while we're running this as part of the CI lint job we neglected to add this to the tox lint job configuration. This meant that the tox lint job was not running this check. There wasn't a reason to exclude it from tox as it only requires cargo, which we'll already using as part of the lint job. This updates the configuration to add it to the tox lint job and runs it as part of CI via tox instead of as a one off.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
