### PR TITLE
Preserve math-mode gate names in latex drawer

### DIFF
--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -111,6 +111,8 @@ def get_gate_ctrl_text(op, drawer, style=None):
         if _is_boolean_expression(gate_text, op):
             gate_text = gate_text.replace("~", "$\\neg$").replace("&", "\\&")
             gate_text = f"$\\texttt{{{gate_text}}}$"
+        elif gate_text.startswith("$") and gate_text.endswith("$"):
+            gate_text = gate_text
         # Capitalize if not a user-created gate or instruction
         elif (
             (gate_text == op.name and op_type not in (Gate, Instruction))

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -16,8 +16,10 @@ import unittest
 import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit import Qubit, Clbit
+from qiskit.circuit import Qubit, Clbit, Gate
 from qiskit.visualization.circuit import _utils
+from qiskit.visualization.circuit.qcstyle import MPLDefaultStyle, MPLStyleDict
+from qiskit.visualization.style import load_style
 from qiskit.visualization import array_to_latex
 from qiskit.utils import optionals
 from test import QiskitTestCase
@@ -354,6 +356,21 @@ class TestVisualizationUtils(QiskitTestCase):
             "a$bc_{\\ensuremath{\\iiint}}X{\\ensuremath{\\forall}}Y",
             _utils.generate_latex_label(r"$a$bc$_∭X∀Y"),
         )
+
+    @unittest.skipUnless(optionals.HAS_PYLATEX, "needs pylatexenc")
+    def test_get_gate_ctrl_text_preserves_mathmode_gate_name(self):
+        """Test latex gate names preserve user-provided math mode."""
+        gate = Gate(r"$U_{\mathrm{rot}}$", 1, [])
+        style, _ = load_style(
+            style=None,
+            style_dict=MPLStyleDict,
+            default_style=MPLDefaultStyle(),
+            user_config_opt="circuit_mpl_style",
+            user_config_path_opt="circuit_mpl_style_path",
+        )
+        gate_text, _, _ = _utils.get_gate_ctrl_text(gate, "latex", style=style)
+        self.assertEqual(r"$U_{\mathrm{rot}}$", gate_text)
+        self.assertEqual(r"U_{\mathrm{rot}}", _utils.generate_latex_label(gate_text))
 
     @unittest.skipUnless(optionals.HAS_SYMPY, "needs sympy")
     def test_array_to_latex(self):


### PR DESCRIPTION
## Summary
- preserve user-provided math-mode gate names in the LaTeX drawer instead of wrapping them a second time
- keep the existing formatting behavior for non-math-mode labels unchanged
- add a focused regression test for latex gate-name handling in the visualization utilities

## Test plan
- [x] Run `python -m unittest test.python.visualization.test_utils.TestVisualizationUtils.test_get_gate_ctrl_text_preserves_mathmode_gate_name test.python.visualization.test_utils.TestVisualizationUtils.test_generate_latex_label_mathmode_utf8char test.python.visualization.test_utils.TestVisualizationUtils.test_generate_latex_label_escaped_dollar_sign_in_mathmode` in an isolated editable copy with compiled `_accelerate`

fixes #9208

AI assistance disclosure: GPT-5.4 (Cursor)