### PR TITLE
Remove incorrect loopback edge from `VF2Layout` test

### DIFF
--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -714,7 +714,6 @@ class TestMultipleTrials(QiskitTestCase):
                     (1, 3),
                     (2, 0),
                     (2, 1),
-                    (2, 2),
                     (2, 3),
                     (3, 0),
                     (3, 1),


### PR DESCRIPTION
The loopback edge is invalid; the resulting `CouplingMap` would break the data model.

Found during #16310

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
