### PR TITLE
Add BitArray helpers for tabular count records

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -17,15 +17,15 @@ BitArray
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import partial
 from itertools import chain, repeat
-from typing import Literal
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any, Literal
 
 import numpy as np
 from numpy.typing import NDArray
 
-from qiskit.exceptions import QiskitError
+from qiskit.exceptions import MissingOptionalLibraryError, QiskitError
 from qiskit.result import Counts, sampled_expectation_value
 
 from .observables_array import ObservablesArray, ObservablesArrayLike
@@ -384,6 +384,54 @@ class BitArray(ShapedMixin):
         """
         converter = partial(self._bytes_to_int, mask=2**self.num_bits - 1)
         return self._get_counts(loc=loc, converter=converter)
+
+    def get_counts_list(
+        self, loc: int | tuple[int, ...] | None = None
+    ) -> list[dict[str, int | str]]:
+        """Return counts as a list of records.
+
+        Each record contains the integer value, bitstring, and count for one observed outcome.
+        Records are ordered by the first appearance of each outcome in the shot data.
+
+        Args:
+            loc: Which entry of this array to return a list for. If ``None``, counts from
+                all positions in this array are unioned together.
+
+        Returns:
+            A list of dictionaries with keys ``"bit_int"``, ``"bitstring"``, and ``"count"``.
+        """
+        return [
+            {
+                "bit_int": bit_int,
+                "bitstring": bin(bit_int)[2:].zfill(self.num_bits),
+                "count": count,
+            }
+            for bit_int, count in self.get_int_counts(loc).items()
+        ]
+
+    def get_counts_dataframe(self, loc: int | tuple[int, ...] | None = None) -> Any:
+        """Return counts as a pandas DataFrame.
+
+        Args:
+            loc: Which entry of this array to return a DataFrame for. If ``None``, counts from
+                all positions in this array are unioned together.
+
+        Returns:
+            A pandas DataFrame with columns ``"bit_int"``, ``"bitstring"``, and ``"count"``.
+
+        Raises:
+            MissingOptionalLibraryError: If pandas is not installed.
+        """
+        try:
+            import pandas as pd
+        except ImportError as ex:
+            raise MissingOptionalLibraryError(
+                "pandas",
+                "BitArray.get_counts_dataframe",
+                pip_install="pip install pandas",
+            ) from ex
+
+        return pd.DataFrame(self.get_counts_list(loc), columns=["bit_int", "bitstring", "count"])
 
     def get_bitstrings(self, loc: int | tuple[int, ...] | None = None) -> list[str]:
         """Return a list of bitstrings.

--- a/releasenotes/notes/2.2/bitarray-counts-records-16188.yaml
+++ b/releasenotes/notes/2.2/bitarray-counts-records-16188.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added :meth:`.BitArray.get_counts_list` and
+    :meth:`.BitArray.get_counts_dataframe` for converting sampled shot counts into
+    tabular records with ``bit_int``, ``bitstring``, and ``count`` fields.

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -12,12 +12,17 @@
 
 """Unit tests for BitArray."""
 
+import importlib.util
+import unittest
 from itertools import product
+from unittest import mock
+
 from test import QiskitTestCase
 
 import ddt
 import numpy as np
 
+from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.primitives.containers import BitArray
 from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.result import Counts
@@ -108,6 +113,63 @@ class BitArrayTestCase(QiskitTestCase):
 
         # test that providing no location takes the union over all shots
         self.assertEqual(bit_array.get_int_counts(), {val1: 2, val2: 1, val3: 1, val4: 2})
+
+    def test_get_counts_list(self):
+        """Test conversion to a list of counts records."""
+        bit_array = BitArray(
+            u_8([[[3, 5], [3, 5], [234, 100]], [[0, 1], [1, 0], [1, 0]]]),
+            num_bits=15,
+        )
+        bs1 = "0000011" + "00000101"
+        bs2 = "1101010" + "01100100"
+        bs3 = "0000000" + "00000001"
+        bs4 = "0000001" + "00000000"
+
+        self.assertEqual(
+            bit_array.get_counts_list(0),
+            [
+                {"bit_int": (3 << 8) + 5, "bitstring": bs1, "count": 2},
+                {"bit_int": ((234 & 127) << 8) + 100, "bitstring": bs2, "count": 1},
+            ],
+        )
+        self.assertEqual(
+            bit_array.get_counts_list(1),
+            [
+                {"bit_int": 1, "bitstring": bs3, "count": 1},
+                {"bit_int": 1 << 8, "bitstring": bs4, "count": 2},
+            ],
+        )
+        self.assertEqual(
+            bit_array.get_counts_list(),
+            [
+                {"bit_int": (3 << 8) + 5, "bitstring": bs1, "count": 2},
+                {"bit_int": ((234 & 127) << 8) + 100, "bitstring": bs2, "count": 1},
+                {"bit_int": 1, "bitstring": bs3, "count": 1},
+                {"bit_int": 1 << 8, "bitstring": bs4, "count": 2},
+            ],
+        )
+
+    @unittest.skipIf(importlib.util.find_spec("pandas") is None, "pandas not available")
+    def test_get_counts_dataframe(self):
+        """Test conversion to a pandas DataFrame."""
+        bit_array = BitArray.from_samples(["10", "01", "10", "11"], num_bits=2)
+
+        frame = bit_array.get_counts_dataframe()
+
+        self.assertEqual(list(frame.columns), ["bit_int", "bitstring", "count"])
+        self.assertEqual(frame.to_dict("records"), bit_array.get_counts_list())
+
+        empty_frame = bit_array.postselect([0, 1], [0, 0]).get_counts_dataframe()
+        self.assertEqual(list(empty_frame.columns), ["bit_int", "bitstring", "count"])
+        self.assertEqual(empty_frame.to_dict("records"), [])
+
+    def test_get_counts_dataframe_without_pandas(self):
+        """Test conversion to a pandas DataFrame raises if pandas is missing."""
+        bit_array = BitArray.from_samples(["0"], num_bits=1)
+
+        with mock.patch.dict("sys.modules", {"pandas": None}):
+            with self.assertRaises(MissingOptionalLibraryError):
+                bit_array.get_counts_dataframe()
 
     def test_get_bitstrings(self):
         """Test conversion to bitstrings."""


### PR DESCRIPTION
### Summary

Fix #16188

This adds two convenience methods to `BitArray` for converting shot counts into tabular records:

- `get_counts_list()` returns a list of dictionaries with `bit_int`, `bitstring`, and `count`.
- `get_counts_dataframe()` returns the same data as a pandas DataFrame.

The pandas import is kept lazy, so pandas is only required when `get_counts_dataframe()` is called.

### Details

The new helpers use the same `loc` behavior as `get_counts()` and `get_int_counts()`. The output preserves the first-observed outcome order from the existing count-generation path while exposing both integer and bitstring forms in the same row, which avoids manually joining separate outputs downstream.

### Tests

```bash
.venv/bin/python -m unittest test.python.primitives.containers.test_bit_array

AI/LLM disclosure

    [x] I didn't use LLM tooling, or only used it privately.

    [ ] I used the following tool to help write this PR description:

    [ ] I used the following tool to generate or modify code: