### PR TITLE
Fix BitArray bitcount padding handling

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -204,12 +204,10 @@ class BitArray(ShapedMixin):
         Returns:
             A ``numpy.uint64``-array with shape ``(*shape, num_shots)``.
         """
-        if self.num_bits % 8 == 0:
-            return np.bitwise_count(self._array).sum(axis=-1)
-
-        result = np.bitwise_count(self._array[..., 1:]).sum(axis=-1)
-        mask = np.uint8(255 >> ((-self.num_bits) % 8))
-        result += np.bitwise_count(np.bitwise_and(self._array[..., 0], mask))
+        result = np.bitwise_count(self._array).sum(axis=-1)
+        excess = self.num_bits % 8
+        if excess > 0:
+            result -= np.bitwise_count(self._array[..., 0] >> np.uint8(excess))
         return result
 
     @staticmethod

--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -204,7 +204,13 @@ class BitArray(ShapedMixin):
         Returns:
             A ``numpy.uint64``-array with shape ``(*shape, num_shots)``.
         """
-        return np.bitwise_count(self._array).sum(axis=-1)
+        if self.num_bits % 8 == 0:
+            return np.bitwise_count(self._array).sum(axis=-1)
+
+        result = np.bitwise_count(self._array[..., 1:]).sum(axis=-1)
+        mask = np.uint8(255 >> ((-self.num_bits) % 8))
+        result += np.bitwise_count(np.bitwise_and(self._array[..., 0], mask))
+        return result
 
     @staticmethod
     def from_bool_array(

--- a/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
+++ b/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed :meth:`.BitArray.bitcount` so it ignores unused padding bits in the
+    Fixed :meth:`.BitArray.bitcount` so that it ignores unused padding bits in the
     packed byte storage.

--- a/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
+++ b/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fixed :meth:`.BitArray.bitcount` so that it ignores unused padding bits in the
-    packed byte storage.
+    packed byte storage. See `#16173 <https://github.com/Qiskit/qiskit/issues/16173>`__.

--- a/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
+++ b/releasenotes/notes/fix-bitarray-padding-bitcount-314547cfe1e07045.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed :meth:`.BitArray.bitcount` so it ignores unused padding bits in the
+    packed byte storage.

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -174,6 +174,13 @@ class BitArrayTestCase(QiskitTestCase):
         ba = BitArray.from_bool_array([[1, 0, 0], [1, 1, 0]])
         self.assertEqual(~ba, BitArray.from_bool_array([[0, 1, 1], [0, 0, 1]]))
 
+    @ddt.data(1, 7, 9, 13)
+    def test_bitcount_ignores_padding_bits(self, num_bits):
+        """Test bitcount only counts logical bits."""
+        ba = ~BitArray.from_samples([0], num_bits)
+        np.testing.assert_array_equal(ba.bitcount(), ba.to_bool_array().sum(axis=-1))
+        self.assertEqual(ba.bitcount().tolist(), [num_bits])
+
     def test_logical_xor(self):
         """Test the logical XOR operator."""
         ba1 = BitArray.from_bool_array([[1, 0, 0], [1, 1, 0]])

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -177,6 +177,9 @@ class BitArrayTestCase(QiskitTestCase):
     @ddt.data(1, 7, 9, 13)
     def test_bitcount_ignores_padding_bits(self, num_bits):
         """Test bitcount only counts logical bits."""
+        ba = BitArray.from_samples([0], num_bits)
+        self.assertEqual(ba.bitcount().tolist(), [0])
+
         ba = ~BitArray.from_samples([0], num_bits)
         np.testing.assert_array_equal(ba.bitcount(), ba.to_bool_array().sum(axis=-1))
         self.assertEqual(ba.bitcount().tolist(), [num_bits])


### PR DESCRIPTION
## Summary

Fixes #16173.

`BitArray.bitcount()` now ignores unused padding bits in the packed byte storage, so counts reflect only the logical `num_bits` bits.

## Details

For non-byte-aligned bit arrays, public operations such as `~` can set padding bits outside the logical bitstring. `bitcount()` now counts the packed storage with `np.bitwise_count`, then subtracts the overcount from padded high bits in the first byte. This matches the logical view used by `to_bool_array()` without copying or mutating `self._array`.

## Tests

- `python3 -m unittest -v test.python.primitives.containers.test_bit_array.BitArrayTestCase.test_bitcount_ignores_padding_bits_1_1 test.python.primitives.containers.test_bit_array.BitArrayTestCase.test_bitcount_ignores_padding_bits_2_7 test.python.primitives.containers.test_bit_array.BitArrayTestCase.test_bitcount_ignores_padding_bits_3_9 test.python.primitives.containers.test_bit_array.BitArrayTestCase.test_bitcount_ignores_padding_bits_4_13`
- `python3 -m unittest -v test.python.primitives.containers.test_bit_array.BitArrayTestCase`
- `.venv/bin/tox -epy313 -- -n test/python/primitives/containers/test_bit_array.py`
- `.venv/bin/black --check qiskit/primitives/containers/bit_array.py test/python/primitives/containers/test_bit_array.py`
- `.venv/bin/ruff check qiskit/primitives/containers/bit_array.py test/python/primitives/containers/test_bit_array.py`
- `.venv/bin/reno -q lint`

## Notes

Full test suite was not run.

## AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5, 2026-05-29 and 2026-06-05).
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5, 2026-05-29 and 2026-06-05). I reviewed the changed lines and understand the byte-padding overcount subtraction.
