### PR TITLE
Fix stack-overflow segfault in OpenQASM 2 expression parsers

### DIFF
--- a/crates/qasm2/src/bytecode.rs
+++ b/crates/qasm2/src/bytecode.rs
@@ -333,6 +333,7 @@ impl BytecodeIterator {
         custom_instructions: &[CustomInstruction],
         custom_classical: &[CustomClassical],
         strict: bool,
+        max_depth: usize,
     ) -> PyResult<Self> {
         Ok(BytecodeIterator {
             parser_state: parse::State::new(
@@ -341,6 +342,7 @@ impl BytecodeIterator {
                 custom_instructions,
                 custom_classical,
                 strict,
+                max_depth,
             )
             .map_err(QASM2ParseError::new_err)?,
             buffer: vec![],

--- a/crates/qasm2/src/expr.rs
+++ b/crates/qasm2/src/expr.rs
@@ -17,6 +17,7 @@
 use core::f64;
 
 use hashbrown::HashMap;
+use pyo3::exceptions::PyRecursionError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
@@ -259,6 +260,8 @@ pub struct ExprParser<'a> {
     pub gate_symbols: &'a HashMap<String, GateSymbol>,
     pub global_symbols: &'a HashMap<String, GlobalSymbol>,
     pub strict: bool,
+    /// Internal recursion-depth limit.
+    pub remaining_depth: usize,
 }
 
 impl ExprParser<'_> {
@@ -587,6 +590,9 @@ impl ExprParser<'_> {
     /// and its parsing would finish when it saw the next `+` binary operation.  For initial entry,
     /// the `power_min` should be zero.
     fn eval_expression(&mut self, power_min: u8, cause: &Token) -> PyResult<Expr> {
+        self.remaining_depth = self.remaining_depth.checked_sub(1).ok_or_else(|| {
+            PyRecursionError::new_err("exceeded maximum permitted expression depth")
+        })?;
         let token = self.next_token()?.ok_or_else(|| {
             QASM2ParseError::new_err(message_bad_eof(
                 Some(&Position::new(
@@ -722,6 +728,7 @@ impl ExprParser<'_> {
             let rhs = self.eval_expression(power_r, &peeked_token)?;
             lhs = self.apply_infix(op, lhs, rhs, &peeked_token)?;
         }
+        self.remaining_depth += 1;
         Ok(lhs)
     }
 

--- a/crates/qasm2/src/lib.rs
+++ b/crates/qasm2/src/lib.rs
@@ -82,6 +82,7 @@ fn bytecode_from_string(
     custom_instructions: Vec<CustomInstruction>,
     custom_classical: Vec<CustomClassical>,
     strict: bool,
+    max_depth: usize,
 ) -> PyResult<bytecode::BytecodeIterator> {
     bytecode::BytecodeIterator::new(
         lex::TokenStream::from_string(string, strict),
@@ -89,6 +90,7 @@ fn bytecode_from_string(
         &custom_instructions,
         &custom_classical,
         strict,
+        max_depth,
     )
 }
 
@@ -103,6 +105,7 @@ fn bytecode_from_file(
     custom_instructions: Vec<CustomInstruction>,
     custom_classical: Vec<CustomClassical>,
     strict: bool,
+    max_depth: usize,
 ) -> PyResult<bytecode::BytecodeIterator> {
     bytecode::BytecodeIterator::new(
         lex::TokenStream::from_path(&path, strict).map_err(|err| {
@@ -117,6 +120,7 @@ fn bytecode_from_file(
         &custom_instructions,
         &custom_classical,
         strict,
+        max_depth,
     )
 }
 

--- a/crates/qasm2/src/parse.rs
+++ b/crates/qasm2/src/parse.rs
@@ -238,6 +238,8 @@ pub struct State {
     allow_version: bool,
     /// Whether we're in strict mode or (the default) more permissive parse.
     strict: bool,
+    /// What the maximum depth for expression recursion is.
+    max_depth: usize,
 }
 
 impl State {
@@ -248,6 +250,7 @@ impl State {
         custom_instructions: &[CustomInstruction],
         custom_classical: &[CustomClassical],
         strict: bool,
+        max_depth: usize,
     ) -> PyResult<Self> {
         let mut state = State {
             tokens: vec![tokens],
@@ -268,6 +271,7 @@ impl State {
             num_gates: 0,
             allow_version: true,
             strict,
+            max_depth,
         };
         for inst in custom_instructions {
             if state.symbols.contains_key(&inst.name)
@@ -977,6 +981,19 @@ impl State {
         self.emit_gate_application(bc, &name_token, index, parameters, &qargs, condition)
     }
 
+    /// Parse an expected expression at this position.
+    fn expect_expression(&mut self, cause: &Token) -> PyResult<Expr> {
+        ExprParser {
+            tokens: &mut self.tokens,
+            context: &mut self.context,
+            gate_symbols: &self.gate_symbols,
+            global_symbols: &self.symbols,
+            strict: self.strict,
+            remaining_depth: self.max_depth,
+        }
+        .parse_expression(cause)
+    }
+
     /// Parse the parameters (if any) from a gate application.
     fn expect_gate_parameters(
         &mut self,
@@ -1002,14 +1019,7 @@ impl State {
         let parameters = if in_gate {
             let mut parameters = Vec::<Expr>::with_capacity(num_params);
             while !self.next_is(TokenType::RParen)? {
-                let mut expr_parser = ExprParser {
-                    tokens: &mut self.tokens,
-                    context: &mut self.context,
-                    gate_symbols: &self.gate_symbols,
-                    global_symbols: &self.symbols,
-                    strict: self.strict,
-                };
-                parameters.push(expr_parser.parse_expression(&lparen_token)?);
+                parameters.push(self.expect_expression(&lparen_token)?);
                 seen_params += 1;
                 comma = self.accept(TokenType::Comma)?;
                 if comma.is_none() {
@@ -1021,14 +1031,7 @@ impl State {
         } else {
             let mut parameters = Vec::<f64>::with_capacity(num_params);
             while !self.next_is(TokenType::RParen)? {
-                let mut expr_parser = ExprParser {
-                    tokens: &mut self.tokens,
-                    context: &mut self.context,
-                    gate_symbols: &self.gate_symbols,
-                    global_symbols: &self.symbols,
-                    strict: self.strict,
-                };
-                match expr_parser.parse_expression(&lparen_token)? {
+                match self.expect_expression(&lparen_token)? {
                     Expr::Constant(value) => parameters.push(value),
                     _ => {
                         return Err(QASM2ParseError::new_err(message_generic(

--- a/qiskit/qasm2/__init__.py
+++ b/qiskit/qasm2/__init__.py
@@ -538,6 +538,7 @@ __all__ = [
 ]
 
 import os
+import sys
 from pathlib import Path
 from typing import Literal
 from collections.abc import Iterable
@@ -586,6 +587,11 @@ def loads(
 ) -> QuantumCircuit:
     """Parse an OpenQASM 2 program from a string into a :class:`.QuantumCircuit`.
 
+    .. note::
+        The internal classical-expression parser is recursive, and will raise a
+        :exc:`RecursionError` if any expression requires excessive depth to evaluate.  This maxmimum
+        depth can be adjusted using :func:`sys.setrecursionlimit`.
+
     Args:
         string: The OpenQASM 2 program in a string.
         include_path: order of directories to search when evaluating ``include`` statements.
@@ -610,6 +616,7 @@ def loads(
             ],
             tuple(custom_classical),
             strict,
+            max_depth=sys.getrecursionlimit(),
         ),
         custom_instructions,
     )
@@ -626,6 +633,11 @@ def load(
 ) -> QuantumCircuit:
     """Parse an OpenQASM 2 program from a file into a :class:`.QuantumCircuit`.  The given path
     should be ASCII or UTF-8 encoded, and contain the OpenQASM 2 program.
+
+    .. note::
+        The internal classical-expression parser is recursive, and will raise a
+        :exc:`RecursionError` if any expression requires excessive depth to evaluate.  This maxmimum
+        depth can be adjusted using :func:`sys.setrecursionlimit`.
 
     Args:
         filename: The path to the OpenQASM 2 file.
@@ -665,6 +677,7 @@ def load(
             ],
             tuple(custom_classical),
             strict,
+            max_depth=sys.getrecursionlimit(),
         ),
         custom_instructions,
     )

--- a/qiskit/qasm2/__init__.py
+++ b/qiskit/qasm2/__init__.py
@@ -577,6 +577,14 @@ def _normalize_path(path: str | os.PathLike) -> str:
     return str(path)
 
 
+def _get_recursion_limit() -> int:
+    """Get a recursion limit suitable for the parser.
+
+    We are more aggressive on Windows because it has a signifincantly more limited stack size by
+    default."""
+    return sys.getrecursionlimit() // 10
+
+
 def loads(
     string: str,
     *,
@@ -590,7 +598,8 @@ def loads(
     .. note::
         The internal classical-expression parser is recursive, and will raise a
         :exc:`RecursionError` if any expression requires excessive depth to evaluate.  This maxmimum
-        depth can be adjusted using :func:`sys.setrecursionlimit`.
+        depth can be adjusted using :func:`sys.setrecursionlimit`; the actual limit is one-tenth of
+        this value.
 
     Args:
         string: The OpenQASM 2 program in a string.
@@ -616,7 +625,7 @@ def loads(
             ],
             tuple(custom_classical),
             strict,
-            max_depth=sys.getrecursionlimit(),
+            max_depth=_get_recursion_limit(),
         ),
         custom_instructions,
     )
@@ -637,7 +646,8 @@ def load(
     .. note::
         The internal classical-expression parser is recursive, and will raise a
         :exc:`RecursionError` if any expression requires excessive depth to evaluate.  This maxmimum
-        depth can be adjusted using :func:`sys.setrecursionlimit`.
+        depth can be adjusted using :func:`sys.setrecursionlimit`; the actual limit is one-tenth of
+        this value.
 
     Args:
         filename: The path to the OpenQASM 2 file.
@@ -677,7 +687,7 @@ def load(
             ],
             tuple(custom_classical),
             strict,
-            max_depth=sys.getrecursionlimit(),
+            max_depth=_get_recursion_limit(),
         ),
         custom_instructions,
     )

--- a/releasenotes/notes/qasm2-recursion-limit-fbf7274ffe58f098.yaml
+++ b/releasenotes/notes/qasm2-recursion-limit-fbf7274ffe58f098.yaml
@@ -1,0 +1,9 @@
+---
+security:
+  - |
+    The OpenQASM 2 parsers (:func:`.qasm2.load` and :func:`.qasm2.loads`) will now exit with
+    a :exc:`RecursionError` when attempting to evaluate an excessively deep expression.  The maximum allowed
+    depth is taken from Python's :func:`sys.getrecursionlimit` at the point of entry to the parsers.
+
+    Previously, the parsers could recurse arbitrarily in Rust space, eventually exceeding the
+    maximum stack space and segfaulting the process.

--- a/test/python/qasm2/test_expression.py
+++ b/test/python/qasm2/test_expression.py
@@ -134,6 +134,28 @@ class TestSimple(QiskitTestCase):
         parameters = list(parsed.data[0].operation.params)
         self.assertEqual([bigint, -bigint, 2 * bigint], parameters)
 
+    def test_excessive_depth_unary(self):
+        """We should either succeed in the evaluation or raise a Python-space error. We should _not_
+        segfault."""
+        expr = "-" * 100_000 + "2.0"
+        program = f"qreg q[1]; U({expr}, 0.0, 0.0) q[0];"
+        # This can be changed to an assertion that the expression evaluates to precisely `2.0` if we
+        # modify the parser to be non-recursive.
+        with self.assertRaises(RecursionError):
+            qiskit.qasm2.loads(program)
+
+    def test_excessive_depth_binary(self):
+        """We should either succeed in the evaluation or raise a Python-space error. We should _not_
+        segfault."""
+        # We have to include the parentheses or the operator-precedence parser will just decay to
+        # iterative anyway.
+        expr = "1.0+(" * 100_000 + "1.0" + ")" * 100_000
+        program = f"qreg q[1]; U({expr}, 0.0, 0.0) q[0];"
+        # This can be changed to an assertion that the expression evaluates to precisely `100001.0`
+        # if we modify the parser to be non-recursive.
+        with self.assertRaises(RecursionError):
+            qiskit.qasm2.loads(program)
+
 
 class TestPrecedenceAssociativity(QiskitTestCase):
     def test_precedence(self):


### PR DESCRIPTION
The current recursive implementation of the operator-precedence expression parsers is susceptible to overflowing the stack on excessively deep expressions.  The simplest way to trigger this is to enter an arbitrary number of parentheses.

This patch puts a simple recursion-depth limit on the expression parser to safely error out before it comes close to the stack depth.  We use `sys.getrecursionlimit` on input simply as a compromise between not wanting to define new keyword arguments in bugfix patches and still wanting to allow some amount of control over the limit.

Future patches could consider replacing the recursive components of the expression parser with iterative state-tracking parsing.  The outer recursive-descent parser that handles the rest of the OpenQASM 2 grammar has a bounded recursion depth by nature of the grammar it is parsing; it is only the expression subparser that can reach arbitrary depths.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
