### PR TITLE
Removing some triple quotes in documentation 

### DIFF
--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -392,7 +392,7 @@ impl From<Box<Index>> for Expr {
 /// expressions, and it does not make sense to add more outside of Qiskit library code.
 ///
 /// All subclasses are responsible for setting their ``type`` attribute in their ``__init__``, and
-/// should not call the parent initializer."""
+/// should not call the parent initializer.
 #[pyclass(
     eq,
     hash,
@@ -416,7 +416,7 @@ impl PyExpr {
     ///     visitor.accept(expr)
     ///
     /// Subclasses of :class:`Expr` should override this to call the correct virtual method on the
-    /// visitor.  This implements double dispatch with the visitor."""
+    /// visitor.  This implements double dispatch with the visitor.
     /// return visitor.visit_generic(self)
     fn accept<'py>(
         slf: PyRef<'py, Self>,

--- a/crates/circuit/src/classical/expr/var.rs
+++ b/crates/circuit/src/classical/expr/var.rs
@@ -76,7 +76,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Var {
 /// construction of variables for use in programs should use :meth:`Var.new` or
 /// :meth:`.QuantumCircuit.add_var`.
 ///
-/// Variables are immutable after construction, so they can be used as dictionary keys."""
+/// Variables are immutable after construction, so they can be used as dictionary keys.
 #[pyclass(
     eq,
     hash,
@@ -144,7 +144,7 @@ impl PyVar {
     /// this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
     /// new-style classical variable (one that owns its own storage separate to the old
     /// :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
-    /// to uniquely identify it."""
+    /// to uniquely identify it.
     #[getter]
     fn get_var(&self, py: Python) -> PyResult<Py<PyAny>> {
         match &self.0 {
@@ -159,7 +159,7 @@ impl PyVar {
 
     /// The name of the variable.  This is required to exist if the backing :attr:`var` attribute
     /// is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
-    /// an old-style variable."""
+    /// an old-style variable.
     #[getter]
     fn get_name(&self, py: Python) -> PyResult<Py<PyAny>> {
         match &self.0 {
@@ -171,7 +171,7 @@ impl PyVar {
 
     /// Whether this :class:`Var` is a standalone variable that owns its storage
     /// location, if applicable. If false, this is a wrapper :class:`Var` around a
-    /// pre-existing circuit object."""
+    /// pre-existing circuit object.
     #[getter]
     fn get_standalone(&self) -> bool {
         match self.0 {

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -88,7 +88,7 @@ impl PyType {
     ///
     /// This is exactly equal to the Python type object that defines
     /// this type, that is ``t.kind is type(t)``, but is exposed like this to make it clear that
-    /// this a hashable enum-like discriminator you can rely on."""
+    /// this a hashable enum-like discriminator you can rely on.
     #[getter]
     fn get_kind(&self, py: Python) -> Py<PyAny> {
         match self.0 {

--- a/crates/circuit/src/variable_mapper.rs
+++ b/crates/circuit/src/variable_mapper.rs
@@ -195,7 +195,7 @@ impl VariableMapper {
     }
 
     /// Map the target's registers to suitable equivalents in the destination, adding an
-    /// extra one if there's no exact match."""
+    /// extra one if there's no exact match.
     fn map_register<F, E>(
         &self,
         theirs: &ClassicalRegister,


### PR DESCRIPTION
There are few wild tripe quotes scattered throughout the documentation. This PR removes them.

<img width="806" height="492" src="https://github.com/user-attachments/assets/fffcd843-736d-45d9-a1e5-f2de11b17935" />


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
