### PR TITLE
Fix QPY scoped cache uploads in GitHub Actions

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,21 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Shared configuration values.  It's also possible to specify these in the GitHub web interface,
-  # but that separates them from the rest of the configuration logic and means that the changes to
-  # the configuration do not appear in the git history.
   config:
     name: Configure
-    runs-on: 'ubuntu-latest'
-    steps:
-      - run: ':'
-    outputs:
-      python-old: '3.10'
-      python-new: '3.14'
-      runner-linux-x86_64: 'ubuntu-latest'
-      runner-linux-arm64: 'ubuntu-24.04-arm'
-      runner-macos-arm64: 'macos-15'
-      runner-windows-x86_64: 'windows-latest'
+    uses: ./.github/workflows/config.yml
 
   # This 'finalize' job is a no-op; its sole purpose is to depend on all the other jobs and provide
   # a single in-code determination of whether the branch-protection rules have been passed.  The

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,0 +1,43 @@
+---
+
+# This is a no-op job whose only purpose is to centralise some shared configuration values.  It's
+# also possible to specify these in the GitHub web interface, but that separates them from the rest
+# of the configuration logic and means that the changes to the configuration do not appear in the
+# git history.
+
+name: Set CI configuration
+
+on:
+  workflow_call:
+    outputs:
+      python-old:
+        description: Oldest supported version of Python
+        value: '3.10'
+
+      python-new:
+        description: Newest supported version of Python
+        value: '3.14'
+
+      runner-linux-x86_64:
+        description: Runner image for Linux x86_64 jobs
+        value: 'ubuntu-latest'
+
+      runner-linux-arm64:
+        description: Runner image for Linux ARM64 jobs
+        value: 'ubuntu-24.04-arm'
+
+      runner-macos-arm64:
+        description: Runner image for macOS ARM64 jobs
+        value: 'macos-15'
+
+      runner-windows-x86_64:
+        description: Runner image for Windows x86_64 jobs
+        value: 'windows-latest'
+
+jobs:
+  # We have to have _some_ job defined or the workflow isn't valid.
+  noop:
+    name: Configure
+    runs-on: 'ubuntu-latest'
+    steps:
+      - run: ':'

--- a/.github/workflows/qpy.yml
+++ b/.github/workflows/qpy.yml
@@ -1,10 +1,6 @@
 name: QPY
 
 on:
-  # Unlike most branch-protection jobs, we want to re-run this on `push` to ensure the cache is
-  # populated in a scope that's reachable by later PRs and the merge queue.
-  push:
-    branches: ["main", "stable/*"]
   workflow_call:
     inputs:
       python-version:
@@ -15,6 +11,10 @@ on:
         description: Runner image to use.
         type: string
         required: true
+      only-update-cache:
+        description: Only run the test suite if we need to regenerate the cached files.
+        type: boolean
+        default: false
 
 jobs:
   backward_compat:
@@ -45,7 +45,4 @@ jobs:
         run: ./run_tests.sh
         env:
           QISKIT_IGNORE_USER_SETTINGS: TRUE
-        # We _usually_ don't want to waste CI resources running this job on `push` if nothing's
-        # changed, since branch protection just did it, but if there's a cache miss then we want to
-        # populate it for later PRs.
-        if: (github.event_name != 'push') || (steps.cache.outputs.cache-hit != 'true')
+        if: (!inputs.only-update-cache) || (steps.cache.outputs.cache-hit != 'true')

--- a/.github/workflows/qpy.yml
+++ b/.github/workflows/qpy.yml
@@ -1,6 +1,10 @@
 name: QPY
 
 on:
+  # Unlike most branch-protection jobs, we want to re-run this on `push` to ensure the cache is
+  # populated in a scope that's reachable by later PRs and the merge queue.
+  push:
+    branches: ["main", "stable/*"]
   workflow_call:
     inputs:
       python-version:
@@ -34,9 +38,14 @@ jobs:
           # but since we risk the QPY tests failing to update if they're not in
           # sync, it's better safe than sorry.
           key: qpy-${{ hashFiles('test/qpy_compat/**') }}
+        id: cache
 
       - name: Run QPY backwards compatibility tests
         working-directory: test/qpy_compat
         run: ./run_tests.sh
         env:
           QISKIT_IGNORE_USER_SETTINGS: TRUE
+        # We _usually_ don't want to waste CI resources running this job on `push` if nothing's
+        # changed, since branch protection just did it, but if there's a cache miss then we want to
+        # populate it for later PRs.
+        if: (github.event_name != 'push') || (steps.cache.outputs.cache-hit != 'true')

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,0 +1,30 @@
+---
+
+# This file is just for updating base caches on PR-target branches.  It isn't a branch-protection
+# requirement, just a CI performance improvement.
+#
+# Some of our branch-protection workflows use caching to avoid needlessly recalculating heavy
+# initial state.  The way GitHub caching works, this can only propagate through to later PRs and the
+# merge queue if a cache triggered trigger _from_ the target branch also runs.  We don't want to
+# waste CI resources actually running a load of test suites on every push if they're not necessary
+# (and typically they're not, because the merge-queue branch-protection rules require the test suite
+# to have passed on the literal commit objects that branches get fast-forwarded onto).
+
+name: Update caches
+on:
+  push:
+    branches: ["main", "stable/*"]
+
+jobs:
+  config:
+    name: Configure
+    uses: ./.github/workflows/config.yml
+
+  qpy:
+    name: QPY
+    needs: config
+    uses: ./.github/workflows/qpy.yml
+    with:
+      python-version: ${{ needs.config.outputs.python-old }}
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      only-update-caches: true

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -27,4 +27,4 @@ jobs:
     with:
       python-version: ${{ needs.config.outputs.python-old }}
       runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-      only-update-caches: true
+      only-update-cache: true


### PR DESCRIPTION
When we consolidated the branch-protection rules[^1], we removed the `on: push` logic from all the jobs too, to avoid duplication of unnecessary work.  This has the knock-on effect of preventing the QPY cache from getting populated into a cache scope[^2] that's reachable from later PRs and the merge queue, and so all the QPY jobs have been taking a lot longer than necessary recently.

[^1]: 913091b5af: Unify GitHub Actions branch-protection run logic (gh-15794)
[^2]: https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

---

I'm not entirely confident in this, but it's hard to check without merging to `main`.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
