### PR TITLE
Fix twirling invalid gate list error message

### DIFF
--- a/qiskit/circuit/twirling.py
+++ b/qiskit/circuit/twirling.py
@@ -96,12 +96,12 @@ def pauli_twirl_2q_gates(
                     raise QiskitError(f"The specified gate name {gate_name} is not supported")
                 twirling_std_gate.append(gate)
             else:
-                twirling_gate = getattr(gate, "_standard_gate", None)
+                standard_gate = getattr(gate, "_standard_gate", None)
 
-                if twirling_gate is None:
+                if standard_gate is None:
                     custom_gates.append(gate)
-                elif twirling_gate in NAME_TO_CLASS.values():
-                    twirling_std_gate.append(twirling_gate)
+                elif standard_gate in NAME_TO_CLASS.values():
+                    twirling_std_gate.append(standard_gate)
                 else:
                     custom_gates.append(gate)
         if not custom_gates:

--- a/qiskit/circuit/twirling.py
+++ b/qiskit/circuit/twirling.py
@@ -90,9 +90,10 @@ def pauli_twirl_2q_gates(
         twirling_std_gate = []
         for gate in twirling_gate:
             if isinstance(gate, str):
-                gate = NAME_TO_CLASS.get(gate, None)
+                gate_name = gate
+                gate = NAME_TO_CLASS.get(gate_name, None)
                 if gate is None:
-                    raise QiskitError(f"The specified gate name {twirling_gate} is not supported")
+                    raise QiskitError(f"The specified gate name {gate_name} is not supported")
                 twirling_std_gate.append(gate)
             else:
                 twirling_gate = getattr(gate, "_standard_gate", None)

--- a/test/python/circuit/test_twirling.py
+++ b/test/python/circuit/test_twirling.py
@@ -130,7 +130,7 @@ class TestTwirling(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.swap(0, 1)
         with self.assertRaisesRegex(QiskitError, "The specified gate name swap is not supported"):
-            pauli_twirl_2q_gates(qc, twirling_gate=[CXGate, "swap"])
+            pauli_twirl_2q_gates(qc, twirling_gate=["cx", "swap"])
 
     def test_invalid_class_entry_in_list(self):
         """Test an error is raised with an unsupported string gate in list."""

--- a/test/python/circuit/test_twirling.py
+++ b/test/python/circuit/test_twirling.py
@@ -129,7 +129,7 @@ class TestTwirling(QiskitTestCase):
         """Test an error is raised with an unsupported string gate in list."""
         qc = QuantumCircuit(2)
         qc.swap(0, 1)
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(QiskitError, "The specified gate name swap is not supported"):
             pauli_twirl_2q_gates(qc, twirling_gate=[CXGate, "swap"])
 
     def test_invalid_class_entry_in_list(self):

--- a/test/python/circuit/test_twirling.py
+++ b/test/python/circuit/test_twirling.py
@@ -133,7 +133,7 @@ class TestTwirling(QiskitTestCase):
             pauli_twirl_2q_gates(qc, twirling_gate=["cx", "swap"])
 
     def test_invalid_class_entry_in_list(self):
-        """Test an error is raised with an unsupported string gate in list."""
+        """Test a mixed list accepts supported gate objects."""
         qc = QuantumCircuit(2)
         qc.swap(0, 1)
         res = pauli_twirl_2q_gates(qc, twirling_gate=[SwapGate(), "cx"])


### PR DESCRIPTION
The list-handling branch in pauli_twirl_2q_gates raised the wrong error message for unsupported string gate names. For mixed inputs such as ["cx", "swap"], the exception reported the whole list instead of the unsupported entry.

This change keeps the original string token in the list-normalization path and uses that token in the error. The regression test now exercises the mixed-string input directly and checks the exact message.

Validation
python -m unittest test.python.circuit.test_twirling
python -m ruff check qiskit/circuit/twirling.py test/python/circuit/test_twirling.py

AI/LLM disclosure
I used Codex GPT-5 for code changes and PR text.