### PR TITLE
Fix marginal_counts silently failing on mixed-width Counts keys

### DIFF
--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -245,7 +245,13 @@ def marginal_distribution(
 
 def _marginalize(counts, indices=None):
     """Get the marginal counts for the given set of indices"""
-    num_clbits = len(next(iter(counts)).replace(" ", ""))
+    if not counts:
+        return {}
+    # ``Counts`` built from hex/int keys without ``memory_slots`` render each key with the minimum
+    # number of bits, so the keys can have different widths (e.g. ``{"0": 50, "11": 30}``). Infer the
+    # width from the widest key; shorter keys are simply missing leading (more-significant) zeros,
+    # since qubit-0 is the least-significant (right-most) bit.
+    num_clbits = max(len(_remove_space_underscore(key)) for key in counts)
     # Check if we do not need to marginalize and if so, trim
     # whitespace and '_' and return
     if (indices is None) or set(range(num_clbits)) == set(indices):
@@ -265,7 +271,9 @@ def _marginalize(counts, indices=None):
     # Build the return list
     new_counts = Counter()
     for key, val in counts.items():
-        new_key = "".join([_remove_space_underscore(key)[-idx - 1] for idx in indices])
+        # Left-pad with zeros so every key is ``num_clbits`` wide before indexing into it.
+        key = _remove_space_underscore(key).zfill(num_clbits)
+        new_key = "".join([key[-idx - 1] for idx in indices])
         new_counts[new_key] += val
     return dict(new_counts)
 

--- a/releasenotes/notes/fix-marginal-counts-mixed-width-7c1e4a9b6d2f0a8e.yaml
+++ b/releasenotes/notes/fix-marginal-counts-mixed-width-7c1e4a9b6d2f0a8e.yaml
@@ -1,0 +1,20 @@
+---
+fixes:
+  - |
+    Fixed :func:`.marginal_counts` (and :meth:`.Counts` marginalization) silently
+    returning an incorrect result when the input :class:`.Counts` had keys of
+    differing widths. This happens, for example, when a :class:`.Counts` object is
+    constructed from hexadecimal keys without specifying ``memory_slots``, in which
+    case each key is rendered with the minimum number of bits::
+
+        from qiskit.result import Counts, marginal_counts
+
+        counts = Counts({"0x0": 50, "0x3": 30})  # -> {"0": 50, "11": 30}
+        marginal_counts(counts, indices=[0])
+
+    Previously the number of classical bits was inferred from the first key only,
+    so the marginalization could take an early-return path and hand back the
+    counts unchanged. The bit width is now inferred from the widest key and
+    shorter keys are zero-padded before marginalizing, producing the correct
+    ``{"0": 50, "1": 30}``.
+    Fixed `#16190 <https://github.com/Qiskit/qiskit/issues/16190>`__.

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -44,6 +44,15 @@ class TestCounts(unittest.TestCase):
         result = utils.marginal_counts(counts_obj, [0, 1])
         self.assertEqual(expected, result)
 
+    def test_marginal_counts_mixed_width_keys(self):
+        # ``Counts`` built from hex keys without ``memory_slots`` render each key with the minimum
+        # number of bits, producing keys of different widths. ``marginal_counts`` used to infer the
+        # bit width from the first key only and silently return the wrong result. See gh-16190.
+        counts_obj = counts.Counts({"0x0": 50, "0x3": 30})
+        self.assertEqual({"0": 50, "11": 30}, counts_obj)
+        result = utils.marginal_counts(counts_obj, indices=[0])
+        self.assertEqual({"0": 50, "1": 30}, result)
+
     def test_marginal_distribution(self):
         raw_counts = {"0x0": 4, "0x1": 7, "0x2": 10, "0x6": 5, "0x9": 11, "0xD": 9, "0xE": 8}
         expected = {"00": 4, "01": 27, "10": 23}


### PR DESCRIPTION
### Summary

Fixes #16190.

`marginal_counts` (and `Counts` marginalization) silently returned an incorrect, unmarginalized result when the input `Counts` had keys of differing bit widths. This happens when a `Counts` object is built from hexadecimal/integer keys without specifying `memory_slots`, in which case each key is rendered with the *minimum* number of bits:

```python
from qiskit.result import Counts, marginal_counts

counts = Counts({"0x0": 50, "0x3": 30})   # -> {"0": 50, "11": 30}
marginal_counts(counts, indices=[0])
# before: {"0": 50, "11": 30}   (wrong - unchanged)
# after:  {"0": 50, "1": 30}    (correct)
```

### Details and comments

The root cause is in `_marginalize` (`qiskit/result/utils.py`): the number of classical bits was inferred from the **first key only** (`len(next(iter(counts)))`). For mixed-width keys like `{"0": 50, "11": 30}`, the first key `"0"` gives `num_clbits = 1`, so marginalizing over `indices=[0]` matches the `set(range(num_clbits)) == set(indices)` "nothing to marginalize" early-return and the counts are handed back unchanged.

This PR infers the width from the **widest** key and left-zero-pads shorter keys before indexing (qubit-0 is the least-significant, right-most bit, so shorter keys are simply missing leading zeros). An empty-input guard is also added.

- Added a regression test `test_marginal_counts_mixed_width_keys` in `test/python/result/test_counts.py`.
- Added a release note.

Existing marginalization tests use uniform-width keys (constructed with `memory_slots`) and are unaffected.