### PR TITLE
Fix seeding transpiler from environmental variable

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -266,7 +266,7 @@ def transpile(
         optimization_level = config.get("transpile_optimization_level", 2)
 
     if seed_transpiler is None:
-        if seed := os.getenv("QISKIT_TRANSPILER_SEED", None) is not None:
+        if (seed := os.getenv("QISKIT_TRANSPILER_SEED", None)) is not None:
             seed_transpiler = int(seed)
         else:
             config = user_config.get_config()

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -218,7 +218,7 @@ def generate_preset_pass_manager(
     config = user_config.get_config()
 
     if seed_transpiler is None:
-        if seed := os.getenv("QISKIT_TRANSPILER_SEED", None) is not None:
+        if (seed := os.getenv("QISKIT_TRANSPILER_SEED", None)) is not None:
             seed_transpiler = int(seed)
         else:
             seed_transpiler = config.get("transpiler_seed", None)
@@ -377,7 +377,7 @@ def generate_preset_clifford_t_pass_manager(
     """
     config = user_config.get_config()
     if seed_transpiler is None:
-        if seed := os.getenv("QISKIT_TRANSPILER_SEED", None) is not None:
+        if (seed := os.getenv("QISKIT_TRANSPILER_SEED", None)) is not None:
             seed_transpiler = int(seed)
         else:
             seed_transpiler = config.get("transpiler_seed", None)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -89,6 +89,7 @@ from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.providers.options import Options
 from qiskit.quantum_info import Operator, random_unitary
+from qiskit.transpiler.passes.layout.sabre_layout import SabreLayout
 from qiskit.utils import should_run_in_parallel
 from qiskit.transpiler import CouplingMap, Layout, PassManager, passes
 from qiskit.transpiler.exceptions import TranspilerError, CircuitTooWideForTarget
@@ -2391,6 +2392,28 @@ class TestTranspile(QiskitTestCase):
         self.assertEqual(shared_circuits, own_circuits)
         together_circuits = make_pm().run(circuits)
         self.assertEqual(together_circuits, own_circuits)
+
+    def test_parse_seed_transpiler_from_env_var(self):
+        """Test that the envoronment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 0)
+
+        # Save the original SabreLayout.run method, and create a mock method that calls the original method,
+        # but also records the value for seed.
+        original_run = SabreLayout.run
+        run_calls = []
+
+        def mock_run(self, dag):
+            run_calls.append(self.seed)
+            original_run(self, dag)
+
+        with patch.dict(os.environ, {"QISKIT_TRANSPILER_SEED": "1234"}):
+            with patch.object(SabreLayout, "run", new=mock_run):
+                _ = transpile(qc, optimization_level=1, coupling_map=CouplingMap.from_line(3))
+        self.assertEqual(len(run_calls), 1)
+        self.assertEqual(run_calls[0], 1234)
 
 
 @ddt

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -89,7 +89,6 @@ from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.providers.options import Options
 from qiskit.quantum_info import Operator, random_unitary
-from qiskit.transpiler.passes.layout.sabre_layout import SabreLayout
 from qiskit.utils import should_run_in_parallel
 from qiskit.transpiler import CouplingMap, Layout, PassManager, passes
 from qiskit.transpiler.exceptions import TranspilerError, CircuitTooWideForTarget
@@ -98,6 +97,7 @@ from qiskit.transpiler.passes import (
     GateDirection,
     VF2PostLayout,
     WrapAngles,
+    SabreLayout,
 )
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
@@ -2394,7 +2394,7 @@ class TestTranspile(QiskitTestCase):
         self.assertEqual(together_circuits, own_circuits)
 
     def test_parse_seed_transpiler_from_env_var(self):
-        """Test that the envoronment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
+        """Test that the environment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
         qc = QuantumCircuit(3)
         qc.cx(0, 1)
         qc.cx(1, 2)

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import os
 import numpy as np
 from ddt import ddt, data, unpack
 
@@ -31,7 +32,7 @@ from qiskit.circuit.library import (
 )
 
 from qiskit.transpiler import PassManager, TransformationPass, CouplingMap, Target, TranspilerError
-from qiskit.transpiler.passes import SynthesizeRZRotations, CheckGateDirection
+from qiskit.transpiler.passes import SynthesizeRZRotations, CheckGateDirection, SabreLayout
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePluginManager
 from qiskit.transpiler.preset_passmanagers import (
     generate_preset_pass_manager,
@@ -815,6 +816,28 @@ class TestCliffordTPassManager(QiskitTestCase):
 
         basis_gates = get_clifford_gate_names() + ["t", "tdg"]
         self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+
+    def test_parse_seed_transpiler_from_env_var(self):
+        """Test that the environment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 0)
+
+        # Save the original SabreLayout.run method, and create a mock method that calls the original method,
+        # but also records the value for seed.
+        original_run = SabreLayout.run
+        run_calls = []
+
+        def mock_run(self, dag):
+            run_calls.append(self.seed)
+            original_run(self, dag)
+
+        with unittest.mock.patch.dict(os.environ, {"QISKIT_TRANSPILER_SEED": "9876"}):
+            with unittest.mock.patch.object(SabreLayout, "run", new=mock_run):
+                _ = transpile(qc, optimization_level=1, coupling_map=CouplingMap.from_line(3))
+        self.assertEqual(len(run_calls), 1)
+        self.assertEqual(run_calls[0], 9876)
 
 
 def _get_t_count(qc):

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -12,9 +12,11 @@
 
 """Tests preset pass manager API"""
 
+import os
 import unittest
 
 
+from qiskit.transpiler.passes.layout.sabre_layout import SabreLayout
 from test import combine
 from ddt import ddt, data
 
@@ -1567,6 +1569,32 @@ class TestGeneratePresetPassManagers(QiskitTestCase):
             ValueError, "Expected non-negative integer as seed for transpiler."
         ):
             generate_preset_pass_manager(seed_transpiler=0.1)
+
+    def test_parse_seed_transpiler_from_env_var(self):
+        """Test that the envoronment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 0)
+
+        # Save the original SabreLayout.run method, and create a mock method that calls the original method,
+        # but also records the value for seed.
+        original_run = SabreLayout.run
+        run_calls = []
+
+        def mock_run(self, dag):
+            run_calls.append(self.seed)
+            original_run(self, dag)
+
+        with unittest.mock.patch.dict(os.environ, {"QISKIT_TRANSPILER_SEED": "42"}):
+            with unittest.mock.patch.object(SabreLayout, "run", new=mock_run):
+                pm = generate_preset_pass_manager(
+                    optimization_level=1, coupling_map=CouplingMap.from_line(3)
+                )
+                _ = pm.run(qc)
+
+        self.assertEqual(len(run_calls), 1)
+        self.assertEqual(run_calls[0], 42)
 
     @combine(
         optimization_level=[0, 1, 2, 3],

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -16,7 +16,6 @@ import os
 import unittest
 
 
-from qiskit.transpiler.passes.layout.sabre_layout import SabreLayout
 from test import combine
 from ddt import ddt, data
 
@@ -46,6 +45,7 @@ from qiskit.transpiler.passes import (
     ALAPScheduleAnalysis,
     PadDynamicalDecoupling,
     RemoveResetInZeroState,
+    SabreLayout,
 )
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.converters import circuit_to_dag
@@ -1571,7 +1571,7 @@ class TestGeneratePresetPassManagers(QiskitTestCase):
             generate_preset_pass_manager(seed_transpiler=0.1)
 
     def test_parse_seed_transpiler_from_env_var(self):
-        """Test that the envoronment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
+        """Test that the environment variable QISKIT_TRANSPILER_SEED is passed to the transpiler."""
         qc = QuantumCircuit(3)
         qc.cx(0, 1)
         qc.cx(1, 2)


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### Summary

In #16001 we have added the ability to set a transpiler seed from the environment variables ``QISKIT_TRANSPILER_SEED``.

However, the code for doing so had a subtle error: the line
```python
seed := os.getenv("QISKIT_TRANSPILER_SEED", None) is not None:
```
evaluates ``os.getenv("QISKIT_TRANSPILER_SEED", None) is not None`` first, and then sets ``seed`` to the result: either ``0`` or ``1``.

I have copied this bug when adding the code for ``generate_preset_clifford_t_pass_manager`` but discovered it while working on #16270.

No release note and no need to backport, since the bug was introduced in this iteration.

### Details

The simplest way that I could find to test this was to mock both ``os.environ`` and ``SabreLayout.run``, checking that ``SabreLayout`` is called once with the specified seed. 


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
