### PR TITLE
Deprecate legacy WrapAngles registry alias

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -186,7 +186,8 @@ Additional data
 
 .. py:data:: qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY
 
-    A legacy location for :attr:`.WrapAngles.DEFAULT_REGISTRY`.  This path should only be used when
+    A deprecated legacy location for :attr:`.WrapAngles.DEFAULT_REGISTRY`.
+    This path is deprecated as of Qiskit 2.5 and should only be used when
     full compatibility with Qiskit 2.2 is required.
 """
 

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -187,7 +187,7 @@ Additional data
 .. py:data:: qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY
 
     A deprecated legacy location for :attr:`.WrapAngles.DEFAULT_REGISTRY`.
-    This path is deprecated as of Qiskit 2.5 and should only be used when
+    This path is deprecated as of Qiskit 2.6 and should only be used when
     full compatibility with Qiskit 2.2 is required.
 """
 

--- a/qiskit/transpiler/passes/utils/wrap_angles.py
+++ b/qiskit/transpiler/passes/utils/wrap_angles.py
@@ -114,7 +114,7 @@ def __getattr__(name):
     if name == "WRAP_ANGLE_REGISTRY":
         warnings.warn(
             "The path qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY is "
-            "deprecated since Qiskit 2.5 and will be removed in Qiskit 3.0 or later. "
+            "deprecated since Qiskit 2.6 and will be removed in Qiskit 3.0 or later. "
             "Instead, use qiskit.transpiler.passes.WrapAngles.DEFAULT_REGISTRY.",
             category=DeprecationWarning,
             stacklevel=2,

--- a/qiskit/transpiler/passes/utils/wrap_angles.py
+++ b/qiskit/transpiler/passes/utils/wrap_angles.py
@@ -12,6 +12,8 @@
 
 """Wrap angles pass for respecting target angle bounds."""
 
+import warnings
+
 from qiskit.transpiler.basepasses import TransformationPass
 
 from qiskit._accelerate import wrap_angles
@@ -108,7 +110,14 @@ class WrapAngles(TransformationPass):
         return dag
 
 
-# TODO This path is the only valid way to access this global object in Qiskit 2.2, and is documented and
-# preserved by the deprecation policy of that version.  The preferred way to access the object is as
-# `WrapAngles.DEFAULT_REGISTRY` and we should deprecate the old access path for Qiskit 2.4.
-WRAP_ANGLE_REGISTRY = WrapAngles.DEFAULT_REGISTRY
+def __getattr__(name):
+    if name == "WRAP_ANGLE_REGISTRY":
+        warnings.warn(
+            "The path qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY is "
+            "deprecated since Qiskit 2.5 and will be removed in Qiskit 3.0 or later. "
+            "Instead, use qiskit.transpiler.passes.WrapAngles.DEFAULT_REGISTRY.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return WrapAngles.DEFAULT_REGISTRY
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/releasenotes/notes/deprecate-wrap-angle-registry-legacy-path-f1a37ddf63c7b6dd.yaml
+++ b/releasenotes/notes/deprecate-wrap-angle-registry-legacy-path-f1a37ddf63c7b6dd.yaml
@@ -3,6 +3,6 @@ deprecations:
   - |
     The legacy alias
     ``qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY`` is
-    deprecated as of Qiskit 2.5 and will be removed in Qiskit 3.0 or a later
+    deprecated as of Qiskit 2.6 and will be removed in Qiskit 3.0 or a later
     major release. Instead, use
     :attr:`qiskit.transpiler.passes.WrapAngles.DEFAULT_REGISTRY`.

--- a/releasenotes/notes/deprecate-wrap-angle-registry-legacy-path-f1a37ddf63c7b6dd.yaml
+++ b/releasenotes/notes/deprecate-wrap-angle-registry-legacy-path-f1a37ddf63c7b6dd.yaml
@@ -1,0 +1,8 @@
+---
+deprecations:
+  - |
+    The legacy alias
+    ``qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY`` is
+    deprecated as of Qiskit 2.5 and will be removed in Qiskit 3.0 or a later
+    major release. Instead, use
+    :attr:`qiskit.transpiler.passes.WrapAngles.DEFAULT_REGISTRY`.

--- a/test/python/transpiler/test_wrap_angles.py
+++ b/test/python/transpiler/test_wrap_angles.py
@@ -77,8 +77,12 @@ class TestWrapAngles(QiskitTestCase):
         res = wrap_pass(circuit)
         self.assertEqual(res.count_ops()["my_custom"], 12)
 
-    def test_legacy_default_registy(self):
-        """Test that the legacy Qiskit 2.2 import path works for the default registry."""
-        from qiskit.transpiler.passes.utils.wrap_angles import WRAP_ANGLE_REGISTRY
+    def test_legacy_default_registry(self):
+        """Test that the legacy Qiskit 2.2 import path warns and still works."""
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY",
+        ):
+            from qiskit.transpiler.passes.utils.wrap_angles import WRAP_ANGLE_REGISTRY
 
         self.assertIs(WRAP_ANGLE_REGISTRY, WrapAngles.DEFAULT_REGISTRY)


### PR DESCRIPTION
The qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY alias is already documented as a legacy compatibility path for Qiskit 2.2, but today it resolves silently. This change turns that documented migration into an actual public deprecation.

The patch keeps the alias working, but routes access through a module-level __getattr__ so the old path emits a DeprecationWarning and points users to WrapAngles.DEFAULT_REGISTRY. It also updates the targeted test to assert the warning, adds a release note, and aligns the public transpiler-pass docs with the new deprecation status.

Validation:
./.venv/bin/python -m unittest test.python.transpiler.test_wrap_angles

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: GPT-5 Codex
- [x] I used the following tool to generate or modify code: GPT-5 Codex