### PR TITLE
doc: qiskit.quantum_info.random module

### DIFF
--- a/docs/apidoc/index.rst
+++ b/docs/apidoc/index.rst
@@ -26,6 +26,7 @@ Quantum information:
    :maxdepth: 1
 
    quantum_info
+   quantum_info_random
 
 Transpilation:
 

--- a/docs/apidoc/quantum_info_random.rst
+++ b/docs/apidoc/quantum_info_random.rst
@@ -1,0 +1,4 @@
+.. automodule:: qiskit.quantum_info.random
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -96,6 +96,8 @@ Utility Functions
 Random
 ======
 
+See also :mod:`qiskit.quantum_info.random`.
+
 .. autofunction:: random_statevector
 .. autofunction:: random_density_matrix
 .. autofunction:: random_unitary

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -39,7 +39,7 @@ def random_pauli(
                                            generator for RNG.
 
     Returns:
-        qiskit.quantum_info.Pauli: a random Pauli
+        Pauli: a random Pauli
     """
     if seed is None:
         rng = np.random.default_rng()

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -39,7 +39,7 @@ def random_pauli(
                                            generator for RNG.
 
     Returns:
-        Pauli: a random Pauli
+        qiskit.quantum_info.Pauli: a random Pauli
     """
     if seed is None:
         rng = np.random.default_rng()

--- a/qiskit/quantum_info/random.py
+++ b/qiskit/quantum_info/random.py
@@ -10,13 +10,41 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Methods for generating random quantum information objects."""
+"""
+=========================================================================
+Generating Random Quantum Information (:mod:`qiskit.quantum_info.random`)
+=========================================================================
 
+.. currentmodule:: qiskit.quantum_info.random
 
-# The import path via qiskit.quantum_info.random is not API-documented,
-# yet it existed for a long time and several packages rely on this import path.
-# Since it also mirrors the API-documented ``qiskit.circuit.random``, we keep
-# the re-export available here.
+Overview
+========
+
+The :mod:`qiskit.quantum_info.random` module provides functions for generating
+random quantum states, operators, and channels. These are useful for testing
+and benchmarking.
+
+Random States
+=============
+
+.. autofunction:: random_statevector
+.. autofunction:: random_density_matrix
+
+Random Operators
+================
+
+.. autofunction:: random_unitary
+.. autofunction:: random_hermitian
+.. autofunction:: random_pauli
+.. autofunction:: random_pauli_list
+.. autofunction:: random_clifford
+.. autofunction:: random_cnotdihedral
+
+Random Channels
+===============
+
+.. autofunction:: random_quantum_channel
+"""
 
 from qiskit.quantum_info.operators.random import (
     random_clifford,

--- a/qiskit/quantum_info/random.py
+++ b/qiskit/quantum_info/random.py
@@ -11,9 +11,9 @@
 # that they have been altered from the originals.
 
 """
-=========================================================================
-Generating Random Quantum Information (:mod:`qiskit.quantum_info.random`)
-=========================================================================
+==============================================================
+Random Quantum Information (:mod:`qiskit.quantum_info.random`)
+==============================================================
 
 .. currentmodule:: qiskit.quantum_info.random
 


### PR DESCRIPTION
Fix #16247

This change formally documents the qiskit.quantum_info.random module as part of the public API.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: IBM Bob

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
