### PR TITLE
Extend `ConvertToPauliProductRotations` to PPRs and PPMs

### DIFF
--- a/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
+++ b/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
@@ -484,6 +484,8 @@ pub fn py_convert_to_pauli_rotations(dag: &DAGCircuit) -> PyResult<DAGCircuit> {
                 | OperationRef::StandardInstruction(StandardInstruction::Barrier(_))
                 | OperationRef::StandardInstruction(StandardInstruction::Reset)
                 | OperationRef::StandardInstruction(StandardInstruction::Delay(_))
+                | OperationRef::PauliProductRotation(_)
+                | OperationRef::PauliProductMeasurement(_)
         ) {
             new_dag.push_back(inst.clone())?;
         } else if inst.op.name() == "measure" {

--- a/qiskit/transpiler/passes/optimization/convert_to_pauli_rotations.py
+++ b/qiskit/transpiler/passes/optimization/convert_to_pauli_rotations.py
@@ -20,10 +20,14 @@ from qiskit._accelerate.convert_to_pauli_rotations import convert_to_pauli_rotat
 
 class ConvertToPauliRotations(TransformationPass):
     r"""
-    Convert a quantum circuit containing single-qubit, two-qubit and three-qubit
-    standard gates, barriers and measurements, into an equivalent circuit containing
-    :class:`.PauliProductRotationGate` gates
-    and :class:`.PauliProductMeasurement` instructions.
+    Convert a quantum circuit into an equivalent circuit composed of
+    :class:`.PauliProductRotationGate` gates and :class:`.PauliProductMeasurement`
+    instructions.
+
+    The pass converts all single-qubit, two-qubit and three-qubit standard gates into
+    Pauli product rotations, converts measures to Pauli product measurements,
+    and leaves barriers, delays, resets, Pauli product rotations, and
+    Pauli product measurements unchanged.
 
     For example::
 

--- a/releasenotes/notes/extend-convert-to-pp-9b5364de7c7265b1.yaml
+++ b/releasenotes/notes/extend-convert-to-pp-9b5364de7c7265b1.yaml
@@ -1,0 +1,6 @@
+---
+features_transpiler:
+  - |
+    Extended the :class:`.ConvertToPauliRotations` transpiler pass to handle circuits
+    with :class:`.PauliProductRotationGate` and :class:`.PauliProductMeasurement` objects.
+    These operations are passed through unchanged during conversion. 

--- a/test/python/transpiler/test_convert_to_pauli_rotations.py
+++ b/test/python/transpiler/test_convert_to_pauli_rotations.py
@@ -184,3 +184,12 @@ class TestConvertToPauliRotations(QiskitTestCase):
             with qc_exp.while_loop((cr, 0)):
                 qc_exp.compose(qc2, [0, 1], inplace=True)
         self.assertEqual(qct, qc_exp)
+
+    def test_pprs_and_ppms_are_unchanged(self):
+        """Test that the pass leaves Pauli product rotations and measurements unchanged."""
+        qc = QuantumCircuit(4, 2)
+        qc.append(PauliProductRotationGate(Pauli("XYZ"), 0.1), [1, 2, 3])
+        qc.append(PauliProductMeasurement(Pauli("-XZ")), [1, 2], [1])
+
+        qct = ConvertToPauliRotations()(qc)
+        self.assertEqual(qc, qct)


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### Summary

Trivially extends `ConvertToPauliProductRotations` to handles circuits with PPRs and PPMs, by leaving them unchanged.

Based on Julien's request, this PR was split from #16270.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
