### PR TITLE
Preserve Initialize integer width in uncompute

### DIFF
--- a/qiskit/circuit/library/data_preparation/initializer.py
+++ b/qiskit/circuit/library/data_preparation/initializer.py
@@ -21,7 +21,6 @@ import typing
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.circuit.instruction import Instruction
-from qiskit.circuit.library.generalized_gates import Isometry
 from .state_preparation import StatePreparation
 from qiskit.circuit.exceptions import CircuitError
 
@@ -91,9 +90,7 @@ class Initialize(Instruction):
         Returns:
             QuantumCircuit: circuit to take ``self.params`` vector to :math:`|{00\\ldots0}\\rangle`
         """
-
-        isom = Isometry(self.params, 0, 0)
-        return isom._gates_to_uncompute()
+        return self._stateprep.definition.inverse()
 
     @property
     def params(self):

--- a/releasenotes/notes/initialize-uncompute-integer-bitmap-c3da1114c2f43013.yaml
+++ b/releasenotes/notes/initialize-uncompute-integer-bitmap-c3da1114c2f43013.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed :meth:`.Initialize.gates_to_uncompute` for integer-bitmap inputs with
+    an explicit ``num_qubits``. The method now preserves the initialization
+    width and returns an uncomputation circuit that matches the prepared state.

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -505,6 +505,16 @@ class TestInitialize(QiskitTestCase):
         vec = Statevector(qc)
         self.assertTrue(vec == Statevector(desired_vector))
 
+    def test_gates_to_uncompute_integer_bitmap(self):
+        """Test gates_to_uncompute preserves integer-bitmap initialization width."""
+        initialize = Initialize(1, num_qubits=2)
+        uncompute = initialize.gates_to_uncompute()
+        prepared_state = Statevector.from_instruction(initialize)
+        zero_state = Statevector.from_label("00")
+
+        self.assertEqual(uncompute.num_qubits, 2)
+        self.assertTrue(prepared_state.evolve(uncompute).equiv(zero_state))
+
     def test_repeat(self):
         """Test the repeat() method."""
         desired_vector = np.array([0.5, 0.5, 0.5, 0.5])

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -515,6 +515,26 @@ class TestInitialize(QiskitTestCase):
         self.assertEqual(uncompute.num_qubits, 2)
         self.assertTrue(prepared_state.evolve(uncompute).equiv(zero_state))
 
+    def test_gates_to_uncompute_integer_bitmap_matches_vector_input(self):
+        """Test equivalent integer and vector inputs produce matching uncompute circuits."""
+        integer_initialize = Initialize(1, num_qubits=2)
+        vector_initialize = Initialize([0, 1, 0, 0])
+        integer_uncompute = integer_initialize.gates_to_uncompute()
+        vector_uncompute = vector_initialize.gates_to_uncompute()
+
+        self.assertEqual(integer_uncompute.num_qubits, vector_uncompute.num_qubits)
+        self.assertTrue(
+            Statevector.from_instruction(integer_initialize)
+            .evolve(integer_uncompute)
+            .equiv(Statevector.from_label("00"))
+        )
+        self.assertTrue(
+            Statevector.from_instruction(vector_initialize)
+            .evolve(vector_uncompute)
+            .equiv(Statevector.from_label("00"))
+        )
+        self.assertTrue(Operator(integer_uncompute).equiv(Operator(vector_uncompute)))
+
     def test_repeat(self):
         """Test the repeat() method."""
         desired_vector = np.array([0.5, 0.5, 0.5, 0.5])


### PR DESCRIPTION
## Summary

Fixes #16413.

`Initialize.gates_to_uncompute()` rebuilt the uncomputation path from `self.params` by passing them straight to `Isometry`.

That works for amplitude-vector inputs, but it drops the public integer-bitmap interpretation when `Initialize` was constructed as `Initialize(<int>, num_qubits=...)`. In that case `self.params` only contains the stored integer value, so `Isometry` sees a length-1 vector and returns a 0-qubit circuit.

This change delegates the uncomputation circuit to the existing `StatePreparation` definition instead. That keeps the documented integer-bitmap width and reuses the same input-form handling as the forward initialization path.

## Details

- replace the direct `Isometry(self.params, 0, 0)` path in `Initialize.gates_to_uncompute()` with `self._stateprep.definition.inverse()`
- add regressions for `Initialize(1, num_qubits=2).gates_to_uncompute()` and the equivalent vector input `Initialize([0, 1, 0, 0])`
- add a release note for the public bugfix

## Testing

- `python -m unittest test.python.circuit.test_initializer.TestInitialize.test_gates_to_uncompute test.python.circuit.test_initializer.TestInitialize.test_gates_to_uncompute_integer_bitmap`
- `python -m unittest test.python.circuit.test_initializer`
- `python -m ruff check qiskit/circuit/library/data_preparation/initializer.py test/python/circuit/test_initializer.py`

## Release Notes

- [x] I have added a release note for end user visible changes.

## AI usage

- [x] I used AI tooling to help draft and validate this change.
- Tool: Codex (GPT-5)
