### PR TITLE
Use stestr to prune its own history in CI jobs

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -118,10 +118,7 @@ jobs:
       - name: Filter stestr history
         if: ${{ !inputs.install-from-sdist }}
         run: |
-          set -e
-          pushd .stestr
-          ls | grep -P "^\d" | xargs -d "\n" rm -f
-          popd
+          test-job/bin/stestr history remove all
       - name: Run Python tests (sdist)
         if: ${{ inputs.install-from-sdist }}
         run: |
@@ -145,8 +142,9 @@ jobs:
         if: ${{ inputs.install-from-sdist }}
         run: |
           set -e
-          pushd /tmp/terra-tests/.stestr
-          ls | grep -P "^\d" | xargs -d "\n" rm -f
+          source test-job/bin/activate
+          pushd /tmp/terra-tests
+          stestr history remove all
           popd
           cp -r /tmp/terra-tests/.stestr .
       - name: Copy and Publish images

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -80,10 +80,7 @@ jobs:
           RUST_BACKTRACE: 1
       - name: Filter stestr history
         run: |
-          set -e
-          pushd .stestr
-          ls | grep -e '^[[:digit:]]' | xargs -n1 rm -f
-          popd
+          test-job/bin/stestr history remove all
       - name: Copy and Publish images
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -74,9 +74,8 @@ jobs:
           stestr run --slowest --abbreviate
       - name: Filter stestr history
         run: |
-          pushd .stestr
-          ls | grep -P "^\d" | xargs -d "\n" rm -f
-          popd
+          .\test-job\Scripts\activate
+          stestr history remove all
         env:
           LANG: "C.UTF-8"
           PYTHONIOENCODING: "utf-8:backslashreplace"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ lint = [
 # Dependencies to run the test suite.  This group needs to be installable on all Python versions
 # that Qiskit supports.
 test = [
-    "stestr>=2.0",
+    "stestr>=3.2.0",
     "ddt>=1.2.0",
     "coverage>=4.4.0",
     "threadpoolctl",  # More detail from Numpy/Scipy BLAS-usage reports.

--- a/releasenotes/notes/stestr-min-bump-8d0e03430cea4f30.yaml
+++ b/releasenotes/notes/stestr-min-bump-8d0e03430cea4f30.yaml
@@ -1,0 +1,7 @@
+---
+build:
+  - The minimum required version of
+    `stestr <https://stestr.readthedocs.io/en/latest/README.html>`__ in the
+    test requirements has been raised from 2.0 to 3.2.0. This was done to
+    leverage new stestr features, mainly the ``stestr history`` command, in
+    continuous integration Python test jobs.


### PR DESCRIPTION
In CI test jobs we cache the stestr timing data to provide a scheduler hint to stestr for future runs. stestr will use this to improve the distribution of tests across the workers to improve the balance of tests between the parallel workers improving throughput. However, the timing data is stored in stestr's repository (the .stestr directory in the repo) along with the subunit streams of all the previous runs. We don't need these subunit streams as they contain the full result and output from all the tests run and we won't use that for scheduling; it's mainly for local debugging purposes. These streams also can get quite large as they contain all the stdout, stderr, and logging from every test. To minimize the size of the data we're caching the CI jobs were configured to filter the stestr repository and remove the subunit streams and only leave the timing data. This was being done manually though and was likely broken on Windows. Since stestr 3.2.0 (released in 2021: https://github.com/mtreinish/stestr/releases/tag/3.2.0 ) there has been a stestr history command to manage the repository's historical subunit streams. To avoid the error prone manual filtering this just switches to use this command instead. It does require raising our lower bound on the stestr version supported for running tests. But since the release is from > 5 years ago that shouldn't be a big deal.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
