### PR TITLE
Fix MultiplierGate truncated result decomposition

### DIFF
--- a/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/multiplier.py
@@ -198,4 +198,4 @@ class MultiplierGate(Gate):
         # This particular decomposition does not use any ancilla qubits.
         # Note that the transpiler may choose a different decomposition
         # based on the number of ancilla qubits available.
-        self.definition = multiplier_qft_r17(self.num_state_qubits)
+        self.definition = multiplier_qft_r17(self.num_state_qubits, self.num_result_qubits)

--- a/releasenotes/notes/fix-multiplier-gate-truncated-result-16168.yaml
+++ b/releasenotes/notes/fix-multiplier-gate-truncated-result-16168.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed :class:`.MultiplierGate` so that its default decomposition preserves
-    the requested number of result qubits. Previously, decomposing a multiplier
-    with a truncated result register, such as ``MultiplierGate(1, 1)``, could
-    fail because the generated definition used too many qubits. Refer to
-    `#16168 <https://github.com/Qiskit/qiskit/issues/16168>`__.
+    the requested number of result qubits. Previously, it ignored this argument
+    and always decomposed using twice the number of state qubits for the 
+    result qubits.
+    Fixed `#16168 <https://github.com/Qiskit/qiskit/issues/16168>`__.

--- a/releasenotes/notes/fix-multiplier-gate-truncated-result-16168.yaml
+++ b/releasenotes/notes/fix-multiplier-gate-truncated-result-16168.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed :class:`.MultiplierGate` so that its default decomposition preserves
+    the requested number of result qubits. Previously, decomposing a multiplier
+    with a truncated result register, such as ``MultiplierGate(1, 1)``, could
+    fail because the generated definition used too many qubits. Refer to
+    `#16168 <https://github.com/Qiskit/qiskit/issues/16168>`__.

--- a/test/python/circuit/library/test_multipliers.py
+++ b/test/python/circuit/library/test_multipliers.py
@@ -185,6 +185,30 @@ class TestMultiplier(QiskitTestCase):
                 ops = set(synth.count_ops().keys())
                 self.assertIn(expected_op, ops)
 
+    def test_multiplier_gate_decompose_with_custom_result_qubits(self):
+        """Test MultiplierGate.decompose() with non-default num_result_qubits."""
+        cases = (
+            (1, 1),
+            (2, 2),
+            (2, 3),
+            (3, 3),
+            (3, 4),
+            (3, 5),
+        )
+
+        for num_state_qubits, num_result_qubits in cases:
+            with self.subTest(
+                num_state_qubits=num_state_qubits, num_result_qubits=num_result_qubits
+            ):
+                gate = MultiplierGate(num_state_qubits, num_result_qubits)
+                self.assertEqual(gate.num_qubits, 2 * num_state_qubits + num_result_qubits)
+                self.assertEqual(gate.definition.num_qubits, gate.num_qubits)
+
+                circuit = QuantumCircuit(gate.num_qubits)
+                circuit.append(gate, range(gate.num_qubits))
+                decomposed = circuit.decompose()
+                self.assertEqual(decomposed.num_qubits, gate.num_qubits)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  ### Summary
  Fixes #16168.
  `MultiplierGate._define()` now passes the gate's requested `num_result_qubits` to `multiplier_qft_r17()`. Previously, truncated-result multipliers such as `MultiplierGate(1, 1)` generated a full-width definition, causing `QuantumCircuit.decompose()` to fail with a qubit-count mismatch.
  ### Details
  `MultiplierGate` stores the requested result width, but its default decomposition only passed `num_state_qubits` into the synthesis function. Since `multiplier_qft_r17()` defaults to `2 * num_state_qubits` result qubits, the generated definition could be wider than the gate.
  This PR forwards `self.num_result_qubits`, adds regression coverage for several valid truncated widths, and includes a release note.
  ### Tests
  - `python -m unittest test.python.circuit.library.test_multipliers.TestMultiplier.test_multiplier_gate_decompose_with_custom_result_qubits`
  - `python -m unittest test.python.circuit.library.test_multipliers.TestMultiplier.test_plugins`
  ### AI/LLM disclosure
  - [ ] I didn't use LLM tooling, or only used it privately.
  - [x] I used the following tool to help write this PR description: Cursor with GPT-5.5.
  - [x] I used the following tool to generate or modify code: Cursor with GPT-5.5.
  I reviewed and understand the generated guidance, code, tests, and release note before submitting.