### PR TITLE
Add docs for TwoQubitControlledUDecomposer

### DIFF
--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -265,9 +265,8 @@ class TwoQubitWeylDecomposition:
 
 
 class TwoQubitControlledUDecomposer:
-    r"""Decompose a two-qubit unitary in terms of a desired two-qubit gate
-    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` that is locally equivalent to an
-    :class:`.RXXGate`.
+    r"""Decompose a general two-qubit unitary in terms of a target two-qubit gate,
+    that is locally equivalent to an :class:`.RXXGate`.
 
     **Synthesis algorithm**
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -272,7 +272,8 @@ class TwoQubitControlledUDecomposer:
     **Synthesis algorithm**
 
     Any two-qubit unitary :math:`U` can be written, through its canonical (Weyl) decomposition
-    [1], as a Weyl gate :math:`U_d(a, b, c)` surrounded by four single-qubit gates:
+    (see :class:`.TwoQubitWeylDecomposition`), as a Weyl gate :math:`U_d(a, b, c)` surrounded by
+    four single-qubit gates:
 
     .. code-block:: text
 
@@ -331,16 +332,18 @@ class TwoQubitControlledUDecomposer:
         q_1: ┤ d2l ├┤1          ├┤ d1l ├┤1          ├┤ e1l ├┤1          ├┤ f1l ├
              └─────┘└───────────┘└─────┘└───────────┘└─────┘└───────────┘└─────┘
 
+    Here ``Equiv(a)``, ``Equiv(b)`` and ``Equiv(c)`` are the user-supplied
+    ``rxx_equivalent_gate`` (the gate locally equivalent to :class:`.RXXGate`) realizing the
+    :math:`R_{XX}(a)`, :math:`R_{XX}(b)` and :math:`R_{XX}(c)` rotations, and the remaining
+    boxes are the consolidated single-qubit gates.
+
     The number of two-qubit gates actually emitted depends on the Weyl parameters of the
     target: rotations with a vanishing angle are dropped, so unitaries that are closer to the
     identity or to a single :class:`.RXXGate` use one or two applications of
     ``rxx_equivalent_gate`` instead of three.
 
-    References:
-        1. B. Kraus, J. I. Cirac, *Optimal Creation of Entanglement Using a Two-Qubit Gate*,
-           `arXiv:quant-ph/0011050 <https://arxiv.org/abs/quant-ph/0011050>`_
-
     """
+
     # Docs generated with assistance from Claude Opus 4.8 (Claude Code).
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -377,7 +377,7 @@ class TwoQubitControlledUDecomposer:
         self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
-    def __call__(  # TODO: add support for the approximate and use_dag arguments
+    def __call__(
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
         r"""Decompose a two-qubit ``unitary`` using the :class:`.TwoQubitControlledUDecomposer`.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -339,7 +339,7 @@ class TwoQubitControlledUDecomposer:
 
     The number of two-qubit gates actually emitted depends on the Weyl parameters of the
     target: rotations with a vanishing angle are dropped, so unitaries that are closer to a
-    single :class:`.RXXGate` use one or two applications of ``rxx_equivalent_gate`` instead
+    single or two instances of :class:`.RXXGate` use one or two applications of ``rxx_equivalent_gate`` respectively instead
     of three. A target close to the identity will use no applications of it.
 
     """

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -377,13 +377,17 @@ class TwoQubitControlledUDecomposer:
         self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
-    def __call__(  # noqa: D417 TODO: Add support for the undocumented arguments
+    def __call__(  # TODO: add support for the approximate and use_dag arguments
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
         r"""Decompose a two-qubit ``unitary`` using the :class:`.TwoQubitControlledUDecomposer`.
 
         Args:
             unitary: :math:`4 \times 4` unitary to synthesize.
+            approximate: Currently not used by this decomposer; accepted for signature
+                compatibility with the other two-qubit decomposers. Reserved for future use.
+            use_dag: Currently not used by this decomposer; accepted for signature
+                compatibility with the other two-qubit decomposers. Reserved for future use.
             atol: Absolute tolerance for checking angles of the single-qubit unitaries when
                 simplifying the returned circuit [Default: 1e-12].
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -338,12 +338,11 @@ class TwoQubitControlledUDecomposer:
     boxes are the consolidated single-qubit gates.
 
     The number of two-qubit gates actually emitted depends on the Weyl parameters of the
-    target: rotations with a vanishing angle are dropped, so unitaries that are closer to the
-    identity or to a single :class:`.RXXGate` use one or two applications of
-    ``rxx_equivalent_gate`` instead of three.
+    target: rotations with a vanishing angle are dropped, so unitaries that are closer to a
+    single :class:`.RXXGate` use one or two applications of ``rxx_equivalent_gate`` instead
+    of three. A target close to the identity will use no applications of it.
 
     """
-
     # Docs generated with assistance from Claude Opus 4.8 (Claude Code).
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
@@ -377,18 +376,20 @@ class TwoQubitControlledUDecomposer:
         self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
-    def __call__(  # noqa: D417 TODO: Add support for the undocumented arguments
+    def __call__( # noqa: D417 TODO: Add support for the undocumented arguments
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
-        """Returns the Weyl decomposition in circuit form.
+        r"""Decompose a two-qubit ``unitary`` using the :class:`.TwoQubitControlledUDecomposer`.
 
         Args:
-            unitary (Operator or ndarray): :math:`4 \times 4` unitary to synthesize.
+            unitary: :math:`4 \times 4` unitary to synthesize.
+            atol: Absolute tolerance for checking angles of the single-qubit unitaries when
+                simplifying the returned circuit [Default: 1e-12].
 
         Returns:
             QuantumCircuit: Synthesized quantum circuit.
 
-        Note: atol is passed to OneQubitEulerDecomposer.
+        Note: atol is passed to :class:`.OneQubitEulerDecomposer`.
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -273,7 +273,7 @@ class TwoQubitControlledUDecomposer:
 
     Any two-qubit unitary :math:`U` can be written, through its canonical (Weyl) decomposition
     (see :class:`.TwoQubitWeylDecomposition`), as a Weyl gate :math:`U_d(a, b, c)` surrounded by
-    four single-qubit gates:
+    four single-qubit unitary gates:
 
     .. code-block:: text
 
@@ -322,7 +322,7 @@ class TwoQubitControlledUDecomposer:
     rotation angle. After every rotation is expanded, all single-qubit gates that fall between
     two consecutive two-qubit gates are multiplied together and consolidated, so the
     synthesized circuit uses at most three applications of ``rxx_equivalent_gate`` and at most
-    eight single-qubit gates:
+    eight single-qubit unitary gates:
 
     .. code-block:: text
 
@@ -335,7 +335,7 @@ class TwoQubitControlledUDecomposer:
     Here ``Equiv(a)``, ``Equiv(b)`` and ``Equiv(c)`` are the user-supplied
     ``rxx_equivalent_gate`` (the gate locally equivalent to :class:`.RXXGate`) realizing the
     :math:`R_{XX}(a)`, :math:`R_{XX}(b)` and :math:`R_{XX}(c)` rotations, and the remaining
-    boxes are the consolidated single-qubit gates.
+    boxes are the consolidated single-qubit unitary gates.
 
     The number of two-qubit gates actually emitted depends on the Weyl parameters of the
     target: rotations with a vanishing angle are dropped, so unitaries that are closer to a

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -343,6 +343,7 @@ class TwoQubitControlledUDecomposer:
     of three. A target close to the identity will use no applications of it.
 
     """
+
     # Docs generated with assistance from Claude Opus 4.8 (Claude Code).
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
@@ -376,7 +377,7 @@ class TwoQubitControlledUDecomposer:
         self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
-    def __call__( # noqa: D417 TODO: Add support for the undocumented arguments
+    def __call__(  # noqa: D417 TODO: Add support for the undocumented arguments
         self, unitary: Operator | np.ndarray, approximate=False, use_dag=False, *, atol=DEFAULT_ATOL
     ) -> QuantumCircuit:
         r"""Decompose a two-qubit ``unitary`` using the :class:`.TwoQubitControlledUDecomposer`.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -265,13 +265,86 @@ class TwoQubitWeylDecomposition:
 
 
 class TwoQubitControlledUDecomposer:
-    r"""Decompose two-qubit unitary in terms of a desired
-    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
-    gate that is locally equivalent to an :class:`.RXXGate`."""
+    r"""Decompose a two-qubit unitary in terms of a desired two-qubit gate
+    :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` that is locally equivalent to an
+    :class:`.RXXGate`.
+
+    **Synthesis algorithm**
+
+    Any two-qubit unitary :math:`U` can be written, through its canonical (Weyl) decomposition
+    [1], as a Weyl gate :math:`U_d(a, b, c)` surrounded by four single-qubit gates:
+
+    .. code-block:: text
+
+             ┌─────┐┌───────┐┌─────┐
+        q_0: ┤ c2r ├┤0      ├┤ c1r ├
+             ├─────┤│  Weyl │├─────┤
+        q_1: ┤ c2l ├┤1      ├┤ c1l ├
+             └─────┘└───────┘└─────┘
+
+    The Weyl gate factorizes into a product of three two-qubit rotations,
+    :math:`U_d(a, b, c) = R_{XX}(a)\, R_{YY}(b)\, R_{ZZ}(c)`:
+
+    .. code-block:: text
+
+             ┌─────────┐┌─────────┐
+        q_0: ┤0        ├┤0        ├─■──────
+             │  Rxx(a) ││  Ryy(b) │ │ZZ(c)
+        q_1: ┤1        ├┤1        ├─■──────
+             └─────────┘└─────────┘
+
+    The :math:`R_{YY}` and :math:`R_{ZZ}` rotations are then mapped onto :math:`R_{XX}`
+    rotations using single-qubit basis changes. With
+    :math:`R_{YY}(b) = (S^\dagger \otimes S^\dagger)\, R_{XX}(b)\, (S \otimes S)`:
+
+    .. code-block:: text
+
+             ┌─────┐┌─────────┐┌───┐
+        q_0: ┤ Sdg ├┤0        ├┤ S ├
+             ├─────┤│  Rxx(b) │├───┤
+        q_1: ┤ Sdg ├┤1        ├┤ S ├
+             └─────┘└─────────┘└───┘
+
+    and :math:`R_{ZZ}(c) = (H \otimes H)\, R_{XX}(c)\, (H \otimes H)`:
+
+    .. code-block:: text
+
+             ┌───┐┌─────────┐┌───┐
+        q_0: ┤ H ├┤0        ├┤ H ├
+             ├───┤│  Rxx(c) │├───┤
+        q_1: ┤ H ├┤1        ├┤ H ├
+             └───┘└─────────┘└───┘
+
+    Finally, each :math:`R_{XX}` rotation is realized with the user-supplied gate that is
+    locally equivalent to :class:`.RXXGate` (the ``rxx_equivalent_gate``), wrapped by the
+    single-qubit gates that account for the local equivalence and for any scaling of the
+    rotation angle. After every rotation is expanded, all single-qubit gates that fall between
+    two consecutive two-qubit gates are multiplied together and consolidated, so the
+    synthesized circuit uses at most three applications of ``rxx_equivalent_gate`` and at most
+    eight single-qubit gates:
+
+    .. code-block:: text
+
+             ┌─────┐┌───────────┐┌─────┐┌───────────┐┌─────┐┌───────────┐┌─────┐
+        q_0: ┤ d2r ├┤0          ├┤ d1r ├┤0          ├┤ e1r ├┤0          ├┤ f1r ├
+             ├─────┤│  Equiv(a) │├─────┤│  Equiv(b) │├─────┤│  Equiv(c) │├─────┤
+        q_1: ┤ d2l ├┤1          ├┤ d1l ├┤1          ├┤ e1l ├┤1          ├┤ f1l ├
+             └─────┘└───────────┘└─────┘└───────────┘└─────┘└───────────┘└─────┘
+
+    The number of two-qubit gates actually emitted depends on the Weyl parameters of the
+    target: rotations with a vanishing angle are dropped, so unitaries that are closer to the
+    identity or to a single :class:`.RXXGate` use one or two applications of
+    ``rxx_equivalent_gate`` instead of three.
+
+    References:
+        1. B. Kraus, J. I. Cirac, *Optimal Creation of Entanglement Using a Two-Qubit Gate*,
+           `arXiv:quant-ph/0011050 <https://arxiv.org/abs/quant-ph/0011050>`_
+
+    """
+    # Docs generated with assistance from Claude Opus 4.8 (Claude Code).
 
     def __init__(self, rxx_equivalent_gate: type[Gate], euler_basis: str = "ZXZ"):
-        r"""Initialize the KAK decomposition.
-
+        r"""
         Args:
             rxx_equivalent_gate: Gate that is locally equivalent to an :class:`.RXXGate`:
                 :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}` gate.
@@ -285,6 +358,8 @@ class TwoQubitControlledUDecomposer:
 
         Raises:
             QiskitError: If the gate is not locally equivalent to an :class:`.RXXGate`.
+
+        .. automethod:: __call__
         """
         if rxx_equivalent_gate._standard_gate is not None:
             self._inner_decomposer = two_qubit_decompose.TwoQubitControlledUDecomposer(


### PR DESCRIPTION
Fix #16350

* Add docs for TwoQubitControlledUDecomposer describing the underlying algorithm without explicit implementation details
* Include the docs for the __call__ method
* remove confusing mention in the __init__ method "Initialize the KAK decomposition"

<img width="1492" height="1710" alt="image" src="https://github.com/user-attachments/assets/0f1b0ac4-8447-4938-b95f-6fcc9418e9c0" />
<img width="1462" height="1336" alt="image" src="https://github.com/user-attachments/assets/52fb582f-b8fe-44c0-81a0-2756d557d634" />
<img width="1466" height="764" alt="image" src="https://github.com/user-attachments/assets/33201794-fbfd-436e-b881-837659fa9020" />


### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Code

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
