### PR TITLE
Related to Qiskit/qiskit-cpp#146（Add C API for circuit parameter symbol names）

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -97,6 +97,7 @@ mod circuit {
             export_fn!(qk_circuit_draw),
             export_fn!(qk_circuit_global_phase),
             export_fn!(qk_circuit_set_global_phase),
+            export_fn!(qk_circuit_param_symbol_name),
         ]
     });
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -382,6 +382,53 @@ pub unsafe extern "C" fn qk_circuit_num_param_symbols(circuit: *const CircuitDat
 }
 
 /// @ingroup QkCircuit
+/// Get the name of an unbound symbol in ``QkParam`` objects in the circuit.
+///
+/// The parameter-symbol order is deterministic and matches Qiskit's canonical parameter order.
+///
+/// @param circuit A pointer to the circuit.
+/// @param index The index of the parameter symbol name to read.
+///
+/// @return A pointer to the symbol name, or a null pointer if ``index`` is out of range. The
+///     returned string must be freed with :c:func:`qk_str_free`.
+///
+/// # Example
+///
+/// ```c
+/// QkCircuit *qc = qk_circuit_new(1, 0);
+/// QkParam *theta = qk_param_new_symbol("theta");
+///
+/// uint32_t q0[1] = {0};
+/// const QkParam *rx_param[1] = {theta};
+///
+/// qk_circuit_parameterized_gate(qc, QkGate_RX, q0, rx_param);
+///
+/// char *name = qk_circuit_param_symbol_name(qc, 0); // == "theta"
+/// qk_str_free(name);
+///
+/// qk_param_free(theta);
+/// qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_param_symbol_name(
+    circuit: *const CircuitData,
+    index: usize,
+) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    let Some(symbol) = circuit.parameters().get(index) else {
+        return std::ptr::null_mut();
+    };
+
+    CString::new(symbol.repr(false)).unwrap().into_raw()
+}
+
+/// @ingroup QkCircuit
 /// Get the global phase of the circuit.
 ///
 /// This function returns a copy of the circuit's global phase

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1199,6 +1199,23 @@ static int test_circuit_draw(void) {
     return Ok;
 }
 
+static int expect_param_symbol_name(const QkCircuit *qc, size_t index, const char *expected) {
+    char *name = qk_circuit_param_symbol_name(qc, index);
+    if (name == NULL) {
+        printf("Expected parameter symbol %s at index %zu, found NULL\n", expected, index);
+        return NullptrError;
+    }
+
+    int result = Ok;
+    if (strcmp(name, expected) != 0) {
+        printf("Expected parameter symbol %s at index %zu, found %s\n", expected, index, name);
+        result = EqualityError;
+    }
+
+    qk_str_free(name);
+    return result;
+}
+
 static int test_parameterized_circuit(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     QkParam *x = qk_param_new_symbol("x");
@@ -1232,6 +1249,22 @@ static int test_parameterized_circuit(void) {
         goto cleanup;
     }
 
+    result = expect_param_symbol_name(qc, 0, "somey longery namey");
+    if (result != Ok) {
+        goto cleanup;
+    }
+    result = expect_param_symbol_name(qc, 1, "x");
+    if (result != Ok) {
+        goto cleanup;
+    }
+    char *missing = qk_circuit_param_symbol_name(qc, 2);
+    if (missing != NULL) {
+        printf("Expected no parameter symbol at index 2, found %s\n", missing);
+        qk_str_free(missing);
+        result = EqualityError;
+        goto cleanup;
+    }
+
     // check number of gates
     size_t num_gates = qk_circuit_num_instructions(qc);
     if (num_gates != 3) {
@@ -1243,6 +1276,79 @@ static int test_parameterized_circuit(void) {
 cleanup:
     qk_param_free(x);
     qk_param_free(y);
+    qk_circuit_free(qc);
+    return result;
+}
+
+static int test_circuit_param_symbol_names_expression(void) {
+    QkCircuit *qc = qk_circuit_new(1, 0);
+    QkParam *theta = qk_param_new_symbol("theta");
+    QkParam *phi = qk_param_new_symbol("phi");
+    QkParam *expr = qk_param_zero();
+
+    int result = Ok;
+    if (qk_param_add(expr, theta, phi) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    uint32_t q0[1] = {0};
+    const QkParam *rx_param[1] = {expr};
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q0, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    size_t num_symbols = qk_circuit_num_param_symbols(qc);
+    if (num_symbols != 2) {
+        result = EqualityError;
+        printf("Expected 2 symbols, found %zu\n", num_symbols);
+        goto cleanup;
+    }
+
+    result = expect_param_symbol_name(qc, 0, "phi");
+    if (result != Ok) {
+        goto cleanup;
+    }
+    result = expect_param_symbol_name(qc, 1, "theta");
+
+cleanup:
+    qk_param_free(theta);
+    qk_param_free(phi);
+    qk_param_free(expr);
+    qk_circuit_free(qc);
+    return result;
+}
+
+static int test_circuit_param_symbol_names_numeric_only(void) {
+    QkCircuit *qc = qk_circuit_new(1, 0);
+    QkParam *angle = qk_param_from_double(0.5);
+
+    uint32_t q0[1] = {0};
+    const QkParam *rx_param[1] = {angle};
+
+    int result = Ok;
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q0, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    size_t num_symbols = qk_circuit_num_param_symbols(qc);
+    if (num_symbols != 0) {
+        result = EqualityError;
+        printf("Expected 0 symbols, found %zu\n", num_symbols);
+        goto cleanup;
+    }
+
+    char *name = qk_circuit_param_symbol_name(qc, 0);
+    if (name != NULL) {
+        printf("Expected no parameter symbol at index 0, found %s\n", name);
+        qk_str_free(name);
+        result = EqualityError;
+    }
+
+cleanup:
+    qk_param_free(angle);
     qk_circuit_free(qc);
     return result;
 }
@@ -1460,6 +1566,8 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_get_instruction_params);
     num_failed += RUN_TEST(test_instruction_params_ownership);
     num_failed += RUN_TEST(test_parameterized_circuit);
+    num_failed += RUN_TEST(test_circuit_param_symbol_names_expression);
+    num_failed += RUN_TEST(test_circuit_param_symbol_names_numeric_only);
     num_failed += RUN_TEST(test_circuit_global_phase);
     num_failed += RUN_TEST(test_circuit_to_dag);
     num_failed += RUN_TEST(test_pbc_instructions);


### PR DESCRIPTION
## Summary

This PR adds a Qiskit C API accessor for enumerating circuit parameter symbol names: `char *qk_circuit_param_symbol_name(const QkCircuit *circuit, size_t index);`. This is needed to support [Qiskit C++ Issue #146: Parameter-Aware OpenQASM 3 Export
#155](https://github.com/Qiskit/qiskit-cpp/pull/155), which requires OpenQASM 3 export for parameterized qiskit-cpp circuits.

## Fix

The final implementation follows the full long-term plan of C API symbol-enumeration: instead of relying on fragile wrapper-side parsing to recover parameter names, it adds a C API symbol-enumeration hook in Qiskit and uses that from qiskit-cpp. **Please take into consideration that pure qiskit-cpp-only fix without Qiskit changes is possible, but only by using C++ wrapper-side parameter tracking, and it is less robust for circuits reconstructed from C API state.**

On the qiskit-cpp side, `src/qasm3/qasm3_exporter.hpp` now owns the exporter. The default `qasm3::dumps(circuit)` path asks the C API for the number of free symbols, enumerates their names with `qk_circuit_param_symbol_name(...)`, and emits declarations such as:

```qasm
input float[64] theta;
```

Those declarations are written after:

```qasm
OPENQASM 3.0;
include "stdgates.inc";
```

and before qubit, bit, and operation lines. Gate parameters themselves are still serialized with `qk_param_str()`, so numeric parameters, symbolic parameters, and expressions keep the C API's existing formatting behavior.

The explicit API:

```cpp
Qiskit::qasm3::dumps(circuit, {"theta", "phi"});
```

is also supported. It validates that the caller-provided names match the circuit's free-parameter count and rejects empty or duplicate names.

On the Qiskit C API side, the fix adds:

```c
char *qk_circuit_param_symbol_name(const QkCircuit *circuit, size_t index);
```

This complements the existing `qk_circuit_num_param_symbols(...)`. The new function returns an owned C string that must be freed with `qk_str_free`, and returns `NULL` when the index is out of range. Internally it uses `CircuitData::parameters()`, giving qiskit-cpp the same canonical deterministic parameter order that Qiskit already tracks in the Rust circuit data.

## Coverage

The qiskit-cpp tests cover the expected exporter behavior:

- non-parameterized QASM output remains valid
- single symbolic parameter declarations
- multiple parameter declarations in canonical order
- parameter expressions such as `theta + phi`
- numeric-only parameters with no `input` declarations
- uppercase `U(...)` emission
- `qasm3::dumps(circuit, names)` explicit-name export
- wrong parameter count, empty name, and duplicate name validation
- compatibility through `QuantumCircuit::to_qasm3()`
- parameterized `compose(...)`
- `append(src[0])` after indexing a parameterized source circuit

The Qiskit C API tests cover the new symbol-name accessor directly:

- symbol count plus names for ordinary parameterized circuits
- expression parameters
- numeric-only parameters
- out-of-range index returning `NULL`

## Result

A parameterized circuit can now export self-contained OpenQASM 3:

```qasm
OPENQASM 3.0;
include "stdgates.inc";
input float[64] theta;
qubit[1] q;
bit[1] c;
rx(theta) q[0];
```

Verification recorded for the final fix:

`qiskit-cpp` verification:

```bash

cmake -S test -B test/build
cmake --build test/build

DYLD_LIBRARY_PATH=/usr/local/anaconda3/lib:/opt/anaconda3/lib \
  ctest -V -C Debug --test-dir test/build
git diff --check
```

Qiskit C API verification, from `qiskit`:

```bash
cargo fmt -p qiskit-cext -p qiskit-cext-vtable
make cheader
make clib
DYLD_LIBRARY_PATH=/usr/local/anaconda3/lib:/opt/anaconda3/lib ctest -V -C Debug --test-dir test/c/build-release
git diff --check
```

The qiskit-cpp suite passed `3/3` and the C API suite passed `27/27`.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [√ ] I used the following tool to generate or modify code: I reviewed the existing code paths, implemented the necessary changes, and verified the update using the commands above. (Drafted with AI assistance)

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
