### PR TITLE
Handle mixed-width Counts inputs in __init__

### DIFF
--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -13,6 +13,7 @@
 """A container class for counts from a circuit execution."""
 
 import re
+import warnings
 
 from qiskit.result import postprocess
 from qiskit import exceptions
@@ -63,6 +64,7 @@ class Counts(dict):
                 ``memory_slots``.
         """
         bin_data = None
+        inferred_memory_slots = None
         data = dict(data)
         if not data:
             self.int_raw = {}
@@ -73,13 +75,16 @@ class Counts(dict):
             if isinstance(first_key, int):
                 self.int_raw = data
                 self.hex_raw = {hex(key): value for key, value in self.int_raw.items()}
+                inferred_memory_slots = self._infer_memory_slots(self.int_raw)
             elif isinstance(first_key, str):
                 if first_key.startswith("0x"):
                     self.hex_raw = data
                     self.int_raw = {int(key, 0): value for key, value in self.hex_raw.items()}
+                    inferred_memory_slots = self._infer_memory_slots(self.int_raw)
                 elif first_key.startswith("0b"):
                     self.int_raw = {int(key, 0): value for key, value in data.items()}
                     self.hex_raw = {hex(key): value for key, value in self.int_raw.items()}
+                    inferred_memory_slots = self._infer_memory_slots(self.int_raw)
                 elif not creg_sizes and not memory_slots:
                     # bit strings with no leading 0b or dit strings
                     self.hex_raw = None
@@ -113,6 +118,16 @@ class Counts(dict):
         if self.creg_sizes:
             header["creg_sizes"] = self.creg_sizes
         self.memory_slots = memory_slots
+        if self.memory_slots is None and self.creg_sizes:
+            self.memory_slots = sum(size for _, size in self.creg_sizes)
+        if self.memory_slots is None and inferred_memory_slots is not None:
+            self.memory_slots = inferred_memory_slots
+            warnings.warn(
+                "Counts keys have inconsistent bit widths. Padding to the maximum inferred "
+                "width; pass memory_slots or creg_sizes to specify the intended width.",
+                UserWarning,
+                stacklevel=2,
+            )
         if self.memory_slots:
             header["memory_slots"] = self.memory_slots
         if not bin_data:
@@ -188,6 +203,14 @@ class Counts(dict):
     def _remove_space_underscore(bitstring):
         """Removes all spaces and underscores from bitstring"""
         return int(bitstring.replace(" ", "").replace("_", ""), 2)
+
+    @staticmethod
+    def _infer_memory_slots(int_keys):
+        """Infer a bit width for integer-like counts inputs when widths differ."""
+        widths = {max(key.bit_length(), 1) for key in int_keys}
+        if len(widths) > 1:
+            return max(widths)
+        return None
 
     def shots(self):
         """Return the number of shots"""

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -25,8 +25,9 @@ from qiskit.result import utils
 class TestCounts(unittest.TestCase):
     def test_just_counts(self):
         raw_counts = {"0x0": 21, "0x2": 12}
-        expected = {"0": 21, "10": 12}
-        result = counts.Counts(raw_counts)
+        expected = {"00": 21, "10": 12}
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            result = counts.Counts(raw_counts)
         self.assertEqual(expected, result)
 
     def test_counts_with_exta_formatting_data(self):
@@ -37,12 +38,47 @@ class TestCounts(unittest.TestCase):
         )
         self.assertEqual(result, expected)
 
+    def test_counts_with_creg_sizes_without_memory_slots(self):
+        raw_counts = {"0x0": 4, "0x2": 10}
+        expected = {"0 0": 4, "1 0": 10}
+        result = counts.Counts(raw_counts, creg_sizes=[["c0", 1], ["c1", 1]])
+        self.assertEqual(result, expected)
+
     def test_marginal_counts(self):
         raw_counts = {"0x0": 4, "0x1": 7, "0x2": 10, "0x6": 5, "0x9": 11, "0xD": 9, "0xE": 8}
         expected = {"00": 4, "01": 27, "10": 23}
         counts_obj = counts.Counts(raw_counts, creg_sizes=[["c0", 4]], memory_slots=4)
         result = utils.marginal_counts(counts_obj, [0, 1])
         self.assertEqual(expected, result)
+
+    def test_marginal_counts_mixed_width_hex_without_memory_slots(self):
+        raw_counts = {"0x0": 50, "0x3": 30}
+        expected_counts = {"00": 50, "11": 30}
+        expected_marginal = {"0": 50, "1": 30}
+
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            counts_obj = counts.Counts(raw_counts)
+
+        self.assertEqual(expected_counts, counts_obj)
+        self.assertEqual(expected_marginal, utils.marginal_counts(counts_obj, [0]))
+
+    def test_mixed_width_int_without_memory_slots(self):
+        raw_counts = {0: 50, 3: 30}
+        expected = {"00": 50, "11": 30}
+
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            counts_obj = counts.Counts(raw_counts)
+
+        self.assertEqual(expected, counts_obj)
+
+    def test_mixed_width_0b_without_memory_slots(self):
+        raw_counts = {"0b0": 50, "0b11": 30}
+        expected = {"00": 50, "11": 30}
+
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            counts_obj = counts.Counts(raw_counts)
+
+        self.assertEqual(expected, counts_obj)
 
     def test_marginal_distribution(self):
         raw_counts = {"0x0": 4, "0x1": 7, "0x2": 10, "0x6": 5, "0x9": 11, "0xD": 9, "0xE": 8}
@@ -87,8 +123,9 @@ class TestCounts(unittest.TestCase):
 
     def test_just_int_counts(self):
         raw_counts = {0: 21, 2: 12}
-        expected = {"0": 21, "10": 12}
-        result = counts.Counts(raw_counts)
+        expected = {"00": 21, "10": 12}
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            result = counts.Counts(raw_counts)
         self.assertEqual(expected, result)
 
     def test_int_counts_with_exta_formatting_data(self):
@@ -304,8 +341,9 @@ class TestCounts(unittest.TestCase):
 
     def test_just_0b_bitstring_counts(self):
         raw_counts = {"0b0": 21, "0b10": 12}
-        expected = {"0": 21, "10": 12}
-        result = counts.Counts(raw_counts)
+        expected = {"00": 21, "10": 12}
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            result = counts.Counts(raw_counts)
         self.assertEqual(expected, result)
 
     def test_0b_bistring_counts_with_exta_formatting_data(self):

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -51,14 +51,13 @@ class TestResultOperations(QiskitTestCase):
     def test_counts_no_header(self):
         """Test that counts are extracted properly without header."""
         raw_counts = {"0x0": 4, "0x2": 10}
-        no_header_processed_counts = {
-            bin(int(bs[2:], 16))[2:]: counts for (bs, counts) in raw_counts.items()
-        }
+        no_header_processed_counts = {"00": 4, "10": 10}
         data = models.ExperimentResultData(counts=raw_counts)
         exp_result = models.ExperimentResult(shots=14, success=True, meas_level=2, data=data)
         result = Result(results=[exp_result], **self.base_result_args)
 
-        self.assertEqual(result.get_counts(0), no_header_processed_counts)
+        with self.assertWarnsRegex(UserWarning, "inconsistent bit widths"):
+            self.assertEqual(result.get_counts(0), no_header_processed_counts)
 
     def test_counts_header(self):
         """Test that counts are extracted properly with header."""


### PR DESCRIPTION
1. This fixes mixed-width Counts normalization at construction time instead of in marginalization.

Before this change, Counts only padded integer-like keys when callers explicitly passed memory_slots. That meant inputs such as {"0x0": 50, "0x3": 30} became {'0': 50, '11': 30}, so downstream consumers saw inconsistent visible widths.

2. Counts.__init__ now infers the maximum width for integer-like inputs when the keys disagree and neither memory_slots nor creg_sizes is provided.

In that case it pads through the existing postprocess.format_counts(...) path and emits a warning so callers still get a result, but they also get told that the intended width was ambiguous.

If creg_sizes is present without memory_slots, the constructor now derives memory_slots from the register sizes instead of skipping width-aware formatting.

3. Tests cover the affected entry points.

I added regressions for mixed-width hex, int, and 0b inputs, updated the no-header Result expectation, and added coverage for creg_sizes without an explicit memory_slots.

4. Validation

python -m unittest test.python.result.test_counts test.python.result.test_result test.python.primitives.containers.test_bit_array

Closes #16190.