### PR TITLE
Refactor ProgramNode::call to flatten+call_flat+unflatten

### DIFF
--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use hashbrown::HashMap;
+use thiserror::Error;
 
 /// A path entry used for tracking a path through a [`DataTree`]
 ///
@@ -20,6 +21,30 @@ use hashbrown::HashMap;
 pub enum PathEntry<'a> {
     Index(usize),
     Key(&'a str),
+}
+
+/// Returned by [`DataTree::unflatten`] when the supplied value count doesn't
+/// match the template's leaf count.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("unflatten: expected {expected} values, got {actual}")]
+pub struct ArityMismatch {
+    pub expected: usize,
+    pub actual: usize,
+}
+
+/// Errors returned by [`DataTree::flatten_against`] when `data`'s structure
+/// does not match self's structure.
+///
+/// The `path` field is rendered as a dotted string (e.g. `"x.0.creg"`),
+/// built lazily at the point of error construction.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TreeMatchError {
+    /// The path is missing in `data`, or descends through a leaf.
+    #[error("missing path {path}")]
+    MissingPath { path: String },
+    /// A leaf was expected at this path but `data` had a branch.
+    #[error("expected a leaf at {path}, found a branch")]
+    ExpectedLeaf { path: String },
 }
 
 /// A struct representing a branch in a [`DataTree`].
@@ -455,7 +480,7 @@ impl<T> DataTree<T> {
     /// let expected = vec![0, 3, 4, 5, 6, 7, 26];
     /// assert_eq!(leaves, expected);
     /// ```
-    pub fn iter_leaves(&self) -> IterLeaves<'_, T> {
+    pub fn iter_leaves(&self) -> impl Iterator<Item = &T> {
         IterLeaves {
             tree: Some(self),
             branch: None,
@@ -517,6 +542,54 @@ impl<T> DataTree<T> {
             inner_next: None,
             path: Vec::new(),
         }
+    }
+
+    /// Build a tree with the same shape as `self`, replacing each leaf value
+    /// by `f(&leaf)`.
+    ///
+    /// ```rust
+    /// use qiskit_providers::DataTree;
+    /// let mut tree = DataTree::new();
+    /// tree.insert_leaf("a", 1);
+    /// tree.insert_leaf("b", 2);
+    /// let doubled = tree.map_leaves(|v| v * 2);
+    /// assert_eq!(doubled.iter_leaves().copied().collect::<Vec<_>>(), vec![2, 4]);
+    /// ```
+    pub fn map_leaves<U>(&self, mut f: impl FnMut(&T) -> U) -> DataTree<U> {
+        map_leaves_helper(self, &mut f)
+    }
+
+    /// Consume this tree, yielding owned leaf values in DFS order. Mirrors
+    /// [`iter_leaves`](Self::iter_leaves) for the consuming case.
+    pub fn into_leaves(self) -> impl Iterator<Item = T> {
+        let mut out = Vec::new();
+        drain_leaves(self, &mut out);
+        out.into_iter()
+    }
+
+    /// Build a tree with the same shape as `self`, taking leaf values from
+    /// `values` in DFS order.
+    ///
+    /// Returns [`ArityMismatch`] if `values.len()` does not equal the leaf
+    /// count of `self`.
+    pub fn unflatten<U>(&self, values: Vec<U>) -> Result<DataTree<U>, ArityMismatch> {
+        let expected = self.iter_leaves().count();
+        if values.len() != expected {
+            return Err(ArityMismatch {
+                expected,
+                actual: values.len(),
+            });
+        }
+        let mut iter = values.into_iter();
+        Ok(unflatten_helper(self, &mut iter))
+    }
+
+    /// Walk `data` lockstep with `self`'s structure, returning `data`'s leaves
+    /// in DFS order. Errors structurally if `data`'s shape doesn't match.
+    pub fn flatten_against<U: Clone>(&self, data: &DataTree<U>) -> Result<Vec<U>, TreeMatchError> {
+        let mut out = Vec::new();
+        flatten_against_helper(self, data, &mut Vec::new(), &mut out)?;
+        Ok(out)
     }
 }
 
@@ -633,7 +706,7 @@ impl<'a, T> Iterator for IterDataTree<'a, T> {
     }
 }
 
-pub struct IterLeaves<'a, T> {
+struct IterLeaves<'a, T> {
     tree: Option<&'a DataTree<T>>,
     branch: Option<&'a DataTreeBranch<T>>,
     index: usize,
@@ -641,7 +714,7 @@ pub struct IterLeaves<'a, T> {
     inner_next: Option<&'a T>,
 }
 
-impl<'a, T: std::fmt::Debug> Iterator for IterLeaves<'a, T> {
+impl<'a, T> Iterator for IterLeaves<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -749,6 +822,114 @@ impl<T: PartialEq> PartialEq for DataTree<T> {
                     return false;
                 };
                 branch.data == other.data && branch.keys == other.keys
+            }
+        }
+    }
+}
+
+fn map_leaves_helper<T, U>(tree: &DataTree<T>, f: &mut impl FnMut(&T) -> U) -> DataTree<U> {
+    match tree {
+        DataTree::Leaf(value) => DataTree::new_leaf(f(value)),
+        DataTree::Branch(_) => {
+            let mut result = DataTree::with_capacity(tree.len());
+            for (key, child) in tree.iter_children() {
+                let new_child = map_leaves_helper(child, f);
+                match (key, new_child) {
+                    (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
+                    (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
+                    (None, DataTree::Leaf(v)) => result.push_leaf(v),
+                    (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
+                }
+            }
+            result
+        }
+    }
+}
+
+fn unflatten_helper<T, U>(template: &DataTree<T>, iter: &mut std::vec::IntoIter<U>) -> DataTree<U> {
+    match template {
+        DataTree::Leaf(_) => DataTree::new_leaf(
+            iter.next()
+                .expect("unflatten: fewer values than template leaves"),
+        ),
+        DataTree::Branch(_) => {
+            let mut result = DataTree::with_capacity(template.len());
+            for (key, child) in template.iter_children() {
+                let subtree = unflatten_helper(child, iter);
+                match (key, subtree) {
+                    (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
+                    (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
+                    (None, DataTree::Leaf(v)) => result.push_leaf(v),
+                    (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
+                }
+            }
+            result
+        }
+    }
+}
+
+/// Render a `[PathEntry]` slice as a dotted path string. Empty path renders
+/// as `""`. Used only to format error messages, so the per-leaf allocation is
+/// fine.
+fn dotted_path(path: &[PathEntry<'_>]) -> String {
+    let mut out = String::new();
+    let mut first = true;
+    for entry in path {
+        if !first {
+            out.push('.');
+        }
+        match entry {
+            PathEntry::Index(i) => out.push_str(&i.to_string()),
+            PathEntry::Key(k) => out.push_str(k),
+        }
+        first = false;
+    }
+    out
+}
+
+fn flatten_against_helper<'a, T, U: Clone>(
+    template: &'a DataTree<T>,
+    data: &'a DataTree<U>,
+    path: &mut Vec<PathEntry<'a>>,
+    out: &mut Vec<U>,
+) -> Result<(), TreeMatchError> {
+    match (template, data) {
+        (DataTree::Leaf(_), DataTree::Leaf(value)) => {
+            out.push(value.clone());
+            Ok(())
+        }
+        (DataTree::Leaf(_), DataTree::Branch(_)) => Err(TreeMatchError::ExpectedLeaf {
+            path: dotted_path(path),
+        }),
+        (DataTree::Branch(_), _) => {
+            for (i, (key, child_template)) in template.iter_children().enumerate() {
+                let entry = match key {
+                    Some(k) => PathEntry::Key(k),
+                    None => PathEntry::Index(i),
+                };
+                let data_child = match entry {
+                    PathEntry::Key(k) => data.get_by_str_key(k),
+                    PathEntry::Index(idx) => data.get(idx),
+                };
+                path.push(entry);
+                let data_child = data_child.ok_or_else(|| TreeMatchError::MissingPath {
+                    path: dotted_path(path),
+                })?;
+                flatten_against_helper(child_template, data_child, path, out)?;
+                path.pop();
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Recursively drain leaves out of an owned `DataTree` in DFS order.
+fn drain_leaves<T>(tree: DataTree<T>, out: &mut Vec<T>) {
+    match tree {
+        DataTree::Leaf(value) => out.push(value),
+        DataTree::Branch(branch) => {
+            for child in branch.data {
+                drain_leaves(child, out);
             }
         }
     }
@@ -902,5 +1083,141 @@ mod test {
         assert_eq!(None, tree.get_by_str_key("x.yy.a"));
         assert_eq!(None, tree.get_by_str_key("🎩"));
         assert_eq!(None, tree.get_by_str_key("z.yyy.a"));
+    }
+
+    #[test]
+    fn test_map_leaves() {
+        let mut sub = DataTree::new();
+        sub.insert_leaf("a", 2);
+        sub.push_leaf(3);
+        let mut tree = DataTree::new();
+        tree.insert_branch("x", sub);
+        tree.insert_leaf("y", 5);
+
+        let doubled = tree.map_leaves(|v| v * 2);
+        assert_eq!(
+            doubled.iter_leaves().copied().collect::<Vec<_>>(),
+            vec![4, 6, 10]
+        );
+        // Shape is preserved: keyed children are still keyed.
+        assert!(doubled.get_by_str_key("x").is_some());
+        assert!(doubled.get_by_str_key("y").is_some());
+    }
+
+    #[test]
+    fn test_into_leaves() {
+        let mut sub = DataTree::new();
+        sub.insert_leaf("a", 1);
+        sub.push_leaf(2);
+        let mut tree = DataTree::new();
+        tree.insert_branch("x", sub);
+        tree.insert_leaf("y", 3);
+        assert_eq!(tree.into_leaves().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_unflatten_preserves_named_vs_anonymous() {
+        let mut sub = DataTree::new();
+        sub.insert_leaf("a", 0);
+        sub.push_leaf(0);
+        let mut template = DataTree::new();
+        template.insert_branch("x", sub);
+        template.insert_leaf("y", 0);
+
+        let result = template.unflatten(vec![1, 2, 3]).unwrap();
+        assert_eq!(result.get_by_str_key("x.a"), Some(&DataTree::Leaf(1)));
+        assert!(result.get_by_str_key("x").unwrap().get(1).is_some()); // anonymous
+        assert_eq!(result.get_by_str_key("y"), Some(&DataTree::Leaf(3)));
+    }
+
+    #[test]
+    fn test_unflatten_arity_mismatch_errors() {
+        let mut template = DataTree::new();
+        template.insert_leaf("x", 0);
+        template.insert_leaf("y", 0);
+        // 2 leaves; passing 1 value
+        let err = template.unflatten(vec![42]).unwrap_err();
+        assert_eq!(
+            err,
+            ArityMismatch {
+                expected: 2,
+                actual: 1
+            }
+        );
+        // 2 leaves; passing 3 values
+        let err = template.unflatten(vec![1, 2, 3]).unwrap_err();
+        assert_eq!(
+            err,
+            ArityMismatch {
+                expected: 2,
+                actual: 3
+            }
+        );
+    }
+
+    #[test]
+    fn test_flatten_against_branch_with_keys() {
+        let mut template = DataTree::new();
+        template.insert_leaf("x", 0);
+        template.insert_leaf("y", 0);
+        let mut data = DataTree::new();
+        data.insert_leaf("x", 1);
+        data.insert_leaf("y", 2);
+        assert_eq!(template.flatten_against(&data).unwrap(), vec![1, 2]);
+    }
+
+    #[test]
+    fn test_flatten_against_missing_key_errors() {
+        let mut template = DataTree::new();
+        template.insert_leaf("x", 0);
+        template.insert_leaf("y", 0);
+        let mut data = DataTree::new();
+        data.insert_leaf("x", 1);
+        let err = template.flatten_against(&data).unwrap_err();
+        assert_eq!(
+            err,
+            TreeMatchError::MissingPath {
+                path: "y".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_flatten_against_branch_where_leaf_expected_errors() {
+        let mut template = DataTree::new();
+        template.insert_leaf("x", 0);
+        template.insert_leaf("y", 0);
+        let mut data = DataTree::new();
+        data.insert_leaf("x", 1);
+        data.insert_branch("y", DataTree::<i32>::new());
+        let err = template.flatten_against(&data).unwrap_err();
+        assert_eq!(
+            err,
+            TreeMatchError::ExpectedLeaf {
+                path: "y".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_flatten_against_then_unflatten_roundtrip() {
+        let mut sub = DataTree::new();
+        sub.insert_leaf("a", 0);
+        sub.push_leaf(0);
+        let mut template = DataTree::new();
+        template.insert_leaf("x", 0);
+        template.insert_branch("y", sub);
+
+        let mut data_sub = DataTree::new();
+        data_sub.insert_leaf("a", 20);
+        data_sub.push_leaf(30);
+        let mut data = DataTree::new();
+        data.insert_leaf("x", 10);
+        data.insert_branch("y", data_sub);
+
+        let flat = template.flatten_against(&data).unwrap();
+        assert_eq!(flat, vec![10, 20, 30]);
+        let back = template.unflatten(flat).unwrap();
+        assert_eq!(back, data);
     }
 }

--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -797,10 +797,8 @@ impl<'a, T> Iterator for IterDataTree<'a, T> {
 }
 
 struct IntoLeaves<T> {
-    /// DFS stack of child iterators, one frame per nesting level. Each frame
-    /// is the remaining children of a branch node. The top of the stack is
-    /// the current branch being consumed; pushing descends into a sub-branch,
-    /// popping backtracks to the parent.
+    /// DFS stack of child iterators, one frame per nesting level.
+    /// Each frame is the remaining children of a branch node.
     stack: Vec<std::vec::IntoIter<DataTree<T>>>,
 }
 

--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -577,7 +577,7 @@ impl<T> DataTree<T> {
         let mut iter = values.into_iter();
         match unflatten_helper(self, &mut iter) {
             Ok(result) => {
-                let left_over = iter.len(); // ExactSizeIterator, O(1)
+                let left_over = iter.len();
                 if left_over == 0 {
                     Ok(result)
                 } else {
@@ -886,19 +886,13 @@ fn unflatten_helper<T, U>(
 /// as `""`. Used only to format error messages, so the per-leaf allocation is
 /// fine.
 fn dotted_path(path: &[PathEntry<'_>]) -> String {
-    let mut out = String::new();
-    let mut first = true;
-    for entry in path {
-        if !first {
-            out.push('.');
-        }
-        match entry {
-            PathEntry::Index(i) => out.push_str(&i.to_string()),
-            PathEntry::Key(k) => out.push_str(k),
-        }
-        first = false;
-    }
-    out
+    path.iter()
+        .map(|e| match e {
+            PathEntry::Index(i) => i.to_string(),
+            PathEntry::Key(k) => k.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 fn flatten_against_helper<'a, T, U: Clone>(

--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -573,15 +573,29 @@ impl<T> DataTree<T> {
     /// Returns [`ArityMismatch`] if `values.len()` does not equal the leaf
     /// count of `self`.
     pub fn unflatten<U>(&self, values: Vec<U>) -> Result<DataTree<U>, ArityMismatch> {
-        let expected = self.iter_leaves().count();
-        if values.len() != expected {
-            return Err(ArityMismatch {
-                expected,
-                actual: values.len(),
-            });
-        }
+        let actual = values.len();
         let mut iter = values.into_iter();
-        Ok(unflatten_helper(self, &mut iter))
+        match unflatten_helper(self, &mut iter) {
+            Ok(result) => {
+                let left_over = iter.len(); // ExactSizeIterator, O(1)
+                if left_over == 0 {
+                    Ok(result)
+                } else {
+                    Err(ArityMismatch {
+                        expected: actual - left_over,
+                        actual,
+                    })
+                }
+            }
+            Err(()) => {
+                // The Iterator was exhausted mid-walk, rewalk the tree to find
+                // out how many we should have expected.
+                Err(ArityMismatch {
+                    expected: self.iter_leaves().count(),
+                    actual,
+                })
+            }
+        }
     }
 
     /// Walk `data` lockstep with `self`'s structure, returning `data`'s leaves
@@ -846,16 +860,16 @@ fn map_leaves_helper<T, U>(tree: &DataTree<T>, f: &mut impl FnMut(&T) -> U) -> D
     }
 }
 
-fn unflatten_helper<T, U>(template: &DataTree<T>, iter: &mut std::vec::IntoIter<U>) -> DataTree<U> {
+fn unflatten_helper<T, U>(
+    template: &DataTree<T>,
+    iter: &mut std::vec::IntoIter<U>,
+) -> Result<DataTree<U>, ()> {
     match template {
-        DataTree::Leaf(_) => DataTree::new_leaf(
-            iter.next()
-                .expect("unflatten: fewer values than template leaves"),
-        ),
+        DataTree::Leaf(_) => Ok(DataTree::new_leaf(iter.next().ok_or(())?)),
         DataTree::Branch(_) => {
             let mut result = DataTree::with_capacity(template.len());
             for (key, child) in template.iter_children() {
-                let subtree = unflatten_helper(child, iter);
+                let subtree = unflatten_helper(child, iter)?;
                 match (key, subtree) {
                     (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
                     (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
@@ -863,7 +877,7 @@ fn unflatten_helper<T, U>(template: &DataTree<T>, iter: &mut std::vec::IntoIter<
                     (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
                 }
             }
-            result
+            Ok(result)
         }
     }
 }

--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -580,19 +580,9 @@ impl<T> DataTree<T> {
     /// Consume this tree, yielding owned leaf values in DFS order. Mirrors
     /// [`iter_leaves`](Self::iter_leaves) for the consuming case.
     pub fn into_leaves(self) -> impl Iterator<Item = T> {
-        fn inner<T>(tree: DataTree<T>, out: &mut Vec<T>) {
-            match tree {
-                DataTree::Leaf(value) => out.push(value),
-                DataTree::Branch(branch) => {
-                    for child in branch.data {
-                        inner(child, out);
-                    }
-                }
-            }
+        IntoLeaves {
+            stack: vec![vec![self].into_iter()],
         }
-        let mut out = Vec::new();
-        inner(self, &mut out);
-        out.into_iter()
     }
 
     /// Build a tree with the same shape as `self`, taking leaf values from
@@ -802,6 +792,31 @@ impl<'a, T> Iterator for IterDataTree<'a, T> {
             }
         } else {
             None
+        }
+    }
+}
+
+struct IntoLeaves<T> {
+    /// DFS stack of child iterators, one frame per nesting level. Each frame
+    /// is the remaining children of a branch node. The top of the stack is
+    /// the current branch being consumed; pushing descends into a sub-branch,
+    /// popping backtracks to the parent.
+    stack: Vec<std::vec::IntoIter<DataTree<T>>>,
+}
+
+impl<T> Iterator for IntoLeaves<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            let top = self.stack.last_mut()?;
+            match top.next() {
+                None => {
+                    self.stack.pop();
+                }
+                Some(DataTree::Leaf(v)) => return Some(v),
+                Some(DataTree::Branch(b)) => self.stack.push(b.data.into_iter()),
+            }
         }
     }
 }

--- a/crates/providers/src/data_tree.rs
+++ b/crates/providers/src/data_tree.rs
@@ -556,14 +556,42 @@ impl<T> DataTree<T> {
     /// assert_eq!(doubled.iter_leaves().copied().collect::<Vec<_>>(), vec![2, 4]);
     /// ```
     pub fn map_leaves<U>(&self, mut f: impl FnMut(&T) -> U) -> DataTree<U> {
-        map_leaves_helper(self, &mut f)
+        fn inner<T, U>(tree: &DataTree<T>, f: &mut impl FnMut(&T) -> U) -> DataTree<U> {
+            match tree {
+                DataTree::Leaf(value) => DataTree::new_leaf(f(value)),
+                DataTree::Branch(_) => {
+                    let mut result = DataTree::with_capacity(tree.len());
+                    for (key, child) in tree.iter_children() {
+                        let new_child = inner(child, f);
+                        match (key, new_child) {
+                            (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
+                            (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
+                            (None, DataTree::Leaf(v)) => result.push_leaf(v),
+                            (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
+                        }
+                    }
+                    result
+                }
+            }
+        }
+        inner(self, &mut f)
     }
 
     /// Consume this tree, yielding owned leaf values in DFS order. Mirrors
     /// [`iter_leaves`](Self::iter_leaves) for the consuming case.
     pub fn into_leaves(self) -> impl Iterator<Item = T> {
+        fn inner<T>(tree: DataTree<T>, out: &mut Vec<T>) {
+            match tree {
+                DataTree::Leaf(value) => out.push(value),
+                DataTree::Branch(branch) => {
+                    for child in branch.data {
+                        inner(child, out);
+                    }
+                }
+            }
+        }
         let mut out = Vec::new();
-        drain_leaves(self, &mut out);
+        inner(self, &mut out);
         out.into_iter()
     }
 
@@ -573,9 +601,31 @@ impl<T> DataTree<T> {
     /// Returns [`ArityMismatch`] if `values.len()` does not equal the leaf
     /// count of `self`.
     pub fn unflatten<U>(&self, values: Vec<U>) -> Result<DataTree<U>, ArityMismatch> {
+        fn inner<T, U>(
+            template: &DataTree<T>,
+            iter: &mut std::vec::IntoIter<U>,
+        ) -> Result<DataTree<U>, ()> {
+            match template {
+                DataTree::Leaf(_) => Ok(DataTree::new_leaf(iter.next().ok_or(())?)),
+                DataTree::Branch(_) => {
+                    let mut result = DataTree::with_capacity(template.len());
+                    for (key, child) in template.iter_children() {
+                        let subtree = inner(child, iter)?;
+                        match (key, subtree) {
+                            (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
+                            (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
+                            (None, DataTree::Leaf(v)) => result.push_leaf(v),
+                            (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
+                        }
+                    }
+                    Ok(result)
+                }
+            }
+        }
+
         let actual = values.len();
         let mut iter = values.into_iter();
-        match unflatten_helper(self, &mut iter) {
+        match inner(self, &mut iter) {
             Ok(result) => {
                 let left_over = iter.len();
                 if left_over == 0 {
@@ -601,8 +651,44 @@ impl<T> DataTree<T> {
     /// Walk `data` lockstep with `self`'s structure, returning `data`'s leaves
     /// in DFS order. Errors structurally if `data`'s shape doesn't match.
     pub fn flatten_against<U: Clone>(&self, data: &DataTree<U>) -> Result<Vec<U>, TreeMatchError> {
+        fn inner<'a, T, U: Clone>(
+            template: &'a DataTree<T>,
+            data: &'a DataTree<U>,
+            path: &mut Vec<PathEntry<'a>>,
+            out: &mut Vec<U>,
+        ) -> Result<(), TreeMatchError> {
+            match (template, data) {
+                (DataTree::Leaf(_), DataTree::Leaf(value)) => {
+                    out.push(value.clone());
+                    Ok(())
+                }
+                (DataTree::Leaf(_), DataTree::Branch(_)) => Err(TreeMatchError::ExpectedLeaf {
+                    path: dotted_path(path),
+                }),
+                (DataTree::Branch(_), _) => {
+                    for (i, (key, child_template)) in template.iter_children().enumerate() {
+                        let entry = match key {
+                            Some(k) => PathEntry::Key(k),
+                            None => PathEntry::Index(i),
+                        };
+                        let data_child = match entry {
+                            PathEntry::Key(k) => data.get_by_str_key(k),
+                            PathEntry::Index(idx) => data.get(idx),
+                        };
+                        path.push(entry);
+                        let data_child = data_child.ok_or_else(|| TreeMatchError::MissingPath {
+                            path: dotted_path(path),
+                        })?;
+                        inner(child_template, data_child, path, out)?;
+                        path.pop();
+                    }
+                    Ok(())
+                }
+            }
+        }
+
         let mut out = Vec::new();
-        flatten_against_helper(self, data, &mut Vec::new(), &mut out)?;
+        inner(self, data, &mut Vec::new(), &mut out)?;
         Ok(out)
     }
 }
@@ -841,47 +927,6 @@ impl<T: PartialEq> PartialEq for DataTree<T> {
     }
 }
 
-fn map_leaves_helper<T, U>(tree: &DataTree<T>, f: &mut impl FnMut(&T) -> U) -> DataTree<U> {
-    match tree {
-        DataTree::Leaf(value) => DataTree::new_leaf(f(value)),
-        DataTree::Branch(_) => {
-            let mut result = DataTree::with_capacity(tree.len());
-            for (key, child) in tree.iter_children() {
-                let new_child = map_leaves_helper(child, f);
-                match (key, new_child) {
-                    (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
-                    (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
-                    (None, DataTree::Leaf(v)) => result.push_leaf(v),
-                    (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
-                }
-            }
-            result
-        }
-    }
-}
-
-fn unflatten_helper<T, U>(
-    template: &DataTree<T>,
-    iter: &mut std::vec::IntoIter<U>,
-) -> Result<DataTree<U>, ()> {
-    match template {
-        DataTree::Leaf(_) => Ok(DataTree::new_leaf(iter.next().ok_or(())?)),
-        DataTree::Branch(_) => {
-            let mut result = DataTree::with_capacity(template.len());
-            for (key, child) in template.iter_children() {
-                let subtree = unflatten_helper(child, iter)?;
-                match (key, subtree) {
-                    (Some(k), DataTree::Leaf(v)) => result.insert_leaf(k, v),
-                    (Some(k), sub @ DataTree::Branch(_)) => result.insert_branch(k, sub),
-                    (None, DataTree::Leaf(v)) => result.push_leaf(v),
-                    (None, sub @ DataTree::Branch(_)) => result.push_branch(sub),
-                }
-            }
-            Ok(result)
-        }
-    }
-}
-
 /// Render a `[PathEntry]` slice as a dotted path string. Empty path renders
 /// as `""`. Used only to format error messages, so the per-leaf allocation is
 /// fine.
@@ -893,54 +938,6 @@ fn dotted_path(path: &[PathEntry<'_>]) -> String {
         })
         .collect::<Vec<_>>()
         .join(".")
-}
-
-fn flatten_against_helper<'a, T, U: Clone>(
-    template: &'a DataTree<T>,
-    data: &'a DataTree<U>,
-    path: &mut Vec<PathEntry<'a>>,
-    out: &mut Vec<U>,
-) -> Result<(), TreeMatchError> {
-    match (template, data) {
-        (DataTree::Leaf(_), DataTree::Leaf(value)) => {
-            out.push(value.clone());
-            Ok(())
-        }
-        (DataTree::Leaf(_), DataTree::Branch(_)) => Err(TreeMatchError::ExpectedLeaf {
-            path: dotted_path(path),
-        }),
-        (DataTree::Branch(_), _) => {
-            for (i, (key, child_template)) in template.iter_children().enumerate() {
-                let entry = match key {
-                    Some(k) => PathEntry::Key(k),
-                    None => PathEntry::Index(i),
-                };
-                let data_child = match entry {
-                    PathEntry::Key(k) => data.get_by_str_key(k),
-                    PathEntry::Index(idx) => data.get(idx),
-                };
-                path.push(entry);
-                let data_child = data_child.ok_or_else(|| TreeMatchError::MissingPath {
-                    path: dotted_path(path),
-                })?;
-                flatten_against_helper(child_template, data_child, path, out)?;
-                path.pop();
-            }
-            Ok(())
-        }
-    }
-}
-
-/// Recursively drain leaves out of an owned `DataTree` in DFS order.
-fn drain_leaves<T>(tree: DataTree<T>, out: &mut Vec<T>) {
-    match tree {
-        DataTree::Leaf(value) => out.push(value),
-        DataTree::Branch(branch) => {
-            for child in branch.data {
-                drain_leaves(child, out);
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -15,6 +15,6 @@ mod program_node;
 mod store;
 pub mod tensor;
 
-pub use data_tree::{DataTree, PathEntry};
-pub use program_node::ProgramNode;
+pub use data_tree::{ArityMismatch, DataTree, PathEntry, TreeMatchError};
+pub use program_node::{CallError, CallInputError, MissingCallError, ProgramNode, ProgramNodeExt};
 pub use store::Store;

--- a/crates/providers/src/program_node.rs
+++ b/crates/providers/src/program_node.rs
@@ -10,8 +10,71 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::data_tree::DataTree;
-use crate::tensor::{Tensor, TensorType};
+use crate::data_tree::{ArityMismatch, DataTree, TreeMatchError};
+use crate::tensor::{DType, Tensor, TensorType};
+use thiserror::Error;
+
+/// Errors returned when a tree-shaped argument does not match [`ProgramNode::input_types`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CallInputError {
+    #[error("missing required input {key:?}")]
+    MissingInput { key: String },
+
+    #[error("expected a leaf at {key:?}, found a branch")]
+    ExpectedLeaf { key: String },
+
+    #[error("unexpected dtype at {key:?}: expected {expected}, found {actual}")]
+    UnexpectedDType {
+        key: String,
+        expected: String,
+        actual: DType,
+    },
+}
+
+impl From<TreeMatchError> for CallInputError {
+    fn from(e: TreeMatchError) -> Self {
+        match e {
+            TreeMatchError::MissingPath { path } => Self::MissingInput { key: path },
+            TreeMatchError::ExpectedLeaf { path } => Self::ExpectedLeaf { key: path },
+        }
+    }
+}
+
+/// Returned by implementations with a missing call implementation when called.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("node {0:?} does not implement call()")]
+pub struct MissingCallError(pub String);
+
+impl MissingCallError {
+    /// Construct a new [`MissingCallError`] tagged with the node's full name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+/// Errors returned by [`ProgramNodeExt::call`].
+#[derive(Debug, Error)]
+pub enum CallError<E> {
+    /// The input tree did not match the contract declared by `input_types()`.
+    #[error(transparent)]
+    Input(CallInputError),
+    /// The node's [`ProgramNode::call_flat`] returned an error.
+    #[error(transparent)]
+    Call(E),
+    /// The node's [`ProgramNode::call_flat`] returned a vector whose length
+    /// did not match the leaf count of `output_types()`.
+    #[error("call_flat returned {actual} outputs, expected {expected}")]
+    OutputArityMismatch { expected: usize, actual: usize },
+}
+
+impl<E> From<ArityMismatch> for CallError<E> {
+    fn from(e: ArityMismatch) -> Self {
+        Self::OutputArityMismatch {
+            expected: e.expected,
+            actual: e.actual,
+        }
+    }
+}
 
 /// A node in a quantum program graph that transforms tensors.
 pub trait ProgramNode {
@@ -37,6 +100,39 @@ pub trait ProgramNode {
     /// Whether this program node implements the call method.
     fn implements_call(&self) -> bool;
 
-    /// The action of this program node.
-    fn call(&self, args: &DataTree<Tensor>) -> Result<DataTree<Tensor>, Self::CallError>;
+    /// The action of this program node with flattened I/O.
+    ///
+    /// `args` is in input-tree DFS leaf order matching `input_types()` and
+    /// the returned vector is in output-tree DFS leaf order matching
+    /// `output_types()`.
+    ///
+    /// # Panics
+    ///
+    /// Implementations are allowed to panic if `args.len()` does not equal
+    /// the leaf count of `input_types()`; callers are responsible for upholding
+    /// this invariant. On the other hand, implementations should raise a call
+    /// error if they find tensors that they don't like.
+    /// [`ProgramNodeExt::call`] and [`QuantumProgram::call_flat`] both do.
+    fn call_flat(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::CallError>;
 }
+
+/// Extension with the wrapper over [`ProgramNode::call_flat`] whose I/O are data trees.
+///
+/// Provided via a blanket impl over every `T: ProgramNode` so that it cannot
+/// be overridden in stable Rust.
+pub trait ProgramNodeExt: ProgramNode {
+    /// The action of this program node.
+    fn call(
+        &self,
+        args: &DataTree<Tensor>,
+    ) -> Result<DataTree<Tensor>, CallError<Self::CallError>> {
+        let flat = self
+            .input_types()
+            .flatten_against(args)
+            .map_err(|e| CallError::Input(e.into()))?;
+        let out = self.call_flat(&flat).map_err(CallError::Call)?;
+        self.output_types().unflatten(out).map_err(Into::into)
+    }
+}
+
+impl<T: ProgramNode + ?Sized> ProgramNodeExt for T {}

--- a/crates/providers/src/store.rs
+++ b/crates/providers/src/store.rs
@@ -24,38 +24,19 @@ static EMPTY_DATA_TREE: LazyLock<DataTree<TensorType>> = LazyLock::new(DataTree:
 /// In a data-flow graph, `Store` nodes play the role of constants — they are wired to
 /// the input ports of computation nodes to supply fixed values.
 pub struct Store {
-    data: DataTree<Tensor>,
+    /// Tensors in DFS leaf order matching `output_types`.
+    leaves: Vec<Tensor>,
     output_types: DataTree<TensorType>,
 }
 
 impl Store {
     /// Construct a new `Store` holding the given data.
     pub fn new(data: DataTree<Tensor>) -> Self {
-        let output_types = derive_output_types(&data);
-        Self { data, output_types }
-    }
-
-    /// Return a reference to the stored data.
-    pub fn data(&self) -> &DataTree<Tensor> {
-        &self.data
-    }
-}
-
-/// Recursively derive output types from concrete tensor data.
-fn derive_output_types(data: &DataTree<Tensor>) -> DataTree<TensorType> {
-    match data {
-        DataTree::Leaf(tensor) => DataTree::new_leaf(tensor.tensor_type()),
-        DataTree::Branch(_) => {
-            let mut result = DataTree::with_capacity(data.len());
-            for (key, child) in data.iter_children() {
-                let child_type = derive_output_types(child);
-                if let Some(k) = key {
-                    result.insert_branch(k, child_type);
-                } else {
-                    result.push_branch(child_type);
-                }
-            }
-            result
+        let output_types = data.map_leaves(Tensor::tensor_type);
+        let leaves: Vec<Tensor> = data.into_leaves().collect();
+        Self {
+            leaves,
+            output_types,
         }
     }
 }
@@ -83,8 +64,8 @@ impl ProgramNode for Store {
         true
     }
 
-    fn call(&self, _args: &DataTree<Tensor>) -> Result<DataTree<Tensor>, Self::CallError> {
-        Ok(self.data.clone())
+    fn call_flat(&self, _args: &[Tensor]) -> Result<Vec<Tensor>, Self::CallError> {
+        Ok(self.leaves.clone())
     }
 }
 
@@ -97,23 +78,12 @@ mod tests {
     fn test_store_leaf_call() {
         let data = DataTree::new_leaf(Tensor::from([1.0_f64, 2.0, 3.0]));
         let store = Store::new(data);
-        let result = store.call(&DataTree::new()).unwrap();
-        let DataTree::Leaf(Tensor::F64(arr)) = result else {
+        let result = store.call_flat(&[]).unwrap();
+        assert_eq!(result.len(), 1);
+        let Tensor::F64(arr) = &result[0] else {
             panic!("expected f64 leaf");
         };
         assert_eq!(arr.as_slice().unwrap(), &[1.0, 2.0, 3.0]);
-    }
-
-    #[test]
-    fn test_store_output_types_leaf() {
-        let data = DataTree::new_leaf(Tensor::from([1.0_f64, 2.0, 3.0]));
-        let store = Store::new(data);
-        let DataTree::Leaf(tt) = store.output_types() else {
-            panic!("expected leaf output type");
-        };
-        assert!(matches!(tt.dtype, DTypeLike::Concrete(DType::F64)));
-        assert_eq!(tt.shape, vec![Dim::Fixed(3)]);
-        assert!(!tt.broadcastable);
     }
 
     #[test]
@@ -154,9 +124,20 @@ mod tests {
     }
 
     #[test]
-    fn test_store_no_inputs() {
-        let store = Store::new(DataTree::new_leaf(Tensor::from([42.0_f64])));
-        assert!(store.input_types().is_empty());
-        assert!(store.implements_call());
+    fn test_store_branched_call_returns_flat_in_dfs_order() {
+        let mut data = DataTree::new();
+        data.insert_leaf("a", Tensor::from([1.0_f64]));
+        data.insert_leaf("b", Tensor::from([2.0_f64]));
+        let store = Store::new(data);
+        let result = store.call_flat(&[]).unwrap();
+        assert_eq!(result.len(), 2);
+        let Tensor::F64(arr_a) = &result[0] else {
+            panic!()
+        };
+        let Tensor::F64(arr_b) = &result[1] else {
+            panic!()
+        };
+        assert_eq!(arr_a.as_slice().unwrap(), &[1.0]);
+        assert_eq!(arr_b.as_slice().unwrap(), &[2.0]);
     }
 }

--- a/crates/providers/src/store.rs
+++ b/crates/providers/src/store.rs
@@ -65,7 +65,7 @@ impl ProgramNode for Store {
     }
 
     fn call_flat(&self, _args: &[Tensor]) -> Result<Vec<Tensor>, Self::CallError> {
-        Ok(self.leaves.clone())
+        Ok(self.leaves.to_vec())
     }
 }
 


### PR DESCRIPTION
This PR split the `ProgramNode` trait so implementations only define `call_flat(args: &[Tensor]) -> Result<Vec<Tensor>, _>` while a new `ProgramNodeExt` trait provides the DataTree-I/O `call(args: &DataTree<Tensor>)` on top (which uses the blanket impl of ProgramNode trick to disallow specializations). This comes with three types of enum error classes: (`CallInputError`, `CallError`, `MissingCallError`).

Since `Store` is the only implementation of `ProgramNode` that's been merged into main so far, it's the only one that needs to change. However, you can (and should) especially check out `QuantumProgram` higher in the PR stack to get a sense for how `call_flat` is actually used: `QuantumProgram` uses it directly, and gets to totally avoid dealing with hash maps because it can reason about all arguments positionally.

The above `ProgramNode` refactor is itself straight forward. However, this PR also adds/updates a bunch of supporting `DataTree` machinery. 

### PR Stack

 - Parent: (None, points at main)
 - [Full Stack](https://github.com/Qiskit/qiskit/issues/15902#user-content-pr-stack)




<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: claude opus 4-7 and sonnet 4-6

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
