### PR TITLE
Fix Initialize and StatePreparation visualization printing full statevector

### DIFF
--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -145,6 +145,7 @@ def get_param_str(op, drawer, ndigits=3):
         or any(isinstance(param, np.ndarray) for param in op.params)
         or any(isinstance(param, QuantumCircuit) for param in op.params)
         or op.name == "pauli_product_measurement"
+        or op.name in ("initialize", "state_preparation")
     ):
         return ""
 

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -38,7 +38,6 @@ from qiskit.circuit import (
 from qiskit.circuit.controlflow import condition_resources
 from qiskit.circuit.classical import expr
 from qiskit.circuit.annotated_operation import _canonicalize_modifiers, ControlModifier
-from qiskit.circuit.library import Initialize
 from qiskit.circuit.library.standard_gates import (
     SwapGate,
     RZZGate,
@@ -466,8 +465,6 @@ class MatplotlibDrawer:
                     and not any(isinstance(param, QuantumCircuit) for param in op.params)
                 ):
                     param_text = get_param_str(op, "mpl", ndigits=3)
-                    if isinstance(op, Initialize):
-                        param_text = f"$[{param_text.replace('$', '')}]$"
                     node_data[node].param_text = param_text
                     raw_param_width = self._get_text_width(
                         param_text, glob_data, fontsize=self._style["sfs"], param=True


### PR DESCRIPTION
### Summary

Fixes visualization of `Initialize` and `StatePreparation` gates printing full statevector parameters in circuit drawings.

### Issue

Qiskit/qiskit#11470 — The `initialize` instruction displays its full statevector (exponentially growing complex amplitudes) in circuit diagrams, making them unreadable for any circuit larger than 1 qubit.

### Changes

**`qiskit/visualization/circuit/_utils.py`** (+1 line)
Added `initialize` and `state_preparation` to the existing `get_param_str()` exclusion list, alongside the existing `pauli_product_measurement` suppression. These gates store statevectors as individual numeric params — displaying them floods the visualization.

**`qiskit/visualization/circuit/matplotlib.py`** (-3 lines)
Removed the now-unreachable special-case code that wrapped Initialize params in `$[...]$` brackets, and the now-unused `Initialize` import.

### Verification

Before — text draw:
```
Initialize(0.10615-0.67964j,-0.36228-0.45361j,0.26142+0.044533j,0.32764-0.11016j)
```

After — text draw:
```
Initialize
```

Tested across all three drawer formats (text, MPL, LaTeX). `StatePreparation` also fixed via the same code path. Other gates (H, CX, Rz) continue to display their params normally.

No functional circuit logic, data flow, or serialization code is touched. Risk is limited to visualization output.
