### PR TITLE
Warn when PauliEvolutionGate matrix ignores synthesis

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -329,8 +329,6 @@ class PauliEvolutionGate(Gate):
         """Unroll, where the default synthesis is matrix based."""
         self.definition = self.synthesis.synthesize(self)
 
-    # AI-assisted change: this warning path was drafted with OpenAI Codex (GPT-5) and then
-    # manually reviewed against the exact-vs-synthesized semantics in issue #16366.
     def _warn_if_ignoring_approximate_synthesis(self) -> None:
         """Warn when matrix evaluation bypasses an explicitly requested approximation."""
         if not self._explicit_synthesis:

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import warnings
 import numpy as np
 import scipy as sc
 
@@ -132,6 +133,7 @@ class PauliEvolutionGate(Gate):
             synthesis: A synthesis strategy. If None, the default synthesis is the Lie-Trotter
                 product formula with a single repetition.
         """
+        explicit_synthesis = synthesis is not None
         if isinstance(operator, list):
             operator = [_to_sparse_op(op) for op in operator]
         else:
@@ -163,6 +165,8 @@ class PauliEvolutionGate(Gate):
             synthesis = LieTrotter()
 
         self.synthesis = synthesis
+        self._explicit_synthesis = explicit_synthesis
+        self._ignored_approximate_synthesis_warned = False
 
     @property
     def time(self) -> ParameterValueType:
@@ -185,12 +189,19 @@ class PauliEvolutionGate(Gate):
     def to_matrix(self) -> np.ndarray:
         """Return the matrix :math:`e^{-it H}` as ``numpy.ndarray``.
 
+        If an approximate synthesis was explicitly requested when constructing this gate,
+        this method still returns the exact matrix exponential and warns that the requested
+        synthesis is ignored. Use :attr:`definition`, :meth:`decompose`, or ``transpile``
+        to obtain the synthesized circuit instead.
+
         Returns:
             The matrix this gate represents.
 
         Raises:
             ValueError: If the ``time`` parameters is not numeric.
         """
+        self._warn_if_ignoring_approximate_synthesis()
+
         # check the parameter is numeric, otherwise raise an error
         if isinstance(self.time, ParameterExpression):
             try:
@@ -223,7 +234,9 @@ class PauliEvolutionGate(Gate):
 
     def inverse(self, annotated: bool = False):
         """Return the inverse, which is obtained by flipping the sign of the evolution time."""
-        return PauliEvolutionGate(self.operator, -self.time, synthesis=self.synthesis)
+        gate = PauliEvolutionGate(self.operator, -self.time, synthesis=self.synthesis)
+        gate._explicit_synthesis = self._explicit_synthesis
+        return gate
 
     def power(self, exponent: float, annotated: bool = False) -> Gate:
         """Raise this gate to the power of ``exponent``.
@@ -240,7 +253,9 @@ class PauliEvolutionGate(Gate):
         Returns:
             An operation implementing ``gate^exponent``.
         """
-        return PauliEvolutionGate(self.operator, self.time * exponent, synthesis=self.synthesis)
+        gate = PauliEvolutionGate(self.operator, self.time * exponent, synthesis=self.synthesis)
+        gate._explicit_synthesis = self._explicit_synthesis
+        return gate
 
     def _return_repeat(self, exponent: float) -> PauliEvolutionGate:
         return self.power(exponent)  # same implementation
@@ -306,11 +321,37 @@ class PauliEvolutionGate(Gate):
         else:
             operator = extend_op(self.operator)
 
-        return PauliEvolutionGate(operator, self.time, label, synthesis=self.synthesis)
+        gate = PauliEvolutionGate(operator, self.time, label, synthesis=self.synthesis)
+        gate._explicit_synthesis = self._explicit_synthesis
+        return gate
 
     def _define(self):
         """Unroll, where the default synthesis is matrix based."""
         self.definition = self.synthesis.synthesize(self)
+
+    # AI-assisted change: this warning path was drafted with OpenAI Codex (GPT-5) and then
+    # manually reviewed against the exact-vs-synthesized semantics in issue #16366.
+    def _warn_if_ignoring_approximate_synthesis(self) -> None:
+        """Warn when matrix evaluation bypasses an explicitly requested approximation."""
+        if not self._explicit_synthesis:
+            return
+        if self._ignored_approximate_synthesis_warned:
+            return
+
+        from qiskit.synthesis.evolution.product_formula import ProductFormula
+
+        if not isinstance(self.synthesis, ProductFormula):
+            return
+
+        self._ignored_approximate_synthesis_warned = True
+        warnings.warn(
+            "PauliEvolutionGate.to_matrix() returns the exact evolution exp(-itH) and "
+            f"ignores the explicitly requested approximate synthesis "
+            f"{self.synthesis.__class__.__name__}. Use .definition, .decompose(), or "
+            "transpile(...) to obtain the synthesized circuit.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     def validate_parameter(self, parameter: ParameterValueType) -> ParameterValueType:
         """Gate parameters should be int, float, or ParameterExpression"""

--- a/releasenotes/notes/pauli-evolution-matrix-warning-0b5ff605335dca3b.yaml
+++ b/releasenotes/notes/pauli-evolution-matrix-warning-0b5ff605335dca3b.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    ``PauliEvolutionGate.to_matrix()`` and ``Operator(...)`` now emit a
+    warning when they evaluate a gate with an explicitly requested approximate
+    product-formula synthesis such as :class:`.LieTrotter` or
+    :class:`.SuzukiTrotter`. The returned matrix is still the exact
+    :math:`e^{-itH}`, but the evaluation no longer silently ignores the
+    user-specified approximate synthesis. See
+    `#16366 <https://github.com/Qiskit/qiskit/issues/16366>`__.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -104,8 +104,6 @@ class TestEvolutionGate(QiskitTestCase):
         with self.assertRaises(ValueError):
             _ = evo.to_matrix()
 
-    # AI-assisted tests: these warning regressions were drafted with OpenAI Codex (GPT-5)
-    # and then checked against the direct gate and circuit Operator paths from issue #16366.
     def test_to_matrix_warns_for_explicit_approximate_synthesis(self):
         """Test to_matrix warns when it ignores an explicitly requested approximation."""
         evo = PauliEvolutionGate(X + Z, time=0.5, synthesis=LieTrotter(reps=1))
@@ -168,6 +166,29 @@ class TestEvolutionGate(QiskitTestCase):
             _ = evo.to_matrix()
 
         self.assertEqual(self._matching_approximate_synthesis_warnings(caught), [])
+
+    @data(
+        ("inverse", lambda gate: gate.inverse()),
+        ("power", lambda gate: gate.power(2)),
+        ("control", lambda gate: gate.control()),
+    )
+    @unpack
+    def test_derived_gates_warn_for_explicit_approximate_synthesis(self, _name, derive):
+        """Test derived gates preserve the warning behavior for explicit approximations."""
+        base = PauliEvolutionGate(X + Z, time=0.5, synthesis=LieTrotter(reps=1))
+        derived = derive(base)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = Operator(derived)
+
+        caught = self._matching_approximate_synthesis_warnings(caught)
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, UserWarning)
+        self.assertIn(
+            "ignores the explicitly requested approximate synthesis LieTrotter",
+            str(caught[0].message),
+        )
 
     def test_reorder_paulis_invariant(self):
         """

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -13,6 +13,7 @@
 """Test the evolution gate."""
 
 from itertools import permutations
+import warnings
 
 import unittest
 import numpy as np
@@ -60,6 +61,16 @@ class TestEvolutionGate(QiskitTestCase):
 
         self.assertTrue(Operator(gate).equiv(exact_gate))
 
+    @staticmethod
+    def _matching_approximate_synthesis_warnings(caught):
+        """Return only the warnings emitted for ignored approximate synthesis."""
+        return [
+            warning
+            for warning in caught
+            if warning.category is UserWarning
+            and "ignores the explicitly requested approximate synthesis" in str(warning.message)
+        ]
+
     def test_matrix_decomposition(self):
         """Test the matrix decomposition."""
         op = (X ^ X ^ X) + (Y ^ Y ^ Y) + (Z ^ Z ^ Z)
@@ -92,6 +103,71 @@ class TestEvolutionGate(QiskitTestCase):
         evo = PauliEvolutionGate(Z, time=Parameter("time"))
         with self.assertRaises(ValueError):
             _ = evo.to_matrix()
+
+    # AI-assisted tests: these warning regressions were drafted with OpenAI Codex (GPT-5)
+    # and then checked against the direct gate and circuit Operator paths from issue #16366.
+    def test_to_matrix_warns_for_explicit_approximate_synthesis(self):
+        """Test to_matrix warns when it ignores an explicitly requested approximation."""
+        evo = PauliEvolutionGate(X + Z, time=0.5, synthesis=LieTrotter(reps=1))
+
+        with self.assertWarnsRegex(
+            UserWarning, "ignores the explicitly requested approximate synthesis LieTrotter"
+        ):
+            _ = evo.to_matrix()
+
+    def test_operator_warns_for_explicit_approximate_synthesis(self):
+        """Test Operator(gate) warns when it resolves through to_matrix."""
+        evo = PauliEvolutionGate(X + Z, time=0.5, synthesis=LieTrotter(reps=1))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = Operator(evo)
+
+        caught = self._matching_approximate_synthesis_warnings(caught)
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, UserWarning)
+        self.assertIn(
+            "ignores the explicitly requested approximate synthesis LieTrotter",
+            str(caught[0].message),
+        )
+
+    def test_circuit_operator_warns_once_for_explicit_approximate_synthesis(self):
+        """Test Operator(circuit) warns once for a gate with explicit approximate synthesis."""
+        evo = PauliEvolutionGate(X + Z, time=0.5, synthesis=LieTrotter(reps=1))
+        qc = QuantumCircuit(1)
+        qc.append(evo, [0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = Operator(qc)
+
+        caught = self._matching_approximate_synthesis_warnings(caught)
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, UserWarning)
+        self.assertIn(
+            "ignores the explicitly requested approximate synthesis LieTrotter",
+            str(caught[0].message),
+        )
+
+    def test_to_matrix_does_not_warn_for_default_synthesis(self):
+        """Test the default synthesis remains silent for matrix evaluation."""
+        evo = PauliEvolutionGate(X + Z, time=0.5)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = evo.to_matrix()
+
+        self.assertEqual(self._matching_approximate_synthesis_warnings(caught), [])
+
+    def test_to_matrix_does_not_warn_for_exact_synthesis(self):
+        """Test exact synthesis choices do not warn for matrix evaluation."""
+        evo = PauliEvolutionGate(X + Z, time=0.5, synthesis=MatrixExponential())
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _ = evo.to_matrix()
+
+        self.assertEqual(self._matching_approximate_synthesis_warnings(caught), [])
 
     def test_reorder_paulis_invariant(self):
         """


### PR DESCRIPTION
Problem

PauliEvolutionGate has two materialization paths today.

`to_matrix()` computes the exact `exp(-itH)` from the stored operator.
`definition` delegates to `self.synthesis.synthesize(self)`, which can be an approximate product-formula circuit.

That makes an explicitly requested approximate synthesis easy to lose without any signal. A gate built with `LieTrotter(reps=1)` returns the exact unitary through `Operator(...)` and `to_matrix()`, while `Operator(gate.definition)` returns the synthesized approximation.

This change keeps the exact semantics of `PauliEvolutionGate`, but stops silently ignoring an explicit approximate synthesis request.

What changed

`PauliEvolutionGate.to_matrix()` now emits a `UserWarning` when the gate was constructed with an explicit approximate `ProductFormula` synthesis such as `LieTrotter`, `SuzukiTrotter`, or `QDrift`.

The returned matrix stays exact. The warning points callers to `.definition`, `.decompose()`, or `transpile(...)` when they want the synthesized circuit.

The explicit-synthesis flag is also preserved by `inverse()`, `power()`, and `control()` so derived gates keep the same warning behavior.

I also removed AI-attribution comments from the source and test files. The PR template disclosure still covers tool usage without adding repo-local prose noise.

Tests

I added regression coverage for:

- direct `to_matrix()` on a gate with explicit approximate synthesis
- `Operator(gate)` on that same gate
- `Operator(circuit)` for a circuit containing that gate
- the default synthesis path staying silent
- exact synthesis choices such as `MatrixExponential()` staying silent
- derived gates from `inverse()`, `power()`, and `control()` preserving the warning behavior

Validation

WSL test environment:
Python 3.12 editable install in the repository `.venv`

Command:
python -m unittest test.python.circuit.library.test_evolution_gate

Result:
84 tests passed, 1 skipped

Fixes #16366

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description:
  OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code:
  OpenAI Codex (GPT-5)