### PR TITLE
Make DAGCircuit rust copy like methods infallible

### DIFF
--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1321,7 +1321,7 @@ pub unsafe extern "C" fn qk_dag_get_instruction(
 /// // rqr_1: ──┼──┤ Y ├
 /// //        ┌─┴─┐└───┘
 /// // rqr_2: ┤ X ├─────
-/// //        └───┘     
+/// //        └───┘
 /// QkDag *dag_right = qk_dag_new();
 /// QkQuantumRegister *rqr = qk_quantum_register_new(3, "rqr");
 /// qk_dag_add_quantum_register(dag_right, rqr);
@@ -1330,7 +1330,7 @@ pub unsafe extern "C" fn qk_dag_get_instruction(
 /// qk_dag_apply_gate(dag_right, QkGate_Y, (uint32_t[]){1}, NULL, false);
 ///
 /// // Build the following dag
-/// //          ┌───┐   
+/// //          ┌───┐
 /// // lqr_0: ──┤ H ├───
 /// //        ┌─┴───┴──┐
 /// // lqr_1: ┤ P(0.1) ├
@@ -1344,13 +1344,13 @@ pub unsafe extern "C" fn qk_dag_get_instruction(
 ///
 /// // Compose left circuit onto right circuit
 /// // Should result in circuit
-/// //             ┌───┐          
+/// //             ┌───┐
 /// // rqr_0: ──■──┤ H ├──────────
 /// //          │  ├───┤┌────────┐
 /// // rqr_1: ──┼──┤ Y ├┤ P(0.1) ├
 /// //        ┌─┴─┐└───┘└────────┘
 /// // rqr_2: ┤ X ├───────────────
-/// //        └───┘               
+/// //        └───┘
 /// qk_dag_compose(dag_right, dag_left, NULL, NULL);
 ///
 /// // Clean up after you're done
@@ -1660,9 +1660,7 @@ pub unsafe extern "C" fn qk_dag_copy_empty_like(
     let vars_mode = vars_mode.into();
     let blocks_mode = blocks_mode.into();
 
-    let copied_dag = dag
-        .copy_empty_like_with_capacity(0, 0, vars_mode, blocks_mode)
-        .expect("Failed to copy the DAG.");
+    let copied_dag = dag.copy_empty_like_with_capacity(0, 0, vars_mode, blocks_mode);
     Box::into_raw(Box::new(copied_dag))
 }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -110,12 +110,6 @@ pub use rustworkx_core::petgraph::stable_graph::NodeIndex;
 #[error("Wire {0:?} already exists in circuit")]
 pub struct DuplicateWireError(Wire);
 
-impl From<DuplicateWireError> for DAGError {
-    fn from(value: DuplicateWireError) -> Self {
-        Self::DuplicateWire(value)
-    }
-}
-
 impl From<DuplicateWireError> for PyErr {
     fn from(value: DuplicateWireError) -> Self {
         DAGCircuitError::new_err(value.to_string())
@@ -133,7 +127,7 @@ pub enum DAGError {
     #[error("Wire {0:?} not found in circuit")]
     WireNotInCircuit(Wire),
     #[error(transparent)]
-    DuplicateWire(DuplicateWireError),
+    DuplicateWire(#[from] DuplicateWireError),
     #[error(
         "{ty} not in circuit. {0}",
         ty = match .0 {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -104,6 +104,24 @@ static SEMANTIC_EQ_SYMMETRIC: [&str; 4] = ["barrier", "swap", "break_loop", "con
 
 pub use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
+/// An error indicating that an input would result in an invalid dag with
+/// duplicate wires or that the input that takes wires contains duplicates
+#[derive(Debug, thiserror::Error)]
+#[error("Wire {0:?} already exists in circuit")]
+pub struct DuplicateWireError(Wire);
+
+impl From<DuplicateWireError> for DAGError {
+    fn from(value: DuplicateWireError) -> Self {
+        Self::DuplicateWire(value)
+    }
+}
+
+impl From<DuplicateWireError> for PyErr {
+    fn from(value: DuplicateWireError) -> Self {
+        DAGCircuitError::new_err(value.to_string())
+    }
+}
+
 /// Possible errors that can be received from any operation on the
 /// [`DAGCircuit`]
 #[derive(Debug, thiserror::Error)]
@@ -114,8 +132,8 @@ pub enum DAGError {
     ClbitsNotIdle(Vec<ShareableClbit>),
     #[error("Wire {0:?} not found in circuit")]
     WireNotInCircuit(Wire),
-    #[error("Duplicate wire {0:?}")]
-    DuplicateWire(Wire),
+    #[error(transparent)]
+    DuplicateWire(DuplicateWireError),
     #[error(
         "{ty} not in circuit. {0}",
         ty = match .0 {
@@ -1320,9 +1338,8 @@ impl DAGCircuit {
     //
     // You likely want `copy_empty_like_with_same_capacity`.
     #[pyo3(name = "copy_empty_like", signature = (*, vars_mode=VarsMode::Alike))]
-    pub fn py_copy_empty_like(&self, vars_mode: VarsMode) -> PyResult<Self> {
+    pub fn py_copy_empty_like(&self, vars_mode: VarsMode) -> Self {
         self.copy_empty_like_with_capacity(0, 0, vars_mode, BlocksMode::Drop)
-            .map_err(Into::into)
     }
 
     /// Put ``self`` into the canonical physical form, with the given number of qubits.
@@ -3290,7 +3307,7 @@ impl DAGCircuit {
         let dags = PyList::empty(py);
 
         for comp_nodes in connected_components.iter() {
-            let mut new_dag = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
+            let mut new_dag = self.copy_empty_like(vars_mode, BlocksMode::Drop);
             new_dag.global_phase = Param::Float(0.);
 
             // A map from nodes in the this DAGCircuit to nodes in the new dag. Used for adding edges
@@ -4069,7 +4086,7 @@ impl DAGCircuit {
                 return Ok(PyIterator::from_object(&layer_list)?.into());
             }
 
-            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
+            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
             let mut block_map = BlockMapper::new();
             let data: Vec<_> = op_nodes
                 .iter()
@@ -4111,7 +4128,7 @@ impl DAGCircuit {
                 Some(NodeType::Operation(node)) => node,
                 _ => unreachable!("A non-operation node was obtained from topological_op_nodes."),
             };
-            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
+            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
             let mut block_map = BlockMapper::new();
 
             // Save the support of the operation we add to the layer
@@ -5046,11 +5063,7 @@ impl DAGCircuit {
     /// `Interned<[Qubit]>` and `Interned<[Clbit]>` keys from `self` are valid in the output DAG.
     ///
     /// This does not include any pre-allocated capacity.
-    pub fn copy_empty_like(
-        &self,
-        vars_mode: VarsMode,
-        blocks_mode: BlocksMode,
-    ) -> Result<Self, DAGError> {
+    pub fn copy_empty_like(&self, vars_mode: VarsMode, blocks_mode: BlocksMode) -> Self {
         self.copy_empty_like_with_capacity(0, 0, vars_mode, blocks_mode)
     }
 
@@ -5063,7 +5076,7 @@ impl DAGCircuit {
         &self,
         vars_mode: VarsMode,
         blocks_mode: BlocksMode,
-    ) -> Result<Self, DAGError> {
+    ) -> Self {
         self.copy_empty_like_with_capacity(
             self.dag.node_count().saturating_sub(2 * self.width()),
             self.dag.edge_count(),
@@ -5083,24 +5096,26 @@ impl DAGCircuit {
         num_edges: usize,
         vars_mode: VarsMode,
         blocks_mode: BlocksMode,
-    ) -> Result<Self, DAGError> {
+    ) -> Self {
         let mut out = self.qubitless_empty_like_with_capacity(
             self.num_qubits(),
             num_ops,
             num_edges,
             vars_mode,
             blocks_mode,
-        )?;
+        );
         for bit in self.qubits.objects() {
-            out.add_qubit_unchecked(bit.clone())?;
+            out.add_qubit_unchecked(bit.clone())
+                .expect("There are no duplicate qubits in a valid dag");
         }
         for reg in self.qregs.registers() {
-            out.add_qreg(reg.clone())?;
+            out.add_qreg(reg.clone())
+                .expect("There are no duplicate qubits/qregs in a valid dag");
         }
         // `copy_empty_like` has historically made a strong assumption that the exact same qargs
         // will be used in the output.  Some Qiskit functions rely on this undocumented behaviour.
         out.qargs_interner.clone_from(&self.qargs_interner);
-        Ok(out)
+        out
     }
 
     /// Create an empty DAG with the canonical "physical" register of the correct length, with all
@@ -5127,7 +5142,7 @@ impl DAGCircuit {
             num_edges,
             VarsMode::Alike,
             blocks_mode,
-        )?;
+        );
         out.add_qreg(QuantumRegister::new_owning("q", num_qubits as u32))?;
         Ok(out)
     }
@@ -5155,7 +5170,7 @@ impl DAGCircuit {
         num_edges: usize,
         vars_mode: VarsMode,
         blocks_mode: BlocksMode,
-    ) -> Result<Self, DAGError> {
+    ) -> Self {
         let (num_vars, num_stretches) = match vars_mode {
             VarsMode::Drop => (0, 0),
             _ => (self.num_vars(), self.num_stretches()),
@@ -5178,10 +5193,14 @@ impl DAGCircuit {
         target_dag.cargs_interner = self.cargs_interner.clone();
 
         for bit in self.clbits.objects() {
-            target_dag.add_clbit_unchecked(bit.clone())?;
+            target_dag
+                .add_clbit_unchecked(bit.clone())
+                .expect("Duplicate clbits not possible in a valid DAG");
         }
         for reg in self.cregs.registers() {
-            target_dag.add_creg(reg.clone())?;
+            target_dag
+                .add_creg(reg.clone())
+                .expect("Duplicate creg/clbits not possible in a valid DAG");
         }
         match vars_mode {
             VarsMode::Alike => {
@@ -5192,11 +5211,13 @@ impl DAGCircuit {
             }
             VarsMode::Drop => {}
         }
-        target_dag.add_var_wires(target_dag.vars_stretches.vars().len())?;
+        target_dag
+            .add_var_wires(target_dag.vars_stretches.vars().len())
+            .expect("Duplicate vars not possible in a valid DAG");
         if blocks_mode == BlocksMode::Keep {
             target_dag.blocks = self.blocks.clone();
         }
-        Ok(target_dag)
+        target_dag
     }
 
     /// Modify `self` to mark its qubits as physical.
@@ -6334,11 +6355,11 @@ impl DAGCircuit {
     ///
     /// Raises:
     ///     DAGCircuitError: if trying to add duplicate wire
-    fn add_wire(&mut self, wire: Wire) -> Result<(NodeIndex, NodeIndex), DAGError> {
+    fn add_wire(&mut self, wire: Wire) -> Result<(NodeIndex, NodeIndex), DuplicateWireError> {
         let (in_node, out_node) = match wire {
             Wire::Qubit(qubit) => {
                 if qubit.index() < self.qubit_io_map.len() {
-                    return Err(format!("Wire {qubit:?} already exists in circuit").into());
+                    return Err(DuplicateWireError(wire));
                 }
                 let in_node = self.dag.add_node(NodeType::QubitIn(qubit));
                 let out_node = self.dag.add_node(NodeType::QubitOut(qubit));
@@ -6347,7 +6368,7 @@ impl DAGCircuit {
             }
             Wire::Clbit(clbit) => {
                 if clbit.index() < self.clbit_io_map.len() {
-                    return Err(format!("Wire {clbit:?} already exists in circuit").into());
+                    return Err(DuplicateWireError(wire));
                 }
                 let in_node = self.dag.add_node(NodeType::ClbitIn(clbit));
                 let out_node = self.dag.add_node(NodeType::ClbitOut(clbit));
@@ -6356,7 +6377,7 @@ impl DAGCircuit {
             }
             Wire::Var(var) => {
                 if var.index() < self.var_io_map.len() {
-                    return Err(format!("Wire {var:?} already exists in circuit").into());
+                    return Err(DuplicateWireError(wire));
                 }
                 let in_node = self.dag.add_node(NodeType::VarIn(var));
                 let out_node = self.dag.add_node(NodeType::VarOut(var));
@@ -6420,7 +6441,10 @@ impl DAGCircuit {
         self.dag.remove_node(out_node);
     }
 
-    pub fn add_qubit_unchecked(&mut self, bit: ShareableQubit) -> Result<Qubit, DAGError> {
+    pub fn add_qubit_unchecked(
+        &mut self,
+        bit: ShareableQubit,
+    ) -> Result<Qubit, DuplicateWireError> {
         let qubit = self.qubits.add_unique_within_capacity(bit.clone());
         self.qubit_locations
             .insert(bit, BitLocations::new((self.qubits.len() - 1) as u32, []));
@@ -6428,7 +6452,10 @@ impl DAGCircuit {
         Ok(qubit)
     }
 
-    pub fn add_clbit_unchecked(&mut self, bit: ShareableClbit) -> Result<Clbit, DAGError> {
+    pub fn add_clbit_unchecked(
+        &mut self,
+        bit: ShareableClbit,
+    ) -> Result<Clbit, DuplicateWireError> {
         let clbit = self.clbits.add_unique_within_capacity(bit.clone());
         self.clbit_locations
             .insert(bit, BitLocations::new((self.clbits.len() - 1) as u32, []));
@@ -7588,7 +7615,7 @@ impl DAGCircuit {
                             .ok_or_else(|| DAGError::WireNotInCircuit(qubit.into()))?;
 
                         if new_dag.qubits.find(shareable_qubit).is_some() {
-                            return Err(DAGError::DuplicateWire(qubit.into()));
+                            return Err(DuplicateWireError(qubit.into()).into());
                         }
                         let qubit_index = qc_data.qubits().find(shareable_qubit).unwrap();
                         ordered_vec[qubit_index.index()] =
@@ -7623,7 +7650,7 @@ impl DAGCircuit {
                             .ok_or_else(|| DAGError::WireNotInCircuit(clbit.into()))?;
 
                         if new_dag.clbits.find(shareable_clbit).is_some() {
-                            return Err(DAGError::DuplicateWire(clbit.into()));
+                            return Err(DuplicateWireError(clbit.into()).into());
                         };
                         let clbit_index = qc_data.clbits().find(shareable_clbit).unwrap();
                         ordered_vec[clbit_index.index()] =

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -331,13 +331,7 @@ fn apply_translation(
     qargs_with_non_global_operation: &AhashIndexMap<Qargs, AhashIndexSet<&str>>,
     qarg_mapping: Option<&HashMap<Qubit, Qubit>>,
 ) -> Result<DAGCircuit, BasisTranslatorError> {
-    let out_dag = dag
-        .copy_empty_like(VarsMode::Alike, BlocksMode::Keep)
-        .map_err(|_| {
-            BasisTranslatorError::BasisDAGCircuitError(
-                "Error copying DAGCircuit instance".to_string(),
-            )
-        })?;
+    let out_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep);
     let mut out_dag_builder = out_dag.into_builder();
     for node in dag.topological_op_nodes(false) {
         let node_obj = dag[node].unwrap_operation();

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -608,7 +608,7 @@ pub fn run_commutative_optimization(
     // We will use it to intern qubits of canonicalized instructions.
     // (In theory, we could also change qubits when merging instructions, however
     // this does not happen right now).
-    let mut new_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep)?;
+    let mut new_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep);
 
     let node_indices = dag.topological_op_nodes(false).collect::<Vec<_>>();
     let num_nodes = node_indices.len();

--- a/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
+++ b/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
@@ -469,7 +469,7 @@ fn generate_pauli_product_rotation_gate(paulis: &[BitTerm], angle: Param) -> Pau
 #[pyfunction]
 #[pyo3(name = "convert_to_pauli_rotations")]
 pub fn py_convert_to_pauli_rotations(dag: &DAGCircuit) -> PyResult<DAGCircuit> {
-    let mut new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
+    let mut new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep);
 
     // Iterate over nodes in the DAG and collect nodes
     let mut global_phase = Param::Float(0.0);

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -467,7 +467,7 @@ fn separate_dag(dag: &mut DAGCircuit) -> PyResult<Vec<DAGCircuit>> {
     let decomposed_dags: PyResult<Vec<DAGCircuit>> = component_qubits
         .into_iter()
         .map(|dag_qubits| -> PyResult<DAGCircuit> {
-            let mut new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Drop)?;
+            let mut new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Drop);
             let qubits_to_revmove: Vec<Qubit> = qubits.difference(&dag_qubits).copied().collect();
 
             new_dag.remove_qubits(qubits_to_revmove)?;

--- a/crates/transpiler/src/passes/elide_permutations.rs
+++ b/crates/transpiler/src/passes/elide_permutations.rs
@@ -39,7 +39,7 @@ pub fn run_elide_permutations(dag: &DAGCircuit) -> PyResult<Option<(DAGCircuit, 
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
 
     // note that DAGCircuit::copy_empty_like clones the interners
-    let mut new_dag = dag.copy_empty_like_with_capacity(0, 0, VarsMode::Alike, BlocksMode::Keep)?;
+    let mut new_dag = dag.copy_empty_like_with_capacity(0, 0, VarsMode::Alike, BlocksMode::Keep);
     for node_index in dag.topological_op_nodes(false) {
         if let NodeType::Operation(inst) = &dag[node_index] {
             match inst.op.view() {

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -80,7 +80,7 @@ pub fn run_litinski_transformation(
         .sum();
     let clifford_count = dag.size(false)? - non_clifford_handled_count;
 
-    let new_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep)?;
+    let new_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep);
     let mut new_dag = new_dag.into_builder();
 
     let num_qubits = dag.num_qubits();

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -99,7 +99,7 @@ pub fn run_split_2q_unitaries(
     // We have swap-like unitaries, so we create a new DAG in a manner similar to
     // The Elide Permutations pass, while also splitting the unitaries to 1-qubit gates
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
-    let new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
+    let new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep);
     let mut new_dag = new_dag.into_builder();
     for node in dag.topological_op_nodes(false) {
         let NodeType::Operation(inst) = &dag.dag()[node] else {

--- a/crates/transpiler/src/passes/two_qubit_peephole.rs
+++ b/crates/transpiler/src/passes/two_qubit_peephole.rs
@@ -284,7 +284,7 @@ fn two_qubit_unitary_peephole_optimize_apply(
 ) -> PyResult<Option<DAGCircuit>> {
     // After we've computed all the sequences to execute now serially build up a new dag.
     let mut processed_runs: Vec<bool> = vec![false; result.run_mapping.len()];
-    let out_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep)?;
+    let out_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep);
     let mut out_dag_builder = out_dag.into_builder();
     for node in toposort(dag.dag(), None).expect("DAG has no cycles") {
         if !matches!(dag.dag()[node], NodeType::Operation(_)) {

--- a/crates/transpiler/src/passes/unitary_synthesis/mod.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/mod.rs
@@ -343,7 +343,7 @@ pub fn run_unitary_synthesis(
     }
 
     let mut out = dag
-        .copy_empty_like(VarsMode::Alike, BlocksMode::Drop)?
+        .copy_empty_like(VarsMode::Alike, BlocksMode::Drop)
         .into_builder();
     for node in dag.topological_op_nodes(false) {
         let inst = dag[node].unwrap_operation();


### PR DESCRIPTION
The DAGCircuit copy like methods are inherently infallible. At their core they are copy the dag state excluding instructions. Copying an existing field in a data structure can't cause a failure when constructing the new copy. However these methods were all listed as fallible. At it's core this is because internally the `DAGCircuit::add_wire()` method is used internally to add cloned version of all the `Wire` objects. The add_wire is user facing and is fallible to detect duplicates and block them from being accidentally added. But in the context of making a copy we know there are no duplicates because it is a DAGCircuit object, so the duplicate check on addition already held.

To fix this discrepancy this adds a new error struct to define a concrete error condition. The inner error from add_wire was previously using DAGError::Generic with a custom string. But since DAGError is an enum it was not clear what the error conditions from the method actually were. This adds the concrete DuplicateWireError to make it clear there is only one error type that the method can emit. This makes it clear that we can only have a duplicate wire error from this method and none of the other DAGError variants apply. Then once that's clear we remove the error pass through in the copy methods and switch to expect() to make it clear that the internal assumption for dismissing the error is that it is not possible for a valid dag to have duplicate wires so the sole error condition is not possible.

One small detail is that this unifies the duplicate wire error. Previously the add_wire method was using the DAGError::generic error variant presumably to set a custom error message. However there was already a duplicate wire error variant that was used on other methods. This unifies the error types because the error condition is the same. It also updates the existing DAGError::DuplicateWire methods that this is the sole error condition to use it directly instead of the broader DAGError.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
