### PR TITLE
Correctly combining control modifiers in `OptimizeAnnotated`

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_annotated.py
+++ b/qiskit/transpiler/passes/optimization/optimize_annotated.py
@@ -156,7 +156,7 @@ class OptimizeAnnotated(TransformationPass):
             modifiers = []
             cur = node.op
             while isinstance(cur, AnnotatedOperation):
-                modifiers.extend(cur.modifiers)
+                modifiers = cur.modifiers + modifiers
                 cur = cur.base_op
             canonical_modifiers = _canonicalize_modifiers(modifiers)
             if len(canonical_modifiers) > 0:

--- a/releasenotes/notes/fix-optimize-annotated-e903f4d21cdb203f.yaml
+++ b/releasenotes/notes/fix-optimize-annotated-e903f4d21cdb203f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.OptimizeAnnotated` transpiler pass where control modifiers
+    with open controls were not combined correctly.
+
+    See `#16410 <https://github.com/Qiskit/qiskit/issues/16410>`__.

--- a/test/python/transpiler/test_optimize_annotated.py
+++ b/test/python/transpiler/test_optimize_annotated.py
@@ -14,7 +14,7 @@
 
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.classical import expr, types
-from qiskit.circuit.library import SwapGate, CXGate, HGate
+from qiskit.circuit.library import SwapGate, XGate, CXGate, HGate
 from qiskit.circuit.annotated_operation import (
     AnnotatedOperation,
     ControlModifier,
@@ -76,6 +76,82 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         qc_expected.append(gate5_expected, [4, 2])
 
         self.assertEqual(qc_optimized, qc_expected)
+
+    def test_combine_open_control_modifiers(self):
+        """Test recursively combining open-controlled modifiers.
+        Regression test of https://github.com/Qiskit/qiskit/issues/16410.
+        """
+        with self.subTest("control0-control1"):
+            gate = AnnotatedOperation(
+                AnnotatedOperation(XGate(), ControlModifier(1, ctrl_state=0)),
+                ControlModifier(1, ctrl_state=1),
+            )
+
+            qc = QuantumCircuit(3)
+            qc.append(gate, [0, 1, 2])
+
+            qct = OptimizeAnnotated()(qc)
+            self.assertEqual(Operator(qc), Operator(qct))
+
+            expected = QuantumCircuit(3)
+            expected.append(
+                AnnotatedOperation(XGate(), ControlModifier(2, ctrl_state=1)), [0, 1, 2]
+            )
+            self.assertEqual(qct, expected)
+
+        with self.subTest("control0-control11"):
+            gate = AnnotatedOperation(
+                AnnotatedOperation(XGate(), ControlModifier(1, ctrl_state=0)),
+                ControlModifier(2, ctrl_state=3),
+            )
+
+            qc = QuantumCircuit(4)
+            qc.append(gate, [0, 1, 2, 3])
+
+            qct = OptimizeAnnotated()(qc)
+            self.assertEqual(Operator(qc), Operator(qct))
+
+            expected = QuantumCircuit(4)
+            expected.append(
+                AnnotatedOperation(XGate(), ControlModifier(3, ctrl_state=3)), [0, 1, 2, 3]
+            )
+            self.assertEqual(qct, expected)
+
+        with self.subTest("control1-control0"):
+            gate = AnnotatedOperation(
+                AnnotatedOperation(XGate(), ControlModifier(1, ctrl_state=1)),
+                ControlModifier(1, ctrl_state=0),
+            )
+
+            qc = QuantumCircuit(3)
+            qc.append(gate, [0, 1, 2])
+
+            qct = OptimizeAnnotated()(qc)
+            self.assertEqual(Operator(qc), Operator(qct))
+
+            expected = QuantumCircuit(3)
+            expected.append(
+                AnnotatedOperation(XGate(), ControlModifier(2, ctrl_state=2)), [0, 1, 2]
+            )
+            self.assertEqual(qct, expected)
+
+        with self.subTest("control11-control0"):
+            gate = AnnotatedOperation(
+                AnnotatedOperation(XGate(), ControlModifier(2, ctrl_state=3)),
+                ControlModifier(1, ctrl_state=0),
+            )
+
+            qc = QuantumCircuit(4)
+            qc.append(gate, [0, 1, 2, 3])
+
+            qct = OptimizeAnnotated()(qc)
+            self.assertEqual(Operator(qc), Operator(qct))
+
+            expected = QuantumCircuit(4)
+            expected.append(
+                AnnotatedOperation(XGate(), ControlModifier(3, ctrl_state=6)), [0, 1, 2, 3]
+            )
+            self.assertEqual(qct, expected)
 
     def test_optimize_definitions(self):
         """Test that the pass descends into gate definitions when basis_gates are defined."""


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Fixes #16410.

As described in the linked issue, the `OptimizeAnnotated` transpiler pass did correctly apply the order of modifiers: 

```python
AnnotatedOperation(AnnotatedOperation(gate, modifiers1), modifiers2)
```

corresponds to applying `modifiers1` first and `modifiers2` next, and not the other way around.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
