### PR TITLE
Accept rotation gate names in CommutationChecker filters

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -466,6 +466,7 @@ impl CommutationChecker {
 
         // if we have rotation gates, we attempt to map them to their generators, for example
         // RX -> X or CPhase -> CZ
+        let original_op1_name = op1.name();
         let (op1_gate, params1, trivial1) = map_rotation(op1, params1, tol);
         if trivial1 {
             return Ok(true);
@@ -475,6 +476,7 @@ impl CommutationChecker {
         } else {
             op1
         };
+        let original_op2_name = op2.name();
         let (op2_gate, params2, trivial2) = map_rotation(op2, params2, tol);
         if trivial2 {
             return Ok(true);
@@ -486,7 +488,9 @@ impl CommutationChecker {
         };
 
         if let Some(gates) = &self.gates {
-            if !gates.is_empty() && (!gates.contains(op1.name()) || !gates.contains(op2.name())) {
+            let op1_allowed = gates.contains(original_op1_name) || gates.contains(op1.name());
+            let op2_allowed = gates.contains(original_op2_name) || gates.contains(op2.name());
+            if !gates.is_empty() && (!op1_allowed || !op2_allowed) {
                 return Ok(false);
             }
         }

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -463,10 +463,13 @@ impl CommutationChecker {
                 _ => &[],
             })
             .unwrap_or_default();
+        let gate_filter = self.gates.as_ref().filter(|gates| !gates.is_empty());
+        let (op1_allowed_by_original_name, op2_allowed_by_original_name) = gate_filter
+            .map(|gates| (gates.contains(op1.name()), gates.contains(op2.name())))
+            .unwrap_or((true, true));
 
         // if we have rotation gates, we attempt to map them to their generators, for example
         // RX -> X or CPhase -> CZ
-        let original_op1_name = op1.name();
         let (op1_gate, params1, trivial1) = map_rotation(op1, params1, tol);
         if trivial1 {
             return Ok(true);
@@ -476,7 +479,6 @@ impl CommutationChecker {
         } else {
             op1
         };
-        let original_op2_name = op2.name();
         let (op2_gate, params2, trivial2) = map_rotation(op2, params2, tol);
         if trivial2 {
             return Ok(true);
@@ -487,10 +489,10 @@ impl CommutationChecker {
             op2
         };
 
-        if let Some(gates) = &self.gates {
-            let op1_allowed = gates.contains(original_op1_name) || gates.contains(op1.name());
-            let op2_allowed = gates.contains(original_op2_name) || gates.contains(op2.name());
-            if !gates.is_empty() && (!op1_allowed || !op2_allowed) {
+        if let Some(gates) = gate_filter {
+            let op1_allowed = op1_allowed_by_original_name || gates.contains(op1.name());
+            let op2_allowed = op2_allowed_by_original_name || gates.contains(op2.name());
+            if !op1_allowed || !op2_allowed {
                 return Ok(false);
             }
         }

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -463,10 +463,12 @@ impl CommutationChecker {
                 _ => &[],
             })
             .unwrap_or_default();
-        let gate_filter = self.gates.as_ref().filter(|gates| !gates.is_empty());
-        let (op1_allowed_by_original_name, op2_allowed_by_original_name) = gate_filter
-            .map(|gates| (gates.contains(op1.name()), gates.contains(op2.name())))
-            .unwrap_or((true, true));
+
+        if let Some(gates) = &self.gates {
+            if !gates.is_empty() && (!gates.contains(op1.name()) || !gates.contains(op2.name())) {
+                return Ok(false);
+            }
+        }
 
         // if we have rotation gates, we attempt to map them to their generators, for example
         // RX -> X or CPhase -> CZ
@@ -488,14 +490,6 @@ impl CommutationChecker {
         } else {
             op2
         };
-
-        if let Some(gates) = gate_filter {
-            let op1_allowed = op1_allowed_by_original_name || gates.contains(op1.name());
-            let op2_allowed = op2_allowed_by_original_name || gates.contains(op2.name());
-            if !op1_allowed || !op2_allowed {
-                return Ok(false);
-            }
-        }
 
         let precheck_status = commutation_precheck(
             op1,

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -446,6 +446,12 @@ impl CommutationChecker {
         matrix_max_num_qubits: u32,
         approximation_degree: f64,
     ) -> Result<bool, CommutationError> {
+        if let Some(gates) = &self.gates {
+            if !gates.is_empty() && (!gates.contains(op1.name()) || !gates.contains(op2.name())) {
+                return Ok(false);
+            }
+        }
+
         // If the average gate infidelity is below this tolerance, they commute. The tolerance
         // is set to max(1e-12, 1 - approximation_degree), to account for roundoffs and for
         // consistency with other places in Qiskit.
@@ -463,12 +469,6 @@ impl CommutationChecker {
                 _ => &[],
             })
             .unwrap_or_default();
-
-        if let Some(gates) = &self.gates {
-            if !gates.is_empty() && (!gates.contains(op1.name()) || !gates.contains(op2.name())) {
-                return Ok(false);
-            }
-        }
 
         // if we have rotation gates, we attempt to map them to their generators, for example
         // RX -> X or CPhase -> CZ

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -447,7 +447,7 @@ impl CommutationChecker {
         approximation_degree: f64,
     ) -> Result<bool, CommutationError> {
         if let Some(gates) = &self.gates {
-            if !gates.is_empty() && (!gates.contains(op1.name()) || !gates.contains(op2.name())) {
+            if !gates.contains(op1.name()) || !gates.contains(op2.name()) {
                 return Ok(false);
             }
         }

--- a/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
+++ b/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
@@ -1,8 +1,6 @@
 ---
 fixes:
   - |
-    Fixed a bug in :class:`qiskit.circuit.CommutationChecker` when the
-    ``gates`` filter is used with parameterized rotation gate names such as
-    ``"rx"``. Previously the filter could reject those gates after their
-    internal generator mapping and incorrectly return ``False`` for
-    self-commuting checks.
+    Fixed a bug in :class:`.CommutationChecker` when checking commutativity
+    of parameterized gates, such as :class:`.RXGate`, when the ``gates``
+    argument is specified.

--- a/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
+++ b/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`qiskit.circuit.CommutationChecker` when the
+    ``gates`` filter is used with parameterized rotation gate names such as
+    ``"rx"``. Previously the filter could reject those gates after their
+    internal generator mapping and incorrectly return ``False`` for
+    self-commuting checks.

--- a/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
+++ b/releasenotes/notes/commutation-checker-rotation-gate-filter-9652352b76b6f6ae.yaml
@@ -4,3 +4,8 @@ fixes:
     Fixed a bug in :class:`.CommutationChecker` when checking commutativity
     of parameterized gates, such as :class:`.RXGate`, when the ``gates``
     argument is specified.
+    Fixed `#16407 <https://github.com/Qiskit/qiskit-terra/pull/16407>`__.
+  - |
+    Fixed a bug in :class:`.CommutationChecker` where passing an empty
+    ``gates`` set now returns ``False`` instead of behaving like no filter
+    was specified.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -277,8 +277,8 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(rx_gate_theta, [0], [], rxx_gate_theta, [0, 1], []))
         self.assertTrue(scc.commute(rz_gate_theta, [0], [], cx_gate, [0, 1], []))
 
-    def test_gate_filter_accepts_rotation_gate_names(self):
-        """Gate filtering should accept both rotation gate names and generator names."""
+    def test_gate_filter_matches_parameterized_gate_names(self):
+        """Gate filtering should use the parameterized gate names, not their generators."""
         rx1 = RXGate(0.1)
         rx2 = RXGate(0.2)
         phase1 = PhaseGate(0.1)
@@ -291,7 +291,7 @@ class TestCommutationChecker(QiskitTestCase):
                 rx1, [0], [], rx2, [0], []
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             CommutationChecker(StandardGateCommutations, gates={"x"}).commute(
                 rx1, [0], [], rx2, [0], []
             )
@@ -306,7 +306,7 @@ class TestCommutationChecker(QiskitTestCase):
                 phase1, [0], [], phase2, [0], []
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             CommutationChecker(StandardGateCommutations, gates={"z"}).commute(
                 phase1, [0], [], phase2, [0], []
             )
@@ -316,7 +316,7 @@ class TestCommutationChecker(QiskitTestCase):
                 cphase1, [0, 1], [], cphase2, [0, 1], []
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             CommutationChecker(StandardGateCommutations, gates={"cz"}).commute(
                 cphase1, [0, 1], [], cphase2, [0, 1], []
             )

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -281,6 +281,10 @@ class TestCommutationChecker(QiskitTestCase):
         """Gate filtering should accept both rotation gate names and generator names."""
         rx1 = RXGate(0.1)
         rx2 = RXGate(0.2)
+        phase1 = PhaseGate(0.1)
+        phase2 = PhaseGate(0.2)
+        cphase1 = CPhaseGate(0.1)
+        cphase2 = CPhaseGate(0.2)
 
         self.assertTrue(
             CommutationChecker(StandardGateCommutations, gates={"rx"}).commute(
@@ -295,6 +299,26 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertFalse(
             CommutationChecker(StandardGateCommutations, gates={"rz"}).commute(
                 rx1, [0], [], rx2, [0], []
+            )
+        )
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"p"}).commute(
+                phase1, [0], [], phase2, [0], []
+            )
+        )
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"z"}).commute(
+                phase1, [0], [], phase2, [0], []
+            )
+        )
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"cp"}).commute(
+                cphase1, [0, 1], [], cphase2, [0, 1], []
+            )
+        )
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"cz"}).commute(
+                cphase1, [0, 1], [], cphase2, [0, 1], []
             )
         )
 

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -278,7 +278,7 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(rz_gate_theta, [0], [], cx_gate, [0, 1], []))
 
     def test_parameterized_gates_when_gates_specified(self):
-        """Gate filtering should use the public gate names and honor empty or mixed filters."""
+        """Gate filtering should use the public gate names and honor mixed filters."""
         rx1 = RXGate(0.1)
         rx2 = RXGate(0.2)
 
@@ -286,7 +286,6 @@ class TestCommutationChecker(QiskitTestCase):
             ({"rx"}, True),
             ({"x"}, False),
             ({"rx", "x"}, True),
-            (set(), True),
             ({"rz"}, False),
         ]:
             with self.subTest(gates=gates):

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -278,7 +278,7 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(rz_gate_theta, [0], [], cx_gate, [0, 1], []))
 
     def test_parameterized_gates_when_gates_specified(self):
-        """Gate filtering should use the public gate names and honor mixed filters."""
+        """Gate filtering should use the public gate names and honor empty or mixed filters."""
         rx1 = RXGate(0.1)
         rx2 = RXGate(0.2)
 
@@ -286,6 +286,7 @@ class TestCommutationChecker(QiskitTestCase):
             ({"rx"}, True),
             ({"x"}, False),
             ({"rx", "x"}, True),
+            (set(), False),
             ({"rz"}, False),
         ]:
             with self.subTest(gates=gates):

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -24,6 +24,7 @@ from qiskit.quantum_info import Operator
 
 from qiskit.circuit import (
     AnnotatedOperation,
+    CommutationChecker,
     ControlModifier,
     Gate,
     InverseModifier,
@@ -32,7 +33,10 @@ from qiskit.circuit import (
     Qubit,
     QuantumCircuit,
 )
-from qiskit.circuit.commutation_library import SessionCommutationChecker as scc
+from qiskit.circuit.commutation_library import (
+    SessionCommutationChecker as scc,
+    StandardGateCommutations,
+)
 from qiskit.circuit.library import (
     Barrier,
     CCXGate,
@@ -272,6 +276,27 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(XGate(), [0], [], rxx_gate_theta, [0, 1], []))
         self.assertTrue(scc.commute(rx_gate_theta, [0], [], rxx_gate_theta, [0, 1], []))
         self.assertTrue(scc.commute(rz_gate_theta, [0], [], cx_gate, [0, 1], []))
+
+    def test_gate_filter_accepts_rotation_gate_names(self):
+        """Gate filtering should accept both rotation gate names and generator names."""
+        rx1 = RXGate(0.1)
+        rx2 = RXGate(0.2)
+
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"rx"}).commute(
+                rx1, [0], [], rx2, [0], []
+            )
+        )
+        self.assertTrue(
+            CommutationChecker(StandardGateCommutations, gates={"x"}).commute(
+                rx1, [0], [], rx2, [0], []
+            )
+        )
+        self.assertFalse(
+            CommutationChecker(StandardGateCommutations, gates={"rz"}).commute(
+                rx1, [0], [], rx2, [0], []
+            )
+        )
 
     def test_parameterized_controlled_rotation_gates(self):
         """Check commutativity between parameterized controlled rotation gates,

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -277,50 +277,25 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(rx_gate_theta, [0], [], rxx_gate_theta, [0, 1], []))
         self.assertTrue(scc.commute(rz_gate_theta, [0], [], cx_gate, [0, 1], []))
 
-    def test_gate_filter_matches_parameterized_gate_names(self):
-        """Gate filtering should use the parameterized gate names, not their generators."""
+    def test_parameterized_gates_when_gates_specified(self):
+        """Gate filtering should use the public gate names and honor empty or mixed filters."""
         rx1 = RXGate(0.1)
         rx2 = RXGate(0.2)
-        phase1 = PhaseGate(0.1)
-        phase2 = PhaseGate(0.2)
-        cphase1 = CPhaseGate(0.1)
-        cphase2 = CPhaseGate(0.2)
 
-        self.assertTrue(
-            CommutationChecker(StandardGateCommutations, gates={"rx"}).commute(
-                rx1, [0], [], rx2, [0], []
-            )
-        )
-        self.assertFalse(
-            CommutationChecker(StandardGateCommutations, gates={"x"}).commute(
-                rx1, [0], [], rx2, [0], []
-            )
-        )
-        self.assertFalse(
-            CommutationChecker(StandardGateCommutations, gates={"rz"}).commute(
-                rx1, [0], [], rx2, [0], []
-            )
-        )
-        self.assertTrue(
-            CommutationChecker(StandardGateCommutations, gates={"p"}).commute(
-                phase1, [0], [], phase2, [0], []
-            )
-        )
-        self.assertFalse(
-            CommutationChecker(StandardGateCommutations, gates={"z"}).commute(
-                phase1, [0], [], phase2, [0], []
-            )
-        )
-        self.assertTrue(
-            CommutationChecker(StandardGateCommutations, gates={"cp"}).commute(
-                cphase1, [0, 1], [], cphase2, [0, 1], []
-            )
-        )
-        self.assertFalse(
-            CommutationChecker(StandardGateCommutations, gates={"cz"}).commute(
-                cphase1, [0, 1], [], cphase2, [0, 1], []
-            )
-        )
+        for gates, expected in [
+            ({"rx"}, True),
+            ({"x"}, False),
+            ({"rx", "x"}, True),
+            (set(), True),
+            ({"rz"}, False),
+        ]:
+            with self.subTest(gates=gates):
+                self.assertEqual(
+                    CommutationChecker(StandardGateCommutations, gates=gates).commute(
+                        rx1, [0], [], rx2, [0], []
+                    ),
+                    expected,
+                )
 
     def test_parameterized_controlled_rotation_gates(self):
         """Check commutativity between parameterized controlled rotation gates,


### PR DESCRIPTION
`CommutationChecker` used to map parameterized rotation gates to their generators before it applied the optional `gates` filter. With a filter like `{"rx"}`, an `RXGate` pair was normalized to `"x"` first, so the filter rejected it before the commutation lookup.

This PR keeps the filter keyed to the public gate names and still keeps generator normalization for the commutation logic itself. A filter like `{"rx"}` now accepts `RXGate` pairs from #16407, while unrelated filters such as `{"rz"}` still return `False`.

The regression coverage checks:
- the exact `RXGate` reproducer from the issue with `gates={"rx"}`
- the rejected generator-name filter with `gates={"x"}`
- the accepted mixed filter with `gates={"rx", "x"}`
- the still-rejected unrelated filter with `gates={"rz"}`

Tests run:
- `python -m unittest test.python.circuit.test_commutation_checker.TestCommutationChecker.test_parameterized_gates_when_gates_specified test.python.circuit.test_commutation_checker.TestCommutationChecker.test_parameterized_gates`
- `python -m unittest test.python.circuit.test_commutation_checker`
- `cargo fmt --all --check`
- `python -m ruff check test/python/circuit/test_commutation_checker.py`

Fix #16407

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description:
  OpenAI GPT-5 Codex
- [x] I used the following tool to generate or modify code:
  OpenAI GPT-5 Codex
