### PR TITLE
Fix QASM3 experimental delay unit serialization

### DIFF
--- a/crates/qasm3/src/ast.rs
+++ b/crates/qasm3/src/ast.rs
@@ -138,7 +138,7 @@ impl Display for DurationUnit {
         let unit_str = match self {
             DurationUnit::Nanosecond => "ns",
             DurationUnit::Microsecond => "us",
-            DurationUnit::Millisecond => "us",
+            DurationUnit::Millisecond => "ms",
             DurationUnit::Second => "s",
             DurationUnit::Sample => "dt",
         };

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1213,7 +1213,7 @@ impl<'a> QASM3Builder {
             None => {
                 if delay_unit == DelayUnit::PS {
                     DurationLiteral {
-                        value: duration * 1000.0,
+                        value: duration / 1000.0,
                         unit: DurationUnit::Nanosecond,
                     }
                 } else {

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -3407,6 +3407,23 @@ class TestQASM3ExporterRust(QiskitTestCase):
         with_qpy = dumps_experimental(qpy_roundtrip)
         self.assertEqual(no_qpy, with_qpy)
 
+    def test_delay_units(self):
+        """Test duration-unit serialization in the experimental exporter."""
+        qc = QuantumCircuit(1)
+        qc.delay(1, 0, unit="ms")
+        qc.delay(1, 0, unit="ps")
+        expected_qasm = "\n".join(
+            [
+                "OPENQASM 3.0;",
+                'include "stdgates.inc";',
+                "qubit[1] q;",
+                "delay[1ms] q[0];",
+                "delay[0.001ns] q[0];",
+                "",
+            ]
+        )
+        self.assertEqual(dumps_experimental(qc), expected_qasm)
+
     def test_annotations(self):
         """Test that the annotation-serialisation framework works."""
         assert_in = self.assertIn


### PR DESCRIPTION
## Summary
- fix the `DurationUnit::Millisecond` serializer so experimental QASM3 exports emit `ms` instead of `us`
- correct the picosecond-to-nanosecond conversion path used by `qasm3.dumps_experimental`
- add a focused regression test covering `ms` and `ps` delay serialization

## Test plan
- [x] Run `python -m unittest test.python.qasm3.test_export.TestQASM3ExporterRust.test_delay_units test.python.qasm3.test_export.TestQASM3ExporterRust.test_delay_qpy_roundtrip test.python.qasm3.test_export.TestCircuitQASM3.test_delay_statement` in an isolated validation worktree

fixes #16097

AI assistance disclosure: GPT-5.4 (Cursor)