### PR TITLE
Fix serial_layers global phase copying

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4123,6 +4123,7 @@ impl DAGCircuit {
                 _ => unreachable!("A non-operation node was obtained from topological_op_nodes."),
             };
             let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
+            new_layer.global_phase = Param::Float(0.);
             let mut block_map = BlockMapper::new();
 
             // Save the support of the operation we add to the layer

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4081,6 +4081,7 @@ impl DAGCircuit {
             }
 
             let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
+            new_layer.global_phase = Param::Float(0.);
             let mut block_map = BlockMapper::new();
             let data: Vec<_> = op_nodes
                 .iter()

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -124,8 +124,6 @@ class BasicSwap(TransformationPass):
             self.property_set["final_layout"] = self.property_set["final_layout"].compose(
                 current_layout, dag.qubits
             )
-
-        new_dag.global_phase = dag.global_phase
         return new_dag
 
     def _fake_run(self, dag):

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -125,6 +125,7 @@ class BasicSwap(TransformationPass):
                 current_layout, dag.qubits
             )
 
+        new_dag.global_phase = dag.global_phase
         return new_dag
 
     def _fake_run(self, dag):

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -124,6 +124,7 @@ class BasicSwap(TransformationPass):
             self.property_set["final_layout"] = self.property_set["final_layout"].compose(
                 current_layout, dag.qubits
             )
+
         return new_dag
 
     def _fake_run(self, dag):

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -1,7 +1,9 @@
 ---
 fixes:
   - |
-    Fixed an issue where :class:`~qiskit.transpiler.passes.BasicSwap` could
-    inflate the input circuit ``global_phase`` while rebuilding the output DAG
-    from serial layers. See `#16271
+    Fixed an issue where :meth:`.DAGCircuit.layers` and
+    :meth:`.DAGCircuit.serial_layers` copied the parent circuit
+    ``global_phase`` into each yielded layer DAG. Rebuilding a circuit from
+    those layer DAGs could then accumulate the original phase more than once,
+    including in :class:`~qiskit.transpiler.passes.BasicSwap`. See `#16271
     <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -1,7 +1,4 @@
 ---
 fixes:
   - |
-    Fixed an issue where the layer-returning methods
-    :meth:`.DAGCircuit.layers` and :meth:`.DAGCircuit.serial_layers`
-    copied the parent DAG ``global_phase`` into each yielded layer DAG.
     Fixes `#16271 <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -4,7 +4,4 @@ fixes:
     Fixed an issue where the layer-returning methods
     :meth:`.DAGCircuit.layers` and :meth:`.DAGCircuit.serial_layers`
     copied the parent DAG ``global_phase`` into each yielded layer DAG.
-    Rebuilding a circuit from those layer DAGs could then accumulate the
-    original phase more than once, including in
-    :class:`~qiskit.transpiler.passes.BasicSwap`. This fixes `#16271
-    <https://github.com/Qiskit/qiskit/issues/16271>`__.
+    Fixes `#16271 <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -1,4 +1,7 @@
 ---
 fixes:
   - |
+    Fixed an issue where the layer-returning methods
+    :meth:`.DAGCircuit.layers` and :meth:`.DAGCircuit.serial_layers`
+    copied the parent DAG ``global_phase`` into each yielded layer DAG.
     Fixes `#16271 <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue where :class:`~qiskit.transpiler.passes.BasicSwap` could
+    inflate the input circuit ``global_phase`` while rebuilding the output DAG
+    from serial layers. See `#16271
+    <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
+++ b/releasenotes/notes/fix-16271-basicswap-global-phase-2afecfbb1c8fa20d.yaml
@@ -1,9 +1,10 @@
 ---
 fixes:
   - |
-    Fixed an issue where :meth:`.DAGCircuit.layers` and
-    :meth:`.DAGCircuit.serial_layers` copied the parent circuit
-    ``global_phase`` into each yielded layer DAG. Rebuilding a circuit from
-    those layer DAGs could then accumulate the original phase more than once,
-    including in :class:`~qiskit.transpiler.passes.BasicSwap`. See `#16271
+    Fixed an issue where the layer-returning methods
+    :meth:`.DAGCircuit.layers` and :meth:`.DAGCircuit.serial_layers`
+    copied the parent DAG ``global_phase`` into each yielded layer DAG.
+    Rebuilding a circuit from those layer DAGs could then accumulate the
+    original phase more than once, including in
+    :class:`~qiskit.transpiler.passes.BasicSwap`. This fixes `#16271
     <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1479,6 +1479,20 @@ class TestDagLayers(DAGTest):
         self.assertEqual(layers[0]["graph"].global_phase, 0.0)
         self.assertEqual(layers[1]["graph"].global_phase, 0.0)
 
+    def test_layers_do_not_copy_global_phase(self):
+        """layers() should not copy the parent DAG global phase."""
+        qc = QuantumCircuit(2, global_phase=math.pi / 7)
+        qc.h(0)
+        qc.cx(0, 1)
+        dag = circuit_to_dag(qc)
+
+        layers = list(dag.layers())
+
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(dag.global_phase, math.pi / 7)
+        self.assertEqual(layers[0]["graph"].global_phase, 0.0)
+        self.assertEqual(layers[1]["graph"].global_phase, 0.0)
+
 
 def _sort_key(indices: dict[Qubit, int]):
     """Return key function for sorting DAGCircuits, given a global qubit mapping."""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1465,6 +1465,20 @@ class TestDagLayers(DAGTest):
             ]
             self.assertEqual(comp, truth)
 
+    def test_serial_layers_do_not_copy_global_phase(self):
+        """serial_layers() should not copy the parent DAG global phase."""
+        qc = QuantumCircuit(2, global_phase=math.pi / 7)
+        qc.h(0)
+        qc.cx(0, 1)
+        dag = circuit_to_dag(qc)
+
+        layers = list(dag.serial_layers())
+
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(dag.global_phase, math.pi / 7)
+        self.assertEqual(layers[0]["graph"].global_phase, 0.0)
+        self.assertEqual(layers[1]["graph"].global_phase, 0.0)
+
 
 def _sort_key(indices: dict[Qubit, int]):
     """Return key function for sorting DAGCircuits, given a global qubit mapping."""

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -424,6 +424,23 @@ class TestBasicSwap(QiskitTestCase):
 
         self.assertEqual(after.global_phase, dag.global_phase)
 
+    def test_preserves_global_phase_when_swaps_inserted(self):
+        """The global phase is preserved when routing inserts swaps."""
+        coupling = CouplingMap.from_line(3)
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = 0.5
+        circuit.cx(qr[0], qr[2])
+
+        dag = circuit_to_dag(circuit)
+        pass_ = BasicSwap(coupling)
+        after = pass_.run(dag)
+
+        self.assertEqual(after.global_phase, dag.global_phase)
+        self.assertEqual(after.count_ops().get("swap", 0), 1)
+        self.assertIsInstance(pass_.property_set["final_layout"], Layout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -408,6 +408,22 @@ class TestBasicSwap(QiskitTestCase):
         self.assertIsInstance(fake_pm.property_set["final_layout"], Layout)
         self.assertEqual(fake_pm.property_set["final_layout"], real_pm.property_set["final_layout"])
 
+    def test_preserves_global_phase(self):
+        """The global phase is preserved when no swaps are needed."""
+        coupling = CouplingMap.from_line(3)
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = 0.5
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+
+        dag = circuit_to_dag(circuit)
+        after = BasicSwap(coupling).run(dag)
+
+        self.assertEqual(after.global_phase, dag.global_phase)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #16271

BasicSwap exposed this bug because it rebuilds its output DAG from serial layers. The accumulator DAG keeps the input global phase, and each layer yielded by serial_layers() was also carrying that same phase. Composing those layers back into the accumulator adds the original phase more than once, so a circuit that should keep global_phase = 0.5 can come out with global_phase = 2.0.

This revision moves the fix to the root cause instead of compensating in BasicSwap.

What changed:
1. serial_layers() now clears the yielded layer DAG global phase instead of copying the parent DAG phase into every layer.
2. BasicSwap no longer needs to reset the output DAG global phase before return.
3. The branch keeps the BasicSwap regression coverage and adds a direct DAGCircuit regression for serial_layers().
4. The release note remains scoped to the user-visible BasicSwap bug in #16271.

Validation:
1. Focused unittest coverage for DAGCircuit layers and BasicSwap routing passed.
2. The issue reproducer now keeps input global_phase = 0.5 after BasicSwap on CouplingMap.from_line(3).
3. A direct serial_layers() probe shows each yielded layer DAG now has global_phase = 0.0.

AI/LLM disclosure
1. I used OpenAI GPT-5 Codex to help generate and modify code.
2. I used OpenAI GPT-5 Codex to help draft this PR description.
