### PR TITLE
Use rust-native error for `BarrierBeforeFinalMeasurement`

### DIFF
--- a/crates/transpiler/src/passes/barrier_before_final_measurement.rs
+++ b/crates/transpiler/src/passes/barrier_before_final_measurement.rs
@@ -15,7 +15,7 @@ use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use qiskit_circuit::Qubit;
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, DAGError, NodeType};
 use qiskit_circuit::operations::{OperationRef, StandardInstruction};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 
@@ -23,10 +23,17 @@ const PARALLEL_THRESHOLD: usize = 150;
 
 #[pyfunction]
 #[pyo3(name = "barrier_before_final_measurements", signature=(dag, label=None))]
-pub fn run_barrier_before_final_measurements(
+pub fn py_run_barrier_before_final_measurements(
     dag: &mut DAGCircuit,
     label: Option<String>,
 ) -> PyResult<()> {
+    run_barrier_before_final_measurements(dag, label).map_err(Into::into)
+}
+
+pub fn run_barrier_before_final_measurements(
+    dag: &mut DAGCircuit,
+    label: Option<String>,
+) -> Result<(), DAGError> {
     // Get a list of the node indices which are final measurement or barriers that are ancestors
     // of a given qubit's output node.
     let find_final_nodes = |[_in_index, out_index]: &[NodeIndex; 2]| -> Vec<NodeIndex> {
@@ -158,6 +165,6 @@ pub fn run_barrier_before_final_measurements(
 }
 
 pub fn barrier_before_final_measurements_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_barrier_before_final_measurements))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_barrier_before_final_measurements))?;
     Ok(())
 }


### PR DESCRIPTION
The following commits modify `BarrierBeforeFinalMeasurement` to use rust-native errors throughout its pipeline. Since the pass only ever deals with `DAGCircuit` manipulation, its error type can seamlessly be used in this function.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
