### PR TITLE
Fix incorrect global phase shift for P and U1 gates in CommutativeCancellation

### DIFF
--- a/crates/transpiler/src/passes/commutation_cancellation.rs
+++ b/crates/transpiler/src/passes/commutation_cancellation.rs
@@ -277,8 +277,12 @@ pub fn cancel_commutations(
                     // if the angle is close to a 4-pi multiple (from above or below), then the
                     // operator is equal to the identity
                 } else if is_multiple_of_pi(total_angle, 2.) {
-                    // a 2-pi multiple has a phase of pi: RX(2pi) = RZ(2pi) = -I = I exp(i pi)
-                    total_phase -= PI;
+                    if cancel_key.gate == GateOrRotation::XRotation
+                        || matches!(z_var_gate, Some(&StandardGate::RZ))
+                    {
+                        // a 2-pi multiple has a phase of pi: RX(2pi) = RZ(2pi) = -I = I exp(i pi)
+                        total_phase -= PI;
+                    }
                 } else if cancel_key.gate == GateOrRotation::ZRotation {
                     let z_gate = z_var_gate.unwrap();
                     dag.insert_1q_on_incoming_qubit((*z_gate, &[total_angle]), cancel_set[0]);

--- a/releasenotes/notes/fix-commutative-cancellation-p-u1-2pi-phase-f4d993f969fdc873.yaml
+++ b/releasenotes/notes/fix-commutative-cancellation-p-u1-2pi-phase-f4d993f969fdc873.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed :class:`.CommutativeCancellation` incorrectly shifting the global
+    phase by :math:`-\pi` when accumulating a :math:`2\pi` rotation using a
+    :class:`.PhaseGate` or :class:`.U1Gate`.
+    Fixed `#16377 <https://github.com/Qiskit/qiskit/issues/16377>`__.

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -138,6 +138,25 @@ class TestCommutativeCancellation(QiskitTestCase):
             tqc = cc(qc)
             self.assertTrue(np.allclose(Operator(qc).data, Operator(tqc).data))
 
+    def test_p_u1_2pi_accumulation(self):
+        """Test P(2pi) and U1(2pi) correctly preserve identity without phase correction."""
+        gate_classes = [PhaseGate, U1Gate]
+        gate_names = ["p", "u1"]
+
+        for gate_cls, gate_name in zip(gate_classes, gate_names):
+            with self.subTest(gate=gate_name):
+                qc = QuantumCircuit(1)
+                qc.append(gate_cls(np.pi / 4), [0])
+
+                for _ in range(7):
+                    qc.t(0)
+
+                cc = CommutativeCancellation(basis_gates=[gate_name, "t", "rz", "cx"])
+                tqc = cc(qc)
+
+                self.assertAlmostEqual(float(tqc.global_phase), 0.0)
+                self.assertTrue(np.allclose(Operator(qc).data, Operator(tqc).data))
+
     def test_commutative_circuit1(self):
         """A simple circuit where three CNOTs commute, the first and the last cancel.
 

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -138,24 +138,26 @@ class TestCommutativeCancellation(QiskitTestCase):
             tqc = cc(qc)
             self.assertTrue(np.allclose(Operator(qc).data, Operator(tqc).data))
 
-    def test_p_u1_2pi_accumulation(self):
-        """Test P(2pi) and U1(2pi) correctly preserve identity without phase correction."""
-        gate_classes = [PhaseGate, U1Gate]
-        gate_names = ["p", "u1"]
+    @ddt.data(RZGate(np.pi / 4), PhaseGate(np.pi / 4), U1Gate(np.pi / 4))
+    def test_p_u1_2pi_accumulation(self, gate):
+        """Test different Z rotations."""
+        basis = ["t", "rz", "cx"]
+        if gate.name not in basis:
+            basis = [gate.name] + basis
+        cc = CommutativeCancellation(basis_gates=basis)
+        reps = (7, 15, 23, 31)
 
-        for gate_cls, gate_name in zip(gate_classes, gate_names):
-            with self.subTest(gate=gate_name):
-                qc = QuantumCircuit(1)
-                qc.append(gate_cls(np.pi / 4), [0])
+        tqcs = []
+        for rep in reps:
+            qc = QuantumCircuit(1)
+            qc.append(gate, [0])
+            for _ in range(rep):
+                qc.t(0)
+            tqcs.append(cc(qc))
 
-                for _ in range(7):
-                    qc.t(0)
-
-                cc = CommutativeCancellation(basis_gates=[gate_name, "t", "rz", "cx"])
-                tqc = cc(qc)
-
-                self.assertAlmostEqual(float(tqc.global_phase), 0.0)
-                self.assertTrue(np.allclose(Operator(qc).data, Operator(tqc).data))
+        phase = -gate.params[0] / 2 if gate.name == "rz" else 0.0
+        expected = [QuantumCircuit(1, global_phase=phase)] * len(tqcs)
+        self.assertEqual(tqcs, expected)
 
     def test_commutative_circuit1(self):
         """A simple circuit where three CNOTs commute, the first and the last cancel.


### PR DESCRIPTION
### Summary

At `crates/transpiler/src/passes/commutation_cancellation.rs`, $\pi$ was incorrectly subtracted from the total phase if a Z-rotation gate accumulated to $2\pi$. While this is correct for gates like the RZ gate where $RZ(2\pi)=-I$, this is incorrect for P and U1 gates where $P(2\pi)=U1(2\pi)=I$. An additional check was added before the $\pi$ subtraction to ensure that the phase adjustment only applies to RX and RZ gates.

### Details

- The $-\pi$ global phase adjustment was restricted so that it only applies for RX and RZ gates.
- Added a test that accumulates a total of $2\pi$ rotation using both `PhaseGate` and `U1Gate` to verify that the commutative cancellation pass leaves the transpiled circuit with zero global phase and remains unitarily equivalent to the original circuit.

Fixes #16377.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:
