### PR TITLE
Have `SynthesizeRZRotations` clear `rsgridsynth` global caches

### DIFF
--- a/crates/synthesis/src/ross_selinger.rs
+++ b/crates/synthesis/src/ross_selinger.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 
 use numpy::PyReadonlyArray2;
 
+use rsgridsynth::clear_caches;
 use rsgridsynth::config::config_from_theta_epsilon;
 use rsgridsynth::gridsynth::gridsynth_gates;
 
@@ -74,6 +75,13 @@ pub fn gridsynth_rz(theta: f64, epsilon: f64) -> PyResult<CircuitData> {
     let phase = if res.global_phase { FRAC_PI_8 } else { 0. };
     let instruction_capacity = res.gates.len();
     circuit_from_string(gates_iter, phase, instruction_capacity)
+}
+
+// The rsgridsynth internally caches results of various computations. However, these results become
+// invalidated if precision changes. Fortunately, rsgridsynth exposes a method to clear (at least
+// some of) these caches.
+pub fn gridsynth_cleanup() {
+    clear_caches();
 }
 
 #[pyfunction]

--- a/crates/synthesis/src/ross_selinger.rs
+++ b/crates/synthesis/src/ross_selinger.rs
@@ -77,9 +77,10 @@ pub fn gridsynth_rz(theta: f64, epsilon: f64) -> PyResult<CircuitData> {
     circuit_from_string(gates_iter, phase, instruction_capacity)
 }
 
-// The rsgridsynth internally caches results of various computations. However, these results become
-// invalidated if precision changes. Fortunately, rsgridsynth exposes a method to clear (at least
-// some of) these caches.
+// rsgridsynth internally caches results of various computations that depend on the
+// number of precision bits. Generally speaking, these caches become invalid when
+// precision changes. Fortunately, rsgridsynth exposes a method to clear some (though not all)
+// of these caches.
 pub fn gridsynth_cleanup() {
     clear_caches();
 }

--- a/crates/transpiler/src/passes/synthesize_rz_rotations.rs
+++ b/crates/transpiler/src/passes/synthesize_rz_rotations.rs
@@ -16,7 +16,7 @@ use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
 use crate::QiskitError;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{OperationRef, Param, StandardGate, add_param};
-use qiskit_synthesis::ross_selinger::gridsynth_rz;
+use qiskit_synthesis::ross_selinger::{gridsynth_cleanup, gridsynth_rz};
 
 const MINIMUM_EPSILON: f64 = 1e-12; // minimum epsilon for synthesis
 
@@ -115,6 +115,12 @@ pub fn py_run_synthesize_rz_rotations(
     if dag.get_op_counts().keys().all(|k| k != "rz") {
         return Ok(());
     }
+
+    // The rsgridsynth internally caches results of various computations. However, these results become
+    // invalidated if precision changes. Fortunately, rsgridsynth exposes a method to clear (at least
+    // some of) these caches. This is not a perfect solution, and probably a major refactoring of
+    // gridsynth would be needed.
+    gridsynth_cleanup();
 
     // Compute error budgets. When approximation degree is used, the total error is
     // computed as 1 - approximation_degree, and the error budget for synthesis and for

--- a/crates/transpiler/src/passes/synthesize_rz_rotations.rs
+++ b/crates/transpiler/src/passes/synthesize_rz_rotations.rs
@@ -116,10 +116,14 @@ pub fn py_run_synthesize_rz_rotations(
         return Ok(());
     }
 
-    // The rsgridsynth internally caches results of various computations. However, these results become
-    // invalidated if precision changes. Fortunately, rsgridsynth exposes a method to clear (at least
-    // some of) these caches. This is not a perfect solution, and probably a major refactoring of
-    // gridsynth would be needed.
+    // rsgridsynth internally caches results of various computations that depend on the
+    // number of precision bits. Generally speaking, these caches become invalid when
+    // precision changes. Fortunately, rsgridsynth exposes a method to clear some (though not all)
+    // of these caches. The current approach is to clear the caches at the start of each run
+    // of SynthesizeRZRotations, while the cached values can be safely reused for all
+    // rotation gates in the circuit.
+    // This is not a complete or perfect solution, so a major refactor of
+    // gridsynth is probably needed.
     gridsynth_cleanup();
 
     // Compute error budgets. When approximation degree is used, the total error is

--- a/releasenotes/notes/fix-synthesize-rz-rotations-with-multiple-error-budgets-1a848d773353e347.yaml
+++ b/releasenotes/notes/fix-synthesize-rz-rotations-with-multiple-error-budgets-1a848d773353e347.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixes an issue when calling the :class:`.SynthesizeRZRotations` transpiler pass
-    multiple times with different error budgets.
+    Fixed an issue where running the :class:`.SynthesizeRZRotations` transpiler pass multiple times
+    with different error budgets could produce incorrect results or trigger internal panics.
 
     See `#16385 <https://github.com/Qiskit/qiskit/issues/16385>`__.

--- a/releasenotes/notes/fix-synthesize-rz-rotations-with-multiple-error-budgets-1a848d773353e347.yaml
+++ b/releasenotes/notes/fix-synthesize-rz-rotations-with-multiple-error-budgets-1a848d773353e347.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue when calling the :class:`.SynthesizeRZRotations` transpiler pass
+    multiple times with different error budgets.
+
+    See `#16385 <https://github.com/Qiskit/qiskit/issues/16385>`__.

--- a/test/python/transpiler/test_synthesize_rz_rotations.py
+++ b/test/python/transpiler/test_synthesize_rz_rotations.py
@@ -161,6 +161,24 @@ class TestSynthesizeRzRotations(QiskitTestCase):
         synthesized = SynthesizeRZRotations()(qc)
         self.assertEqual(synthesized.count_ops().get("t", 0), 1)
 
+    def test_called_with_different_error_budgets(self):
+        """
+        Test SynthesizeRZRotations when called multiple times with different error
+        budgets.
+
+        Regression test of https://github.com/Qiskit/qiskit/issues/16385.
+        """
+        # Each run represents a triple (angle, synthesis error, cache error)
+        runs = [(0.0, 0.5, 0.1), (1.0, 0.1, 0.1), (2.0, 0.5, 0.2), (-1.0, 0.3, 0.4)]
+
+        for angle, synthesis_error, cache_error in runs:
+            qc = QuantumCircuit(1)
+            qc.rz(angle, 0)
+            qct = SynthesizeRZRotations(synthesis_error=synthesis_error, cache_error=cache_error)(
+                qc
+            )
+            self.assertLessEqual(operator_norm_distance(qct, angle), synthesis_error)
+
 
 def operator_norm_distance(circuit, angle):
     """Return the operator norm distance of the circuit to RZ(angle)."""


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### Summary

Fixes #16385. 

The `SynthesizeRZRotations` transpiler pass relies on the Ross–Selinger algorithm as implemented in the `rsgridsynth` package (available at https://github.com/qiskit-community/rsgridsynth). This package uses `dashu` for arbitrary‑precision floating‑point arithmetic, where nearly all numerical computations (e.g., multiplying by constants or taking square roots and logarithms) depend on a global precision context specifying the number of bits of precision.

Although `rsgridsynth` exposes the precision setting as a global variable and provides APIs to modify it, the library also maintains extensive global caches that depend on the current precision. These include, among others: cached value of $\pi$, cached inverses, determinants, and adjoints for grid operations, matrix caches for unitary operations, caches for the DOmega and ZOmega rings, cached Diophantine data, and probably more. When `SynthesizeRZRotations` is invoked multiple times with different values of `epsilon` (which translate into different numbers of precision bits), the previously populated caches generally speaking become invalid. 

Fortunately, `rsgridsynth` does provide a `clear_caches` method that clears several of the most problematic caches (though not all of them). As a mitigation, this PR updates `SynthesizeRZRotations` to explicitly call `clear_caches` at the start of each run, however this is not a complete or an ideal solution. A fully robust fix would likely require a major refactor of `rsgridsynth`.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
