### PR TITLE
Handle ancilla-expanded layouts in Statevector.from_circuit

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -162,7 +162,10 @@ class Statevector(QuantumState, TolerancesMixin):
 
         # Apply layout permutations if needed (this handles transpiler layout changes)
         if not ignore_set_layout and layout is not None:
-            layout_indices = layout.final_index_layout()
+            # The simulated statevector spans the full output circuit, including
+            # any ancillas introduced during transpilation, so the permutation
+            # must be computed over that same full qubit set.
+            layout_indices = layout.final_index_layout(filter_ancillas=False)
             # Apply LSb0 qubit ordering (least-significant-bit is 0)
             num_qubits = statevec.num_qubits
             reversed_perm = [

--- a/releasenotes/notes/statevector-from-circuit-ancilla-layout-crash-49b7b85e2935cb23.yaml
+++ b/releasenotes/notes/statevector-from-circuit-ancilla-layout-crash-49b7b85e2935cb23.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`qiskit.quantum_info.Statevector.from_circuit` for transpiled circuits
+    whose stored layout includes transpiler-added ancillas. Previously this could raise an
+    ``IndexError`` while applying the layout permutation.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -25,6 +25,7 @@ from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
 from qiskit.circuit.library import HGate, QFTGate, GlobalPhaseGate, DiagonalGate, CXGate, XGate
 from qiskit.providers.basic_provider import BasicSimulator
+from qiskit.transpiler import CouplingMap
 from qiskit.utils import optionals
 from qiskit.quantum_info.random import random_unitary, random_statevector, random_pauli
 from qiskit.quantum_info.states import Statevector
@@ -99,6 +100,22 @@ class TestStatevector(QiskitTestCase):
         sv2 = Statevector.from_circuit(qc, ignore_set_layout=True)
 
         self.assertTrue(sv1.equiv(sv2))
+
+    def test_from_circuit_expanded_layout_with_ancillas(self):
+        """Statevector.from_circuit handles transpiler-added ancillas in layout permutations."""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+
+        transpiled = transpile(qc, coupling_map=CouplingMap.from_line(5), initial_layout=[0, 2, 4])
+
+        expected = QuantumCircuit(5)
+        expected.h(0)
+        expected.cx(0, 1)
+        expected.cx(1, 2)
+
+        self.assertTrue(Statevector.from_circuit(transpiled).equiv(Statevector.from_instruction(expected)))
 
     @classmethod
     def rand_vec(cls, n, normalize=False):

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -115,7 +115,17 @@ class TestStatevector(QiskitTestCase):
         expected.cx(0, 1)
         expected.cx(1, 2)
 
-        self.assertTrue(Statevector.from_circuit(transpiled).equiv(Statevector.from_instruction(expected)))
+        statevector = Statevector.from_circuit(transpiled)
+
+        self.assertTrue(statevector.equiv(Statevector.from_instruction(expected)))
+        self.assertTrue(
+            statevector.equiv(
+                Statevector.from_label("0" * transpiled.num_qubits).evolve(
+                    Operator.from_circuit(transpiled)
+                )
+            )
+        )
+        self.assertFalse(statevector.equiv(Statevector.from_circuit(transpiled, ignore_set_layout=True)))
 
     @classmethod
     def rand_vec(cls, n, normalize=False):


### PR DESCRIPTION
`Statevector.from_circuit()` simulates the transpiled circuit first and then applies the stored layout permutation.

That post-processing step used `layout.final_index_layout()` with its default `filter_ancillas=True` behavior. That works when transpilation preserves the circuit width. It fails when transpilation expands the circuit with ancillas, because the simulated statevector spans the full output circuit while the permutation only covers the original logical qubits. In that case `Statevector.from_circuit()` can raise `IndexError` while reordering tensor axes.

This patch switches the permutation source to `layout.final_index_layout(filter_ancillas=False)`. That keeps the permutation width aligned with the simulated statevector and preserves the existing layout-correction behavior for transpiled circuits.

The regression test covers a 3-qubit circuit transpiled onto a 5-qubit coupling map with an explicit sparse initial layout. It now checks three things on the same input:
- the crash is gone,
- the returned statevector matches the expected 5-qubit embedded circuit,
- the result matches `Operator.from_circuit()` semantics while `ignore_set_layout=True` still preserves the unpermuted behavior.

Tests run:
.venv/bin/python -m unittest test.python.quantum_info.states.test_statevector.TestStatevector.test_from_circuit_expanded_layout_with_ancillas test.python.quantum_info.states.test_statevector.TestStatevector.test_from_circuit_transpilation_consistency
.venv/bin/python -m unittest test.python.quantum_info.states.test_statevector
.venv/bin/python -m ruff check qiskit/quantum_info/states/statevector.py test/python/quantum_info/states/test_statevector.py

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description:
  OpenAI GPT-5 Codex
- [x] I used the following tool to generate or modify code:
  OpenAI GPT-5 Codex
