### PR TITLE
Fix BasicSwap silent global_phase inflation

### DIFF
--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -125,6 +125,7 @@ class BasicSwap(TransformationPass):
                 current_layout, dag.qubits
             )
 
+        new_dag.global_phase = dag.global_phase
         return new_dag
 
     def _fake_run(self, dag):

--- a/releasenotes/notes/fix-16271-basicswap-phase-35a28a666636d383.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-phase-35a28a666636d383.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where :class:`~qiskit.transpiler.passes.BasicSwap` would silently inflate the
+    ``global_phase`` of the input circuit by repeatedly adding the initial global phase during layer composition.
+    See `#16271 <https://github.com/Qiskit/qiskit/issues/16271>`__ for details.

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -408,6 +408,23 @@ class TestBasicSwap(QiskitTestCase):
         self.assertIsInstance(fake_pm.property_set["final_layout"], Layout)
         self.assertEqual(fake_pm.property_set["final_layout"], real_pm.property_set["final_layout"])
 
+    def test_preserves_global_phase(self):
+        """Test that the global phase of the circuit is preserved."""
+        coupling = CouplingMap.from_line(3)
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = 0.5
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+
+        dag = circuit_to_dag(circuit)
+        pass_ = BasicSwap(coupling)
+        after = pass_.run(dag)
+
+        self.assertEqual(after.global_phase, 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #16271

The \BasicSwap\ routing pass would silently inflate the \global_phase\ of the input circuit by repeatedly adding the original DAG's global phase each time a subdag layer was composed onto the new DAG. This fix resets the \global_phase\ of the new DAG back to the original \global_phase\ before returning.

**LLM Attribution**: This pull request was generated with the assistance of an LLM.