### PR TITLE
Expand dagcircuit module-level documentation

### DIFF
--- a/qiskit/dagcircuit/__init__.py
+++ b/qiskit/dagcircuit/__init__.py
@@ -17,7 +17,35 @@ DAG Circuits (:mod:`qiskit.dagcircuit`)
 
 .. currentmodule:: qiskit.dagcircuit
 
-Circuits as Directed Acyclic Graphs
+Qiskit's graph-based circuit representations
+============================================
+
+Qiskit uses directed acyclic graphs (DAGs) as intermediate representations of circuits for
+transformations, analyses and optimization.  The two main public DAG types in this module are
+:class:`DAGCircuit` and :class:`DAGDependency`.  Both represent the operations of a circuit and their
+relationships, but they model different kinds of structure and are useful in different contexts.
+
+Use :class:`DAGCircuit` when you need a circuit-like graph whose edges are the quantum and classical
+wires flowing between operations.  This is the primary graph representation used throughout the
+transpiler stack, and is the right choice for most analyses and transformations that care about wire
+order, data flow, or rewrites that should preserve the step-by-step structure of the circuit.
+
+Use :class:`DAGDependency` when you need to reason about dependencies induced by
+non-commutativity.  Its edges represent when operations cannot commute past each other, which makes
+it useful for passes and algorithms that care more about partial ordering than about the exact wire
+graph.
+
+The node classes exposed by this module are the typed views into these graph representations:
+
+* :class:`DAGOpNode`, :class:`DAGInNode`, and :class:`DAGOutNode` are the node types used by
+  :class:`DAGCircuit`.
+* :class:`DAGDepNode` is the node type used by :class:`DAGDependency`.
+
+In typical workflows, a :class:`.QuantumCircuit` is converted into one of these DAG forms, processed,
+and then converted back into a circuit.  The :mod:`qiskit.converters` module provides the helper
+functions for moving between these representations.
+
+Circuits as directed acyclic graphs
 ===================================
 
 .. autosummary::


### PR DESCRIPTION
## Summary
- expand the module docs in `qiskit.dagcircuit` with an overview of the two public DAG representations
- explain the difference between `DAGCircuit` and `DAGDependency`
- describe the node types exposed by the module and how these DAGs fit typical converter-driven workflows

## Test plan
- [x] Run `python3 -m py_compile qiskit/dagcircuit/__init__.py`

fixes #3404

AI assistance disclosure: GPT-5.4 (Cursor)