### PR TITLE
Update docs for TwoQubitControlledUDecomposer regarding 8 1-qubit target

### DIFF
--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -265,28 +265,24 @@ class TwoQubitWeylDecomposition:
 
 
 class TwoQubitControlledUDecomposer:
-    r"""Decompose two-qubit unitary in terms of a desired
-    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
-    gate that is locally equivalent to an :class:`.RXXGate`.
+    r"""Decompose a two-qubit unitary in terms of a desired two-qubit gate
+    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` that is locally equivalent to an
+    :class:`.RXXGate`.
 
-    This decomposer synthesizes a general two-qubit unitary using at most 3 instances
-    of the target 2-qubit gate and at most 8 single-qubit unitary gates
-    (in the general case where 3 2-qubit gates are needed). The 8 single-qubit
-    unitary gates are obtained by multiplying the adjacent 1-qubit unitary matrices
-    between the 2-qubit gates.
+    **Synthesis algorithm**
 
-    The synthesis algorithm proceeds as follows:
-
-    **Step 1.** Given a general :math:`4 \times 4` unitary :math:`U`, find the KAK decomposition:
+    Any two-qubit unitary :math:`U \in U(4)` admits a canonical (Weyl) decomposition
+    (see :class:`.TwoQubitWeylDecomposition`)
 
     .. math::
 
-        U = (c_2^r \otimes c_2^l) \cdot W \cdot (c_1^r \otimes c_1^l)
+        U = (c_2^r \otimes c_2^l)\, U_d(a, b, c)\, (c_1^r \otimes c_1^l),
+        \quad c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)
 
-    where :math:`W` is a Weyl (canonical) gate and :math:`c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)`.
-    This yields 4 single-qubit unitary gates:
+    where :math:`U_d(a, b, c) = e^{i(a\, XX + b\, YY + c\, ZZ)}` is the Weyl gate
+    with parameters :math:`\tfrac{\pi}{4} \geq a \geq b \geq |c|`:
 
-    .. parsed-literal::
+    .. code-block:: text
 
              ┌─────┐┌───────┐┌─────┐
         q_0: ┤ c2r ├┤0      ├┤ c1r ├
@@ -294,13 +290,12 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ c2l ├┤1      ├┤ c1l ├
              └─────┘└───────┘└─────┘
 
-    **Step 2.** Write the Weyl gate :math:`W` as:
+    The Weyl gate factorizes as
+    :math:`U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)`,
+    where :math:`R_{XX}(\theta) = e^{-i\frac{\theta}{2} XX}` and similarly for
+    :math:`R_{YY}` and :math:`R_{ZZ}`:
 
-    .. math::
-
-        W = R_{XX}(a) \cdot R_{YY}(b) \cdot R_{ZZ}(c)
-
-    .. parsed-literal::
+    .. code-block:: text
 
              ┌─────────┐┌─────────┐
         q_0: ┤0        ├┤0        ├─■──────
@@ -308,17 +303,20 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤1        ├┤1        ├─■──────
              └─────────┘└─────────┘
 
-    **Step 3.** Rewrite :math:`R_{YY}` and :math:`R_{ZZ}` in terms of :math:`R_{XX}`:
+    The :math:`R_{YY}` and :math:`R_{ZZ}` rotations are conjugated into :math:`R_{XX}`
+    via the local unitaries
 
     .. math::
 
-        R_{YY}(b) = (S^\dagger \otimes S^\dagger) \cdot R_{XX}(b) \cdot (S \otimes S)
+        R_{YY}(b) = (S^\dagger \otimes S^\dagger)\, R_{XX}(b)\, (S \otimes S)
 
     .. math::
 
-        R_{ZZ}(c) = (H \otimes H) \cdot R_{XX}(c) \cdot (H \otimes H)
+        R_{ZZ}(c) = (H \otimes H)\, R_{XX}(c)\, (H \otimes H)
 
-    .. parsed-literal::
+    giving:
+
+    .. code-block:: text
 
              ┌─────┐┌─────────┐┌───┐
         q_0: ┤ Sdg ├┤0        ├┤ S ├
@@ -332,36 +330,40 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ H ├┤1        ├┤ H ├
              └───┘└─────────┘└───┘
 
-    **Step 4.** Replace each :math:`R_{XX}` with the target gate ``Equiv``
-    (which is locally equivalent to :class:`.RXXGate`):
+    Each :math:`R_{XX}(\theta)` is then realized by the user-supplied
+    ``rxx_equivalent_gate`` :math:`\text{Equiv}`, which satisfies
+    :math:`\text{Equiv} \sim U_d(\alpha, 0, 0)` for some :math:`\alpha \neq 0`,
+    via the local decomposition
 
     .. math::
 
-        R_{XX}(\theta) = (k_2^r \otimes k_2^l) \cdot \text{Equiv} \cdot (k_1^r \otimes k_1^l)
+        R_{XX}(\theta) = (k_2^r \otimes k_2^l)\, \text{Equiv}\, (k_1^r \otimes k_1^l),
+        \quad k_1^r, k_1^l, k_2^r, k_2^l \in SU(2)
 
-    .. parsed-literal::
+    All single-qubit unitary gates between consecutive two-qubit gates are then
+    consolidated by matrix multiplication into at most eight single-qubit unitary gates,
+    yielding the final circuit:
 
-             ┌─────┐┌────────┐┌─────┐
-        q_0: ┤ k2r ├┤0       ├┤ k1r ├
-             ├─────┤│  Equiv │├─────┤
-        q_1: ┤ k2l ├┤1       ├┤ k1l ├
-             └─────┘└────────┘└─────┘
+    .. code-block:: text
 
-    Finally, all adjacent single-qubit unitaries between the 2-qubit gates are merged,
-    reducing the total to at most 8 single-qubit unitary gates:
+             ┌─────┐┌───────────┐┌─────┐┌───────────┐┌─────┐┌───────────┐┌─────┐
+        q_0: ┤ d2r ├┤0          ├┤ d1r ├┤0          ├┤ e1r ├┤0          ├┤ f1r ├
+             ├─────┤│  Equiv(a) │├─────┤│  Equiv(b) │├─────┤│  Equiv(c) │├─────┤
+        q_1: ┤ d2l ├┤1          ├┤ d1l ├┤1          ├┤ e1l ├┤1          ├┤ f1l ├
+             └─────┘└───────────┘└─────┘└───────────┘└─────┘└───────────┘└─────┘
 
-    .. parsed-literal::
+    where ``Equiv(a)``, ``Equiv(b)``, ``Equiv(c)`` realize :math:`R_{XX}(a)`,
+    :math:`R_{XX}(b)`, :math:`R_{XX}(c)` respectively, and the remaining boxes are
+    the consolidated single-qubit unitary gates.
 
-             ┌──────┐┌───────────┐┌──────┐┌───────────┐┌──────┐┌───────────┐┌──────┐
-        q_0: ┤ U1_r ├┤0          ├┤ U2_r ├┤0          ├┤ U3_r ├┤0          ├┤ U4_r ├
-             ├──────┤│  Equiv(a) │├──────┤│  Equiv(b) │├──────┤│  Equiv(c) │├──────┤
-        q_1: ┤ U1_l ├┤1          ├┤ U2_l ├┤1          ├┤ U3_l ├┤1          ├┤ U4_l ├
-             └──────┘└───────────┘└──────┘└───────────┘└──────┘└───────────┘└──────┘
+    The number of ``rxx_equivalent_gate`` applications depends on the Weyl parameters:
+    rotations with a vanishing angle are dropped, so unitaries equivalent to the identity,
+    a single :class:`.RXXGate`, or two instances of :class:`.RXXGate` use zero, one,
+    or two applications of ``rxx_equivalent_gate`` respectively.
     """
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
-        r"""Initialize the KAK decomposition.
-
+        r"""
         Args:
             rxx_equivalent_gate: Gate that is locally equivalent to an :class:`.RXXGate`:
                 :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` gate.
@@ -392,20 +394,21 @@ class TwoQubitControlledUDecomposer:
     def __call__(  # noqa: D417 TODO: Add support for the undocumented arguments
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
-        """Returns the Weyl decomposition in circuit form.
+        """Decompose a two-qubit unitary and return it as a quantum circuit.
 
         Args:
-            unitary (Operator or ndarray): :math:`4 \times 4` unitary to synthesize.
+            unitary: :math:`4 \times 4` unitary to synthesize.
+            atol: Absolute tolerance for checking angles of the single-qubit unitaries
+                when simplifying the returned circuit. Default: 1e-12.
 
         Returns:
             QuantumCircuit: Synthesized quantum circuit.
 
-        Note: atol is passed to OneQubitEulerDecomposer.
+        Note: atol is passed to :class:`.OneQubitEulerDecomposer`.
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
-
-
+    
 class TwoQubitBasisDecomposer:
     """A class for decomposing 2-qubit unitaries into minimal number of uses of a 2-qubit
     basis gate.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -437,7 +437,8 @@ class TwoQubitControlledUDecomposer:
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
-    
+
+
 class TwoQubitBasisDecomposer:
     """A class for decomposing 2-qubit unitaries into minimal number of uses of a 2-qubit
     basis gate.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -269,10 +269,11 @@ class TwoQubitControlledUDecomposer:
     :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
     gate that is locally equivalent to an :class:`.RXXGate`.
 
-    This decomposer synthesizes a general two-qubit unitary using at most 8 single-qubit
-    unitary gates (in the general case where 3 2-qubit gates are needed), along with up to
-    3 instances of the target 2-qubit gate. The reduction to 8 single-qubit unitaries is
-    achieved by multiplying the adjacent 1-qubit unitary matrices between the 2-qubit gates.
+    This decomposer synthesizes a general two-qubit unitary using at most 3 instances
+    of the target 2-qubit gate and at most 8 single-qubit unitary gates
+    (in the general case where 3 2-qubit gates are needed). The 8 single-qubit
+    unitary gates are obtained by multiplying the adjacent 1-qubit unitary matrices
+    between the 2-qubit gates.
 
     The synthesis algorithm proceeds as follows:
 
@@ -313,6 +314,8 @@ class TwoQubitControlledUDecomposer:
 
         R_{YY}(b) = (S^\dagger \otimes S^\dagger) \cdot R_{XX}(b) \cdot (S \otimes S)
 
+    .. math::
+
         R_{ZZ}(c) = (H \otimes H) \cdot R_{XX}(c) \cdot (H \otimes H)
 
     .. parsed-literal::
@@ -345,7 +348,7 @@ class TwoQubitControlledUDecomposer:
              └─────┘└────────┘└─────┘
 
     Finally, all adjacent single-qubit unitaries between the 2-qubit gates are merged,
-    reducing the total from 24 to at most 8 single-qubit unitary gates:
+    reducing the total to at most 8 single-qubit unitary gates:
 
     .. parsed-literal::
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -345,7 +345,7 @@ class TwoQubitControlledUDecomposer:
              └─────┘└────────┘└─────┘
 
     Finally, all adjacent single-qubit unitaries between the 2-qubit gates are merged,
-    reducing the total from 24 to at most 8 single-qubit gates:
+    reducing the total from 24 to at most 8 single-qubit unitary gates:
 
     .. parsed-literal::
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -267,7 +267,14 @@ class TwoQubitWeylDecomposition:
 class TwoQubitControlledUDecomposer:
     r"""Decompose two-qubit unitary in terms of a desired
     :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
-    gate that is locally equivalent to an :class:`.RXXGate`."""
+    gate that is locally equivalent to an :class:`.RXXGate`.
+    
+    This decomposer synthesizes a general two-qubit unitary using at most 8 single-qubit
+    unitary gates (in the general case where 3 2-qubit gates are needed),
+    along with up to 3 instances of the target 2-qubit gate. The reduction to 8 
+    single-qubit unitaries is achieved by multiplying the adjacent 1-qubit unitary
+    matrices between the 2-qubit gates.
+    """
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
         r"""Initialize the KAK decomposition.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -265,22 +265,21 @@ class TwoQubitWeylDecomposition:
 
 
 class TwoQubitControlledUDecomposer:
-    r"""Decompose a two-qubit unitary in terms of a desired two-qubit gate
-    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` that is locally equivalent to an
-    :class:`.RXXGate`.
+    r"""Decompose two-qubit unitary in terms of a desired
+    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
+    gate that is locally equivalent to an :class:`.RXXGate`.
 
     **Synthesis algorithm**
 
-    Any two-qubit unitary :math:`U \in U(4)` admits a canonical (Weyl) decomposition
-    (see :class:`.TwoQubitWeylDecomposition`)
+    Any two-qubit unitary :math:`U \in U(4)` can be written via the KAK decomposition
+    (see :class:`.TwoQubitWeylDecomposition`) as:
 
     .. math::
 
-        U = (c_2^r \otimes c_2^l)\, U_d(a, b, c)\, (c_1^r \otimes c_1^l),
-        \quad c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)
+        U = (c_2^r \otimes c_2^l)\, U_d(a, b, c)\, (c_1^r \otimes c_1^l)
 
-    where :math:`U_d(a, b, c) = e^{i(a\, XX + b\, YY + c\, ZZ)}` is the Weyl gate
-    with parameters :math:`\tfrac{\pi}{4} \geq a \geq b \geq |c|`:
+    where :math:`U_d(a, b, c) = e^{i(a\,XX + b\,YY + c\,ZZ)}` is the Weyl gate
+    and :math:`c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)`:
 
     .. code-block:: text
 
@@ -290,10 +289,8 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ c2l ├┤1      ├┤ c1l ├
              └─────┘└───────┘└─────┘
 
-    The Weyl gate factorizes as
-    :math:`U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)`,
-    where :math:`R_{XX}(\theta) = e^{-i\frac{\theta}{2} XX}` and similarly for
-    :math:`R_{YY}` and :math:`R_{ZZ}`:
+    **Step 1.** The Weyl gate decomposes as
+    :math:`U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)`:
 
     .. code-block:: text
 
@@ -303,8 +300,8 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤1        ├┤1        ├─■──────
              └─────────┘└─────────┘
 
-    The :math:`R_{YY}` and :math:`R_{ZZ}` rotations are conjugated into :math:`R_{XX}`
-    via the local unitaries
+    **Step 2.** :math:`R_{YY}` and :math:`R_{ZZ}` are rewritten as :math:`R_{XX}`
+    via single-qubit conjugations:
 
     .. math::
 
@@ -313,8 +310,6 @@ class TwoQubitControlledUDecomposer:
     .. math::
 
         R_{ZZ}(c) = (H \otimes H)\, R_{XX}(c)\, (H \otimes H)
-
-    giving:
 
     .. code-block:: text
 
@@ -330,19 +325,16 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ H ├┤1        ├┤ H ├
              └───┘└─────────┘└───┘
 
-    Each :math:`R_{XX}(\theta)` is then realized by the user-supplied
-    ``rxx_equivalent_gate`` :math:`\text{Equiv}`, which satisfies
-    :math:`\text{Equiv} \sim U_d(\alpha, 0, 0)` for some :math:`\alpha \neq 0`,
-    via the local decomposition
+    **Step 3.** Each :math:`R_{XX}(\theta)` is realized with the ``rxx_equivalent_gate``:
 
     .. math::
 
         R_{XX}(\theta) = (k_2^r \otimes k_2^l)\, \text{Equiv}\, (k_1^r \otimes k_1^l),
         \quad k_1^r, k_1^l, k_2^r, k_2^l \in SU(2)
 
-    All single-qubit unitary gates between consecutive two-qubit gates are then
-    consolidated by matrix multiplication into at most eight single-qubit unitary gates,
-    yielding the final circuit:
+    Adjacent single-qubit unitary gates between the two-qubit gates are then merged,
+    giving at most three ``rxx_equivalent_gate`` applications and at most eight
+    single-qubit unitary gates:
 
     .. code-block:: text
 
@@ -356,10 +348,9 @@ class TwoQubitControlledUDecomposer:
     :math:`R_{XX}(b)`, :math:`R_{XX}(c)` respectively, and the remaining boxes are
     the consolidated single-qubit unitary gates.
 
-    The number of ``rxx_equivalent_gate`` applications depends on the Weyl parameters:
-    rotations with a vanishing angle are dropped, so unitaries equivalent to the identity,
-    a single :class:`.RXXGate`, or two instances of :class:`.RXXGate` use zero, one,
-    or two applications of ``rxx_equivalent_gate`` respectively.
+    Rotations with a vanishing angle are dropped, so unitaries equivalent to the
+    identity, a single :class:`.RXXGate`, or two instances of :class:`.RXXGate` use
+    zero, one, or two applications of ``rxx_equivalent_gate`` respectively.
     """
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
@@ -391,14 +382,16 @@ class TwoQubitControlledUDecomposer:
         self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
-    def __call__(  # noqa: D417 TODO: Add support for the undocumented arguments
+    def __call__(
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
         """Decompose a two-qubit unitary and return it as a quantum circuit.
 
         Args:
-            unitary: :math:`4 \times 4` unitary to synthesize.
-            atol: Absolute tolerance for checking angles of the single-qubit unitaries
+            unitary: :math:`4 \\times 4` unitary to synthesize.
+            approximate: Not used. Present for signature compatibility with other decomposers.
+            use_dag: Not used. Present for signature compatibility with other decomposers.
+            atol: Absolute tolerance for checking angles of the single-qubit unitary gates
                 when simplifying the returned circuit. Default: 1e-12.
 
         Returns:
@@ -408,7 +401,7 @@ class TwoQubitControlledUDecomposer:
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
-    
+        
 class TwoQubitBasisDecomposer:
     """A class for decomposing 2-qubit unitaries into minimal number of uses of a 2-qubit
     basis gate.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -278,19 +278,30 @@ class TwoQubitControlledUDecomposer:
 
         U = (c_2^r \otimes c_2^l)\, U_d(a, b, c)\, (c_1^r \otimes c_1^l)
 
-    where :math:`U_d(a, b, c) = e^{i(a\,XX + b\,YY + c\,ZZ)}` is the Weyl gate
-    and :math:`c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)`:
+    where :math:`U_d(a, b, c) = e^{i(a\,XX + b\,YY + c\,ZZ)}` is the Weyl (canonical) gate
+    with Weyl chamber parameters :math:`\tfrac{\pi}{4} \geq a \geq b \geq |c| \geq 0`,
+    and :math:`c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)` are single-qubit unitaries.
+    This gives an initial circuit of the form:
 
     .. code-block:: text
 
-             ┌─────┐┌───────┐┌─────┐
-        q_0: ┤ c2r ├┤0      ├┤ c1r ├
-             ├─────┤│  Weyl │├─────┤
-        q_1: ┤ c2l ├┤1      ├┤ c1l ├
-             └─────┘└───────┘└─────┘
+             ┌─────┐┌───────────┐┌─────┐
+        q_0: ┤ c2r ├┤0          ├┤ c1r ├
+             ├─────┤│  Ud(a,b,c)│├─────┤
+        q_1: ┤ c2l ├┤1          ├┤ c1l ├
+             └─────┘└───────────┘└─────┘
 
-    **Step 1.** The Weyl gate decomposes as
-    :math:`U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)`:
+    **Step 1: Expand the Weyl gate into three two-qubit rotations**
+
+    The Weyl gate decomposes exactly as a product of three Pauli rotations:
+
+    .. math::
+
+        U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)
+
+    where :math:`R_{XX}(\theta) = e^{-i \frac{\theta}{2} X \otimes X}`,
+    :math:`R_{YY}(\theta) = e^{-i \frac{\theta}{2} Y \otimes Y}`, and
+    :math:`R_{ZZ}(\theta) = e^{-i \frac{\theta}{2} Z \otimes Z}`:
 
     .. code-block:: text
 
@@ -300,8 +311,11 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤1        ├┤1        ├─■──────
              └─────────┘└─────────┘
 
-    **Step 2.** :math:`R_{YY}` and :math:`R_{ZZ}` are rewritten as :math:`R_{XX}`
-    via single-qubit conjugations:
+    **Step 2: Conjugate** :math:`R_{YY}` **and** :math:`R_{ZZ}` **into** :math:`R_{XX}`
+
+    Since all three Pauli rotations are locally equivalent, :math:`R_{YY}` and
+    :math:`R_{ZZ}` can be rewritten as :math:`R_{XX}` rotations by conjugating with
+    single-qubit Clifford gates:
 
     .. math::
 
@@ -310,6 +324,8 @@ class TwoQubitControlledUDecomposer:
     .. math::
 
         R_{ZZ}(c) = (H \otimes H)\, R_{XX}(c)\, (H \otimes H)
+
+    giving the two sub-circuits:
 
     .. code-block:: text
 
@@ -325,16 +341,27 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ H ├┤1        ├┤ H ├
              └───┘└─────────┘└───┘
 
-    **Step 3.** Each :math:`R_{XX}(\theta)` is realized with the ``rxx_equivalent_gate``:
+    **Step 3: Realize each** :math:`R_{XX}` **with the target gate**
+
+    Each :math:`R_{XX}(\theta)` is decomposed using the user-supplied
+    ``rxx_equivalent_gate`` :math:`\text{Equiv} \sim U_d(\alpha, 0, 0)`.
+    Since :math:`\text{Equiv}` and :math:`R_{XX}` are locally equivalent,
+    there exist :math:`k_1^r, k_1^l, k_2^r, k_2^l \in SU(2)` such that:
 
     .. math::
 
-        R_{XX}(\theta) = (k_2^r \otimes k_2^l)\, \text{Equiv}\, (k_1^r \otimes k_1^l),
-        \quad k_1^r, k_1^l, k_2^r, k_2^l \in SU(2)
+        R_{XX}(\theta) = (k_2^r \otimes k_2^l)\, \text{Equiv}\, (k_1^r \otimes k_1^l)
 
-    Adjacent single-qubit unitary gates between the two-qubit gates are then merged,
-    giving at most three ``rxx_equivalent_gate`` applications and at most eight
-    single-qubit unitary gates:
+    where the angle scaling between :math:`\theta` and :math:`\alpha` is absorbed
+    into the surrounding single-qubit unitaries.
+
+    **Step 4: Consolidate single-qubit unitary gates**
+
+    After substituting the target gate for every :math:`R_{XX}`, the full circuit
+    contains up to 24 single-qubit unitary gates. All single-qubit unitary gates
+    that appear between consecutive two-qubit gates are merged by matrix multiplication
+    into a single :math:`SU(2)` operation per qubit, reducing the count to at most
+    eight single-qubit unitary gates in total. The final synthesized circuit has the form:
 
     .. code-block:: text
 
@@ -344,13 +371,23 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ d2l ├┤1          ├┤ d1l ├┤1          ├┤ e1l ├┤1          ├┤ f1l ├
              └─────┘└───────────┘└─────┘└───────────┘└─────┘└───────────┘└─────┘
 
-    where ``Equiv(a)``, ``Equiv(b)``, ``Equiv(c)`` realize :math:`R_{XX}(a)`,
-    :math:`R_{XX}(b)`, :math:`R_{XX}(c)` respectively, and the remaining boxes are
-    the consolidated single-qubit unitary gates.
+    where ``Equiv(a)``, ``Equiv(b)``, and ``Equiv(c)`` realize :math:`R_{XX}(a)`,
+    :math:`R_{XX}(b)`, and :math:`R_{XX}(c)` respectively using the target gate,
+    and ``d2r``, ``d2l``, ``d1r``, ``d1l``, ``e1r``, ``e1l``, ``f1r``, ``f1l``
+    are the consolidated single-qubit unitary gates on each qubit.
 
-    Rotations with a vanishing angle are dropped, so unitaries equivalent to the
-    identity, a single :class:`.RXXGate`, or two instances of :class:`.RXXGate` use
-    zero, one, or two applications of ``rxx_equivalent_gate`` respectively.
+    **Gate count**
+
+    The number of ``rxx_equivalent_gate`` applications depends on the Weyl chamber
+    parameters of the target unitary:
+
+    - If :math:`a = b = c = 0` (identity-like): zero applications.
+    - If :math:`b = c = 0` (single :class:`.RXXGate`-like): one application.
+    - If :math:`c = 0` (two :class:`.RXXGate`-like): two applications.
+    - General case: three applications.
+
+    Rotations with a vanishing angle are dropped automatically, so the decomposer
+    always emits the minimal number of two-qubit gates for the given unitary.
     """
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
@@ -392,12 +429,11 @@ class TwoQubitControlledUDecomposer:
             approximate: Not used. Present for signature compatibility with other decomposers.
             use_dag: Not used. Present for signature compatibility with other decomposers.
             atol: Absolute tolerance for checking angles of the single-qubit unitary gates
-                when simplifying the returned circuit. Default: 1e-12.
+                when simplifying the returned circuit. Passed to
+                :class:`.OneQubitEulerDecomposer`. Default: 1e-12.
 
         Returns:
             QuantumCircuit: Synthesized quantum circuit.
-
-        Note: atol is passed to :class:`.OneQubitEulerDecomposer`.
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -401,7 +401,7 @@ class TwoQubitControlledUDecomposer:
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
-        
+    
 class TwoQubitBasisDecomposer:
     """A class for decomposing 2-qubit unitaries into minimal number of uses of a 2-qubit
     basis gate.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -268,12 +268,92 @@ class TwoQubitControlledUDecomposer:
     r"""Decompose two-qubit unitary in terms of a desired
     :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
     gate that is locally equivalent to an :class:`.RXXGate`.
-    
+
     This decomposer synthesizes a general two-qubit unitary using at most 8 single-qubit
-    unitary gates (in the general case where 3 2-qubit gates are needed),
-    along with up to 3 instances of the target 2-qubit gate. The reduction to 8 
-    single-qubit unitaries is achieved by multiplying the adjacent 1-qubit unitary
-    matrices between the 2-qubit gates.
+    unitary gates (in the general case where 3 2-qubit gates are needed), along with up to
+    3 instances of the target 2-qubit gate. The reduction to 8 single-qubit unitaries is
+    achieved by multiplying the adjacent 1-qubit unitary matrices between the 2-qubit gates.
+
+    The synthesis algorithm proceeds as follows:
+
+    **Step 1.** Given a general :math:`4 \times 4` unitary :math:`U`, find the KAK decomposition:
+
+    .. math::
+
+        U = (c_2^r \otimes c_2^l) \cdot W \cdot (c_1^r \otimes c_1^l)
+
+    where :math:`W` is a Weyl (canonical) gate and :math:`c_1^r, c_1^l, c_2^r, c_2^l \in SU(2)`.
+    This yields 4 single-qubit unitary gates:
+
+    .. parsed-literal::
+
+             ┌─────┐┌───────┐┌─────┐
+        q_0: ┤ c2r ├┤0      ├┤ c1r ├
+             ├─────┤│  Weyl │├─────┤
+        q_1: ┤ c2l ├┤1      ├┤ c1l ├
+             └─────┘└───────┘└─────┘
+
+    **Step 2.** Write the Weyl gate :math:`W` as:
+
+    .. math::
+
+        W = R_{XX}(a) \cdot R_{YY}(b) \cdot R_{ZZ}(c)
+
+    .. parsed-literal::
+
+             ┌─────────┐┌─────────┐
+        q_0: ┤0        ├┤0        ├─■──────
+             │  Rxx(a) ││  Ryy(b) │ │ZZ(c)
+        q_1: ┤1        ├┤1        ├─■──────
+             └─────────┘└─────────┘
+
+    **Step 3.** Rewrite :math:`R_{YY}` and :math:`R_{ZZ}` in terms of :math:`R_{XX}`:
+
+    .. math::
+
+        R_{YY}(b) = (S^\dagger \otimes S^\dagger) \cdot R_{XX}(b) \cdot (S \otimes S)
+
+        R_{ZZ}(c) = (H \otimes H) \cdot R_{XX}(c) \cdot (H \otimes H)
+
+    .. parsed-literal::
+
+             ┌─────┐┌─────────┐┌───┐
+        q_0: ┤ Sdg ├┤0        ├┤ S ├
+             ├─────┤│  Rxx(b) │├───┤
+        q_1: ┤ Sdg ├┤1        ├┤ S ├
+             └─────┘└─────────┘└───┘
+
+             ┌───┐┌─────────┐┌───┐
+        q_0: ┤ H ├┤0        ├┤ H ├
+             ├───┤│  Rxx(c) │├───┤
+        q_1: ┤ H ├┤1        ├┤ H ├
+             └───┘└─────────┘└───┘
+
+    **Step 4.** Replace each :math:`R_{XX}` with the target gate ``Equiv``
+    (which is locally equivalent to :class:`.RXXGate`):
+
+    .. math::
+
+        R_{XX}(\theta) = (k_2^r \otimes k_2^l) \cdot \text{Equiv} \cdot (k_1^r \otimes k_1^l)
+
+    .. parsed-literal::
+
+             ┌─────┐┌────────┐┌─────┐
+        q_0: ┤ k2r ├┤0       ├┤ k1r ├
+             ├─────┤│  Equiv │├─────┤
+        q_1: ┤ k2l ├┤1       ├┤ k1l ├
+             └─────┘└────────┘└─────┘
+
+    Finally, all adjacent single-qubit unitaries between the 2-qubit gates are merged,
+    reducing the total from 24 to at most 8 single-qubit gates:
+
+    .. parsed-literal::
+
+             ┌──────┐┌───────────┐┌──────┐┌───────────┐┌──────┐┌───────────┐┌──────┐
+        q_0: ┤ U1_r ├┤0          ├┤ U2_r ├┤0          ├┤ U3_r ├┤0          ├┤ U4_r ├
+             ├──────┤│  Equiv(a) │├──────┤│  Equiv(b) │├──────┤│  Equiv(c) │├──────┤
+        q_1: ┤ U1_l ├┤1          ├┤ U2_l ├┤1          ├┤ U3_l ├┤1          ├┤ U4_l ├
+             └──────┘└───────────┘└──────┘└───────────┘└──────┘└───────────┘└──────┘
     """
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):


### PR DESCRIPTION
### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->

**Fix #16350: Update TwoQubitControlledUDecomposer documentation**

The documentation for `TwoQubitControlledUDecomposer` was not updated after the class received a significant update in #16123.

This PR updates the docstring to accurately describe the current behavior: the decomposer now synthesizes a general two-qubit unitary using **at most 8 single-qubit unitary gates** (in the general case where 3 two-qubit gates are needed), down from the previous 24. This reduction is achieved by multiplying adjacent 1-qubit unitary matrices between the 2-qubit gates, rather than decomposing each one independently.

**Screenshot of generated docs (`tox -e docs`):**

<img width="1458" height="854" alt="image" src="https://github.com/user-attachments/assets/43aa2fca-9021-4989-83f6-9625f91e7c20" />
