### PR TITLE
Reject loopback edges in `CouplingMap`

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -20,6 +20,7 @@ onto a device with this coupling.
 """
 
 import math
+import warnings
 
 import rustworkx as rx
 from rustworkx.visualization import graphviz_draw
@@ -68,7 +69,13 @@ class CouplingMap:
         self._is_symmetric = None
 
         if couplinglist is not None:
-            self.graph.extend_from_edge_list([tuple(x) for x in couplinglist])
+            edges = []
+            for src, dst in couplinglist:
+                if src == dst:
+                    warnings.warn(_loopback_warning(src), stacklevel=2)
+                    continue
+                edges.append((src, dst))
+            self.graph.extend_from_edge_list(edges)
 
     def size(self):
         """Return the number of physical qubits in this graph."""
@@ -114,6 +121,9 @@ class CouplingMap:
         src (int): source physical qubit
         dst (int): destination physical qubit
         """
+        if src == dst:
+            warnings.warn(_loopback_warning(src), stacklevel=2)
+            return
         if src not in self.physical_qubits:
             self.add_physical_qubit(src)
         if dst not in self.physical_qubits:
@@ -506,3 +516,7 @@ class CouplingMap:
         """
 
         return graphviz_draw(self.graph, method=method)
+
+
+def _loopback_warning(src: int) -> Warning:
+    return UserWarning(f"qubits cannot be coupled to themselves: ignoring edge ({src}, {src})")

--- a/releasenotes/notes/couplingmap-no-loopback-498d543175300f28.yaml
+++ b/releasenotes/notes/couplingmap-no-loopback-498d543175300f28.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.CouplingMap` will now ignore edges that join a qubit to itself, and issue a warning
+    about it.  Previously these were incorrectly silently accepted, which could cause long-range
+    errors in code depending on the coupling graph.

--- a/test/python/transpiler/test_coupling.py
+++ b/test/python/transpiler/test_coupling.py
@@ -519,6 +519,15 @@ class CouplingTest(QiskitTestCase):
         # additional test for comparison to a non-CouplingMap object
         self.assertNotEqual(coupling0, 1)
 
+    def test_ignores_self_coupling(self):
+        edges = [(0, 1), (1, 1), (1, 2), (2, 3)]
+        with self.assertWarnsRegex(Warning, "qubits cannot be coupled to themselves"):
+            coupling = CouplingMap(edges)
+        self.assertEqual(set(coupling.get_edges()), {(a, b) for (a, b) in edges if a != b})
+        with self.assertWarnsRegex(Warning, "qubits cannot be coupled to themselves"):
+            coupling.add_edge(2, 2)
+        self.assertEqual(set(coupling.get_edges()), {(a, b) for (a, b) in edges if a != b})
+
 
 class CouplingVisualizationTest(QiskitVisualizationTestCase):
     @unittest.skipUnless(optionals.HAS_GRAPHVIZ, "Graphviz not installed")


### PR DESCRIPTION
The `CouplingMap` is supposed to represent the allowed two-qubit interactions.  It is not valid to have a 2q interaction that uses the same qubit twice, and various downstream consumers of `CouplingMap` could error in very strange ways if this happened.

Fix #16267.

Also motivated by a thread in public Slack that found the `transpiler` rejecting compilations against coupling maps with loopback edges on the basis that a completely different edge was apparently not present.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
