### PR TITLE
Add label parameter for gate-methods in QuantumCircuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -6284,6 +6284,7 @@ class QuantumCircuit:
         control_qubit1: QubitSpecifier,
         control_qubit2: QubitSpecifier,
         target_qubit: QubitSpecifier,
+        label: str | None = None,
         ctrl_state: str | int | None = None,
     ) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.CCXGate`.
@@ -6294,6 +6295,7 @@ class QuantumCircuit:
             control_qubit1: The qubit(s) used as the first control.
             control_qubit2: The qubit(s) used as the second control.
             target_qubit: The qubit(s) targeted by the gate.
+            label: The string label of the gate in the circuit.
             ctrl_state:
                 The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling
                 on the '1' state.
@@ -6307,12 +6309,13 @@ class QuantumCircuit:
                 StandardGate.CCX,
                 [control_qubit1, control_qubit2, target_qubit],
                 (),
+                label=label,
             )
 
         from .library.standard_gates.x import CCXGate
 
         return self.append(
-            CCXGate(ctrl_state=ctrl_state),
+            CCXGate(label=label, ctrl_state=ctrl_state),
             [control_qubit1, control_qubit2, target_qubit],
             [],
             copy=False,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -6337,6 +6337,7 @@ class QuantumCircuit:
         ancilla_qubits: QubitSpecifier | Sequence[QubitSpecifier] | None = None,
         mode: str | None = None,
         ctrl_state: str | int | None = None,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MCXGate`.
 
@@ -6355,9 +6356,11 @@ class QuantumCircuit:
             target_qubit: The qubit(s) targeted by the gate.
             ancilla_qubits: The qubits used as the ancillae, if the mode requires them.
             mode: The choice of mode, explained further above.
+            label: The string label of the gate in the circuit.
             ctrl_state:
                 The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling
                 on the '1' state.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
@@ -6385,16 +6388,18 @@ class QuantumCircuit:
             _ = self._qbit_argument_conversion(ancilla_qubits)
 
         if mode is None:
-            gate = MCXGate(num_ctrl_qubits, ctrl_state=ctrl_state)
+            gate = MCXGate(num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
         elif mode in available_implementations:
             if mode == "noancilla":
-                gate = MCXGate(num_ctrl_qubits, ctrl_state=ctrl_state)
+                gate = MCXGate(num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
             elif mode in ["recursion", "advanced"]:
-                gate = MCXRecursive(num_ctrl_qubits, ctrl_state=ctrl_state)
+                gate = MCXRecursive(num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
             elif mode in ["v-chain", "basic"]:
-                gate = MCXVChain(num_ctrl_qubits, False, ctrl_state=ctrl_state)
+                gate = MCXVChain(num_ctrl_qubits, False, label=label, ctrl_state=ctrl_state)
             elif mode in ["v-chain-dirty", "basic-dirty-ancilla"]:
-                gate = MCXVChain(num_ctrl_qubits, dirty_ancillas=True, ctrl_state=ctrl_state)
+                gate = MCXVChain(
+                    num_ctrl_qubits, dirty_ancillas=True, label=label, ctrl_state=ctrl_state
+                )
             else:
                 raise ValueError("unreachable.")
             # else is unreachable, we exhausted all options

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5155,18 +5155,19 @@ class QuantumCircuit:
             qarg = self.qubits
         return self.append(Delay(duration, unit=unit), [qarg], [], copy=False)
 
-    def h(self, qubit: QubitSpecifier) -> InstructionSet:
+    def h(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.HGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.H, [qubit], ())
+        return self._append_standard_gate(StandardGate.H, [qubit], (), label=label)
 
     def ch(
         self,
@@ -5205,18 +5206,19 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def id(self, qubit: QubitSpecifier) -> InstructionSet:
+    def id(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.IGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.I, [qubit], ())
+        return self._append_standard_gate(StandardGate.I, [qubit], (), label=label)
 
     def ms(self, theta: ParameterValueType, qubits: Sequence[QubitSpecifier]) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MSGate`.
@@ -5235,7 +5237,9 @@ class QuantumCircuit:
 
         return self.append(MSGate(len(qubits), theta), qubits, copy=False)
 
-    def p(self, theta: ParameterValueType, qubit: QubitSpecifier) -> InstructionSet:
+    def p(
+        self, theta: ParameterValueType, qubit: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.PhaseGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -5243,11 +5247,12 @@ class QuantumCircuit:
         Args:
             theta: The angle of the rotation.
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.Phase, [qubit], (theta,))
+        return self._append_standard_gate(StandardGate.Phase, [qubit], (theta,), label=label)
 
     def cp(
         self,
@@ -5542,7 +5547,11 @@ class QuantumCircuit:
             self.compose(cgate, control_qubits + [target_qubit], inplace=True)
 
     def r(
-        self, theta: ParameterValueType, phi: ParameterValueType, qubit: QubitSpecifier
+        self,
+        theta: ParameterValueType,
+        phi: ParameterValueType,
+        qubit: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RGate`.
 
@@ -5552,11 +5561,12 @@ class QuantumCircuit:
             theta: The angle of the rotation.
             phi: The angle of the axis of rotation in the x-y plane.
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.R, [qubit], [theta, phi])
+        return self._append_standard_gate(StandardGate.R, [qubit], [theta, phi], label=label)
 
     def rv(
         self,
@@ -5694,7 +5704,11 @@ class QuantumCircuit:
         )
 
     def rxx(
-        self, theta: ParameterValueType, qubit1: QubitSpecifier, qubit2: QubitSpecifier
+        self,
+        theta: ParameterValueType,
+        qubit1: QubitSpecifier,
+        qubit2: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RXXGate`.
 
@@ -5704,11 +5718,12 @@ class QuantumCircuit:
             theta: The angle of the rotation.
             qubit1: The qubit(s) to apply the gate to.
             qubit2: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.RXX, [qubit1, qubit2], [theta])
+        return self._append_standard_gate(StandardGate.RXX, [qubit1, qubit2], [theta], label=label)
 
     def ry(
         self, theta: ParameterValueType, qubit: QubitSpecifier, label: str | None = None
@@ -5767,7 +5782,11 @@ class QuantumCircuit:
         )
 
     def ryy(
-        self, theta: ParameterValueType, qubit1: QubitSpecifier, qubit2: QubitSpecifier
+        self,
+        theta: ParameterValueType,
+        qubit1: QubitSpecifier,
+        qubit2: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RYYGate`.
 
@@ -5777,13 +5796,16 @@ class QuantumCircuit:
             theta: The rotation angle of the gate.
             qubit1: The qubit(s) to apply the gate to.
             qubit2: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.RYY, [qubit1, qubit2], [theta])
+        return self._append_standard_gate(StandardGate.RYY, [qubit1, qubit2], [theta], label=label)
 
-    def rz(self, phi: ParameterValueType, qubit: QubitSpecifier) -> InstructionSet:
+    def rz(
+        self, phi: ParameterValueType, qubit: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RZGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -5791,11 +5813,12 @@ class QuantumCircuit:
         Args:
             phi: The rotation angle of the gate.
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.RZ, [qubit], [phi])
+        return self._append_standard_gate(StandardGate.RZ, [qubit], [phi], label=label)
 
     def crz(
         self,
@@ -5837,7 +5860,11 @@ class QuantumCircuit:
         )
 
     def rzx(
-        self, theta: ParameterValueType, qubit1: QubitSpecifier, qubit2: QubitSpecifier
+        self,
+        theta: ParameterValueType,
+        qubit1: QubitSpecifier,
+        qubit2: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RZXGate`.
 
@@ -5847,14 +5874,19 @@ class QuantumCircuit:
             theta: The rotation angle of the gate.
             qubit1: The qubit(s) to apply the gate to.
             qubit2: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.RZX, [qubit1, qubit2], [theta])
+        return self._append_standard_gate(StandardGate.RZX, [qubit1, qubit2], [theta], label=label)
 
     def rzz(
-        self, theta: ParameterValueType, qubit1: QubitSpecifier, qubit2: QubitSpecifier
+        self,
+        theta: ParameterValueType,
+        qubit1: QubitSpecifier,
+        qubit2: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RZZGate`.
 
@@ -5864,13 +5896,16 @@ class QuantumCircuit:
             theta: The rotation angle of the gate.
             qubit1: The qubit(s) to apply the gate to.
             qubit2: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.RZZ, [qubit1, qubit2], [theta])
+        return self._append_standard_gate(StandardGate.RZZ, [qubit1, qubit2], [theta], label=label)
 
-    def ecr(self, qubit1: QubitSpecifier, qubit2: QubitSpecifier) -> InstructionSet:
+    def ecr(
+        self, qubit1: QubitSpecifier, qubit2: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.ECRGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -5878,37 +5913,40 @@ class QuantumCircuit:
         Args:
             qubit1: The first qubit to apply the gate to.
             qubit2: The second qubit to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.ECR, [qubit1, qubit2], ())
+        return self._append_standard_gate(StandardGate.ECR, [qubit1, qubit2], (), label=label)
 
-    def s(self, qubit: QubitSpecifier) -> InstructionSet:
+    def s(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.S, [qubit], ())
+        return self._append_standard_gate(StandardGate.S, [qubit], (), label=label)
 
-    def sdg(self, qubit: QubitSpecifier) -> InstructionSet:
+    def sdg(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SdgGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.Sdg, [qubit], ())
+        return self._append_standard_gate(StandardGate.Sdg, [qubit], (), label=label)
 
     def cs(
         self,
@@ -5984,7 +6022,9 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def swap(self, qubit1: QubitSpecifier, qubit2: QubitSpecifier) -> InstructionSet:
+    def swap(
+        self, qubit1: QubitSpecifier, qubit2: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SwapGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -5992,6 +6032,7 @@ class QuantumCircuit:
         Args:
             qubit1: The first qubit to apply the gate to.
             qubit2: The second qubit to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
@@ -6000,9 +6041,12 @@ class QuantumCircuit:
             StandardGate.Swap,
             [qubit1, qubit2],
             (),
+            label=label,
         )
 
-    def iswap(self, qubit1: QubitSpecifier, qubit2: QubitSpecifier) -> InstructionSet:
+    def iswap(
+        self, qubit1: QubitSpecifier, qubit2: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.iSwapGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -6010,11 +6054,12 @@ class QuantumCircuit:
         Args:
             qubit1: The first qubit to apply the gate to.
             qubit2: The second qubit to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.ISwap, [qubit1, qubit2], ())
+        return self._append_standard_gate(StandardGate.ISwap, [qubit1, qubit2], (), label=label)
 
     def cswap(
         self,
@@ -6058,31 +6103,33 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def sx(self, qubit: QubitSpecifier) -> InstructionSet:
+    def sx(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SXGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.SX, [qubit], ())
+        return self._append_standard_gate(StandardGate.SX, [qubit], (), label=label)
 
-    def sxdg(self, qubit: QubitSpecifier) -> InstructionSet:
+    def sxdg(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SXdgGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.SXdg, [qubit], ())
+        return self._append_standard_gate(StandardGate.SXdg, [qubit], (), label=label)
 
     def csx(
         self,
@@ -6121,31 +6168,33 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def t(self, qubit: QubitSpecifier) -> InstructionSet:
+    def t(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.TGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.T, [qubit], ())
+        return self._append_standard_gate(StandardGate.T, [qubit], (), label=label)
 
-    def tdg(self, qubit: QubitSpecifier) -> InstructionSet:
+    def tdg(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.TdgGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.Tdg, [qubit], ())
+        return self._append_standard_gate(StandardGate.Tdg, [qubit], (), label=label)
 
     def u(
         self,
@@ -6153,6 +6202,7 @@ class QuantumCircuit:
         phi: ParameterValueType,
         lam: ParameterValueType,
         qubit: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.UGate`.
 
@@ -6163,11 +6213,12 @@ class QuantumCircuit:
             phi: The :math:`\phi` rotation angle of the gate.
             lam: The :math:`\lambda` rotation angle of the gate.
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.U, [qubit], [theta, phi, lam])
+        return self._append_standard_gate(StandardGate.U, [qubit], [theta, phi, lam], label=label)
 
     def cu(
         self,
@@ -6271,7 +6322,9 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def dcx(self, qubit1: QubitSpecifier, qubit2: QubitSpecifier) -> InstructionSet:
+    def dcx(
+        self, qubit1: QubitSpecifier, qubit2: QubitSpecifier, label: str | None = None
+    ) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.DCXGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
@@ -6279,11 +6332,12 @@ class QuantumCircuit:
         Args:
             qubit1: The qubit(s) to apply the gate to.
             qubit2: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.DCX, [qubit1, qubit2], ())
+        return self._append_standard_gate(StandardGate.DCX, [qubit1, qubit2], (), label=label)
 
     def ccx(
         self,
@@ -6441,18 +6495,19 @@ class QuantumCircuit:
 
         return self.append(gate, control_qubits[:] + [target_qubit] + ancilla_qubits[:], [])
 
-    def y(self, qubit: QubitSpecifier) -> InstructionSet:
+    def y(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.YGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.Y, [qubit], ())
+        return self._append_standard_gate(StandardGate.Y, [qubit], (), label=label)
 
     def cy(
         self,
@@ -6494,18 +6549,19 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def z(self, qubit: QubitSpecifier) -> InstructionSet:
+    def z(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.ZGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.Z, [qubit], ())
+        return self._append_standard_gate(StandardGate.Z, [qubit], (), label=label)
 
     def cz(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5293,6 +5293,7 @@ class QuantumCircuit:
         lam: ParameterValueType,
         control_qubits: Sequence[QubitSpecifier],
         target_qubit: QubitSpecifier,
+        label: str | None = None,
         ctrl_state: str | int | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MCPhaseGate`.
@@ -5303,6 +5304,7 @@ class QuantumCircuit:
             lam: The angle of the rotation.
             control_qubits: The qubits used as the controls.
             target_qubit: The qubit(s) targeted by the gate.
+            label: The string label of the gate in the circuit.
             ctrl_state:
                 The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling
                 on the '1' state.
@@ -5314,7 +5316,7 @@ class QuantumCircuit:
 
         num_ctrl_qubits = len(control_qubits)
         return self.append(
-            MCPhaseGate(lam, num_ctrl_qubits, ctrl_state=ctrl_state),
+            MCPhaseGate(lam, num_ctrl_qubits, label=label, ctrl_state=ctrl_state),
             control_qubits[:] + [target_qubit],
             [],
             copy=False,
@@ -5588,6 +5590,7 @@ class QuantumCircuit:
         control_qubit1: QubitSpecifier,
         control_qubit2: QubitSpecifier,
         target_qubit: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RCCXGate`.
 
@@ -5597,12 +5600,13 @@ class QuantumCircuit:
             control_qubit1: The qubit(s) used as the first control.
             control_qubit2: The qubit(s) used as the second control.
             target_qubit: The qubit(s) targeted by the gate.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
         return self._append_standard_gate(
-            StandardGate.RCCX, [control_qubit1, control_qubit2, target_qubit], ()
+            StandardGate.RCCX, [control_qubit1, control_qubit2, target_qubit], (), label=label
         )
 
     def rcccx(
@@ -5611,6 +5615,7 @@ class QuantumCircuit:
         control_qubit2: QubitSpecifier,
         control_qubit3: QubitSpecifier,
         target_qubit: QubitSpecifier,
+        label: str | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.RC3XGate`.
 
@@ -5621,7 +5626,7 @@ class QuantumCircuit:
             control_qubit2: The qubit(s) used as the second control.
             control_qubit3: The qubit(s) used as the third control.
             target_qubit: The qubit(s) targeted by the gate.
-
+            label: The string label of the gate in the circuit.
         Returns:
             A handle to the instructions created.
         """
@@ -5629,6 +5634,7 @@ class QuantumCircuit:
             StandardGate.RC3X,
             [control_qubit1, control_qubit2, control_qubit3, target_qubit],
             (),
+            label=label,
         )
 
     def rx(

--- a/releasenotes/notes/quantum-circuit-gate-labels-45a67cc63.yaml
+++ b/releasenotes/notes/quantum-circuit-gate-labels-45a67cc63.yaml
@@ -1,0 +1,22 @@
+---
+features_circuits:
+  - |
+    Added support for the ``label`` keyword argument to operations in QuantumCircuit.
+    :class:`.QuantumCircuit` gate helpers, including :meth:`.QuantumCircuit.h`,
+    :meth:`.QuantumCircuit.id`, :meth:`.QuantumCircuit.p`,
+    :meth:`.QuantumCircuit.mcp`, :meth:`.QuantumCircuit.r`,
+    :meth:`.QuantumCircuit.rccx`, :meth:`.QuantumCircuit.rcccx`,
+    :meth:`.QuantumCircuit.rxx`, :meth:`.QuantumCircuit.ryy`,
+    :meth:`.QuantumCircuit.rz`, :meth:`.QuantumCircuit.rzx`,
+    :meth:`.QuantumCircuit.rzz`, :meth:`.QuantumCircuit.ecr`,
+    :meth:`.QuantumCircuit.s`, :meth:`.QuantumCircuit.sdg`,
+    :meth:`.QuantumCircuit.swap`, :meth:`.QuantumCircuit.iswap`,
+    :meth:`.QuantumCircuit.sx`, :meth:`.QuantumCircuit.sxdg`,
+    :meth:`.QuantumCircuit.t`, :meth:`.QuantumCircuit.tdg`,
+    :meth:`.QuantumCircuit.u`, :meth:`.QuantumCircuit.dcx`,
+    :meth:`.QuantumCircuit.mcx`, :meth:`.QuantumCircuit.y`, and
+    :meth:`.QuantumCircuit.z`.
+fixes:
+  - |
+    Fixes `#16393 <https://github.com/Qiskit/qiskit/issues/16393>`__ and
+    `#5098 <https://github.com/Qiskit/qiskit/issues/5098>`__.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -72,38 +72,61 @@ class TestCircuitOperations(QiskitTestCase):
 
     @data(
         ("h", (0,)),
+        ("ch", (0, 1)),
         ("id", (0,)),
         ("p", (0.1, 0)),
         ("r", (0.1, 0.2, 0)),
+        ("rx", (0.1, 0)),
+        ("crx", (0.1, 0, 1)),
+        ("ry", (0.1, 0)),
+        ("cry", (0.1, 0, 1)),
         ("rxx", (0.1, 0, 1)),
         ("ryy", (0.1, 0, 1)),
         ("rz", (0.1, 0)),
+        ("crz", (0.1, 0, 1)),
         ("rzx", (0.1, 0, 1)),
         ("rzz", (0.1, 0, 1)),
         ("ecr", (0, 1)),
         ("s", (0,)),
+        ("cs", (0, 1)),
         ("sdg", (0,)),
+        ("csdg", (0, 1)),
         ("swap", (0, 1)),
         ("iswap", (0, 1)),
         ("sx", (0,)),
+        ("csx", (0, 1)),
         ("sxdg", (0,)),
         ("t", (0,)),
         ("tdg", (0,)),
         ("u", (0.1, 0.2, 0.3, 0)),
+        ("cu", (0.1, 0.2, 0.3, 0.4, 0, 1)),
+        ("x", (0,)),
+        ("cx", (0, 1)),
         ("dcx", (0, 1)),
         ("y", (0,)),
+        ("cy", (0, 1)),
         ("z", (0,)),
+        ("cz", (0, 1)),
         ("ccx", (0, 1, 2)),
+        ("ccz", (0, 1, 2)),
         ("mcx", ([0, 1, 2], 3)),
         ("mcp", (0.2, [0, 1, 2], 3)),
         ("cswap", (0, 1, 2)),
         ("rccx", (0, 1, 2)),
         ("rcccx", (0, 1, 2, 3)),
+        ("prepare_state", ([1, 0], [0])),
+        ("unitary", ([[0, 1], [1, 0]], [0])),
+        ("box", (QuantumCircuit(1), [0], [])),
+        ("while_loop", ((0, 0), QuantumCircuit(1, 1), [0], [0])),
+        ("for_loop", (range(2), None, QuantumCircuit(1, 1), [0], [0])),
+        ("if_test", ((0, 0), QuantumCircuit(1, 1), [0], [0])),
+        ("if_else", ((0, 0), QuantumCircuit(1, 1), QuantumCircuit(1, 1), [0], [0])),
+        ("switch", (0, [(0, QuantumCircuit(1, 1))], [0], [0])),
     )
     def test_operation_label_parameters(self, case):
         """Test standard QuantumCircuit gate helpers forward labels to the appended operation."""
         method_name, args = case
-        qc = QuantumCircuit(4)
+        qc = QuantumCircuit(4, 1)
         label = "my_label"
 
         getattr(qc, method_name)(*args, label=label)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -71,6 +71,40 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(test, expected)
 
     @data(
+        ("h", (0,)),
+        ("id", (0,)),
+        ("p", (0.1, 0)),
+        ("r", (0.1, 0.2, 0)),
+        ("rxx", (0.1, 0, 1)),
+        ("ryy", (0.1, 0, 1)),
+        ("rz", (0.1, 0)),
+        ("rzx", (0.1, 0, 1)),
+        ("rzz", (0.1, 0, 1)),
+        ("ecr", (0, 1)),
+        ("s", (0,)),
+        ("sdg", (0,)),
+        ("swap", (0, 1)),
+        ("iswap", (0, 1)),
+        ("sx", (0,)),
+        ("sxdg", (0,)),
+        ("t", (0,)),
+        ("tdg", (0,)),
+        ("u", (0.1, 0.2, 0.3, 0)),
+        ("dcx", (0, 1)),
+        ("y", (0,)),
+        ("z", (0,)),
+    )
+    def test_standard_gates_label_param(self, case):
+        """Test standard QuantumCircuit gate helpers forward labels to the appended operation."""
+        method_name, args = case
+        qc = QuantumCircuit(4)
+
+        getattr(qc, method_name)(*args, label="my_label")
+
+        self.assertEqual(len(qc.data), 1)
+        self.assertEqual(qc.data[0].operation.label, "my_label")
+
+    @data(
         slice(0, 2),
         slice(None, 1),
         slice(1, None),

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -93,16 +93,23 @@ class TestCircuitOperations(QiskitTestCase):
         ("dcx", (0, 1)),
         ("y", (0,)),
         ("z", (0,)),
+        ("ccx", (0, 1, 2)),
+        ("mcx", ([0, 1, 2], 3)),
+        ("mcp", (0.2, [0, 1, 2], 3)),
+        ("cswap", (0, 1, 2)),
+        ("rccx", (0, 1, 2)),
+        ("rcccx", (0, 1, 2, 3)),
     )
-    def test_standard_gates_label_param(self, case):
+    def test_operation_label_parameters(self, case):
         """Test standard QuantumCircuit gate helpers forward labels to the appended operation."""
         method_name, args = case
         qc = QuantumCircuit(4)
+        label = "my_label"
 
-        getattr(qc, method_name)(*args, label="my_label")
+        getattr(qc, method_name)(*args, label=label)
 
-        self.assertEqual(len(qc.data), 1)
-        self.assertEqual(qc.data[0].operation.label, "my_label")
+        self.assertTrue(qc.data)
+        self.assertEqual(qc.data[0].operation.label, label)
 
     @data(
         slice(0, 2),

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1131,7 +1131,9 @@ class TestControlledGate(QiskitTestCase):
         getattr(qc, method_name)(*args, label=label, **kwargs)
 
         self.assertTrue(qc.data)
-        self.assertEqual([instruction.operation.label for instruction in qc.data], [label] * len(qc.data))
+        self.assertEqual(
+            [instruction.operation.label for instruction in qc.data], [label] * len(qc.data)
+        )
 
     @data(
         ("ccx", 4, None, [0, 1], 2, "10"),

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1114,6 +1114,14 @@ class TestControlledGate(QiskitTestCase):
         ref_circuit.append(ccx, [qreg[0], qreg[1], qreg[2]])
         self.assertEqual(qc, ref_circuit)
 
+    def test_ccx_label_parameter(self):
+        """To check that labels are forwarded to CCX gates."""
+        qreg = QuantumRegister(3)
+        qc = QuantumCircuit(qreg)
+        qc.ccx(qreg[0], qreg[1], qreg[2], label="my_ccx", ctrl_state=0)
+
+        self.assertEqual(qc.data[0].operation.label, "my_ccx")
+
     @data((4, [0, 1, 2], 3, "010"), (4, [2, 1, 3], 0, 2))
     @unpack
     def test_multi_control_x_ctrl_state_parameter(

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1139,6 +1139,14 @@ class TestControlledGate(QiskitTestCase):
 
         self.assertEqual(operator_qc, operator_qc1)
 
+    def test_multi_control_x_label_parameter(self):
+        """To check that labels are forwarded to MCX gates."""
+        qc = QuantumCircuit(4)
+        qc.mcx([0, 1, 2], 3, label="my_mcx")
+
+        self.assertEqual(len(qc.data), 1)
+        self.assertEqual(qc.data[0].operation.label, "my_mcx")
+
     @data((4, 0.2, [0, 1, 2], 3, "010"), (4, 0.6, [2, 1, 3], 0, 0))
     @unpack
     def test_multi_control_p_ctrl_state_parameter(

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1114,98 +1114,64 @@ class TestControlledGate(QiskitTestCase):
         ref_circuit.append(ccx, [qreg[0], qreg[1], qreg[2]])
         self.assertEqual(qc, ref_circuit)
 
-    def test_ccx_label_parameter(self):
-        """To check that labels are forwarded to CCX gates."""
-        qreg = QuantumRegister(3)
-        qc = QuantumCircuit(qreg)
-        qc.ccx(qreg[0], qreg[1], qreg[2], label="my_ccx", ctrl_state=0)
-
-        self.assertEqual(qc.data[0].operation.label, "my_ccx")
-
-    @data((4, [0, 1, 2], 3, "010"), (4, [2, 1, 3], 0, 2))
+    @data(
+        ("ccx", (0, 1, 2), {}),
+        ("mcx", ([0, 1, 2], 3), {}),
+        ("mcp", (0.2, [0, 1, 2], 3), {}),
+        ("cswap", (0, 1, 2), {}),
+        ("rccx", (0, 1, 2), {}),
+        ("rcccx", (0, 1, 2, 3), {}),
+    )
     @unpack
-    def test_multi_control_x_ctrl_state_parameter(
-        self, num_qubits, ctrl_qubits, target_qubit, ctrl_state
-    ):
-        """To check the consistency of parameters ctrl_state in MCX"""
-        qc = QuantumCircuit(num_qubits)
-        qc.mcx(ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
-        operator_qc = Operator(qc)
-
-        qc1 = QuantumCircuit(num_qubits)
-        gate = MCXGate(num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
-        qc1.append(gate, ctrl_qubits + [target_qubit])
-        operator_qc1 = Operator(qc1)
-
-        self.assertEqual(operator_qc, operator_qc1)
-
-    def test_multi_control_x_label_parameter(self):
-        """To check that labels are forwarded to MCX gates."""
+    def test_controlled_operation_label_parameters(self, method_name, args, kwargs):
+        """Test that controlled-operation helpers forward labels to appended gates."""
         qc = QuantumCircuit(4)
-        qc.mcx([0, 1, 2], 3, label="my_mcx")
+        label = "my_label"
 
-        self.assertEqual(len(qc.data), 1)
-        self.assertEqual(qc.data[0].operation.label, "my_mcx")
+        getattr(qc, method_name)(*args, label=label, **kwargs)
 
-    @data((4, 0.2, [0, 1, 2], 3, "010"), (4, 0.6, [2, 1, 3], 0, 0))
+        self.assertTrue(qc.data)
+        self.assertEqual([instruction.operation.label for instruction in qc.data], [label] * len(qc.data))
+
+    @data(
+        ("ccx", 4, None, [0, 1], 2, "10"),
+        ("ccx", 4, None, [1, 2], 3, 1),
+        ("cswap", 4, None, [0], [1, 2], "0"),
+        ("cswap", 4, None, [3], [1, 0], 0),
+        ("mcx", 4, None, [0, 1, 2], 3, "010"),
+        ("mcx", 4, None, [2, 1, 3], 0, 2),
+        ("mcp", 4, 0.2, [0, 1, 2], 3, "010"),
+        ("mcp", 4, 0.6, [2, 1, 3], 0, 0),
+        ("mcp", 4, 0.2, [0, 1, 2], 3, "000"),
+        ("mcp", 3, 0.6, [0, 1], 2, 1),
+    )
     @unpack
-    def test_multi_control_p_ctrl_state_parameter(
-        self, num_qubits, lam, ctrl_qubits, target_qubit, ctrl_state
+    def test_controlled_operation_ctrl_state_parameter(
+        self, method_name, num_qubits, gate_param, ctrl_qubits, target_qubit, ctrl_state
     ):
-        """To check the consistency of parameters ctrl_state in MCP"""
+        """To check the consistency of ctrl_state for controlled-operation helpers."""
         qc = QuantumCircuit(num_qubits)
-        qc.mcp(lam, ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
-        operator_qc = Operator(qc)
+        if method_name == "ccx":
+            qc.ccx(*ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
+            gate = CCXGate(ctrl_state=ctrl_state)
+            qargs = ctrl_qubits + [target_qubit]
+        elif method_name == "cswap":
+            qc.cswap(*ctrl_qubits, *target_qubit, ctrl_state=ctrl_state)
+            gate = CSwapGate(ctrl_state=ctrl_state)
+            qargs = ctrl_qubits + target_qubit
+        elif method_name == "mcx":
+            qc.mcx(ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
+            gate = MCXGate(num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
+            qargs = ctrl_qubits + [target_qubit]
+        else:
+            qc.mcp(gate_param, ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
+            gate = MCPhaseGate(gate_param, num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
+            qargs = ctrl_qubits + [target_qubit]
 
-        qc1 = QuantumCircuit(num_qubits)
-        gate = MCPhaseGate(lam, num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
-        qc1.append(gate, ctrl_qubits + [target_qubit])
-        operator_qc1 = Operator(qc1)
+        expected = QuantumCircuit(num_qubits)
+        expected.append(gate, qargs)
 
-        self.assertEqual(operator_qc, operator_qc1)
-
-    def test_multi_control_p_label_parameter(self):
-        """To check that labels are forwarded to MCPhase gates."""
-        qc = QuantumCircuit(4)
-        qc.mcp(0.2, [0, 1, 2], 3, label="my_mcp")
-
-        self.assertEqual(len(qc.data), 1)
-        self.assertEqual(qc.data[0].operation.label, "my_mcp")
-
-    def test_cswap_label_parameter(self):
-        """To check that cswap forwards labels."""
-        qc = QuantumCircuit(3)
-        qc.cswap(0, 1, 2, label="my_cswap")
-
-        self.assertEqual(len(qc.data), 1)
-        self.assertEqual(qc.data[0].operation.label, "my_cswap")
-
-    def test_relative_phase_toffoli_label_parameter(self):
-        """rccx and rcccx should accept and preserve labels."""
-        qc = QuantumCircuit(4)
-        qc.rccx(0, 1, 2, label="my_rccx")
-        qc.rcccx(0, 1, 2, 3, label="my_rcccx")
-
-        self.assertEqual(qc.data[0].operation.label, "my_rccx")
-        self.assertEqual(qc.data[1].operation.label, "my_rcccx")
-
-    @data((4, 0.2, [0, 1, 2], 3, "000"), (3, 0.6, [0, 1], 2, 1))
-    @unpack
-    def test_open_control_mcphase_ctrl_state_parameter(
-        self, num_qubits, lam, ctrl_qubits, target_qubit, ctrl_state
-    ):
-        """To check the consistency of parameters ctrl_state in MCPhaseGate"""
-        qc = QuantumCircuit(num_qubits)
-        num_controls = len(ctrl_qubits)
-        qc.mcp(lam, ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
-
-        # obtain unitary for circuit
-        simulated = Operator(qc).data
-        simulated = simulated[: 2 ** (num_controls + 1), : 2 ** (num_controls + 1)]
-        base = PhaseGate(lam).to_matrix()
-        expected = _compute_control_matrix(base, num_controls, ctrl_state=ctrl_state)
-
-        self.assertTrue(matrix_equal(simulated, expected))
+        self.assertEqual(Operator(qc), Operator(expected))
 
     def test_open_control_composite_unrolling(self):
         """test unrolling of open control gates when gate is in basis"""

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1115,27 +1115,6 @@ class TestControlledGate(QiskitTestCase):
         self.assertEqual(qc, ref_circuit)
 
     @data(
-        ("ccx", (0, 1, 2), {}),
-        ("mcx", ([0, 1, 2], 3), {}),
-        ("mcp", (0.2, [0, 1, 2], 3), {}),
-        ("cswap", (0, 1, 2), {}),
-        ("rccx", (0, 1, 2), {}),
-        ("rcccx", (0, 1, 2, 3), {}),
-    )
-    @unpack
-    def test_controlled_operation_label_parameters(self, method_name, args, kwargs):
-        """Test that controlled-operation helpers forward labels to appended gates."""
-        qc = QuantumCircuit(4)
-        label = "my_label"
-
-        getattr(qc, method_name)(*args, label=label, **kwargs)
-
-        self.assertTrue(qc.data)
-        self.assertEqual(
-            [instruction.operation.label for instruction in qc.data], [label] * len(qc.data)
-        )
-
-    @data(
         ("ccx", 4, None, [0, 1], 2, "10"),
         ("ccx", 4, None, [1, 2], 3, 1),
         ("cswap", 4, None, [0], [1, 2], "0"),

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1164,6 +1164,31 @@ class TestControlledGate(QiskitTestCase):
 
         self.assertEqual(operator_qc, operator_qc1)
 
+    def test_multi_control_p_label_parameter(self):
+        """To check that labels are forwarded to MCPhase gates."""
+        qc = QuantumCircuit(4)
+        qc.mcp(0.2, [0, 1, 2], 3, label="my_mcp")
+
+        self.assertEqual(len(qc.data), 1)
+        self.assertEqual(qc.data[0].operation.label, "my_mcp")
+
+    def test_cswap_label_parameter(self):
+        """To check that cswap forwards labels."""
+        qc = QuantumCircuit(3)
+        qc.cswap(0, 1, 2, label="my_cswap")
+
+        self.assertEqual(len(qc.data), 1)
+        self.assertEqual(qc.data[0].operation.label, "my_cswap")
+
+    def test_relative_phase_toffoli_label_parameter(self):
+        """rccx and rcccx should accept and preserve labels."""
+        qc = QuantumCircuit(4)
+        qc.rccx(0, 1, 2, label="my_rccx")
+        qc.rcccx(0, 1, 2, 3, label="my_rcccx")
+
+        self.assertEqual(qc.data[0].operation.label, "my_rccx")
+        self.assertEqual(qc.data[1].operation.label, "my_rcccx")
+
     @data((4, 0.2, [0, 1, 2], 3, "000"), (3, 0.6, [0, 1], 2, 1))
     @unpack
     def test_open_control_mcphase_ctrl_state_parameter(


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
Fix #5098. Additionally, enabled `label` param for (non-controlled) single qubit gates in `quantumcirtuit.py`. Operationas that depends on `CircuitInstruction` are left out at the moment -- that seems to require changes in `rust`?

```sh
ccx (toffoli)    # done  
mcx,  # done 
rccx, # done 
rcccx, # done 
cswap (fredkin), # same as 
mcp (mcu1) # same as MCP 
```

### AI/LLM disclosure
- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description: copilot 
- [x] I used the following tool to generate or modify code: copilot 

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
