### PR TITLE
Unify common helper functions in rust transpiler passes

### DIFF
--- a/crates/transpiler/src/passes/common.rs
+++ b/crates/transpiler/src/passes/common.rs
@@ -17,6 +17,7 @@ use std::f64::consts::PI;
 use crate::gate_metrics::rotation_trace_and_dim;
 use qiskit_circuit::operations::StandardGate;
 
+// Default value for tolerance level. It is used to check the fidely tolerance.
 pub const MINIMUM_TOL: f64 = 1e-12;
 
 /// Fidelity-based computation to check whether an operation `G` is equivalent
@@ -46,6 +47,7 @@ pub fn average_gate_fidelity_below_tol(tr_over_dim: Complex64, dim: f64, tol: f6
 /// Otherwise, return `None`.
 /// E.g, if the angle is a multiple m of PI/4 then it returns m, where 0 <= m < 16,
 /// and if the angle is a multiple m of PI/2 then it returns m, where 0 <= m < 8.
+/// Panics if the StandardGate is not a rotation gate.
 pub fn is_angle_close_to_multiple_of_pi_k(
     gate: StandardGate,
     k: usize,

--- a/crates/transpiler/src/passes/common.rs
+++ b/crates/transpiler/src/passes/common.rs
@@ -1,0 +1,73 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use num_complex::Complex64;
+use num_complex::ComplexFloat;
+use std::f64::consts::PI;
+
+use crate::gate_metrics::rotation_trace_and_dim;
+use qiskit_circuit::operations::StandardGate;
+
+pub const MINIMUM_TOL: f64 = 1e-12;
+
+/// Fidelity-based computation to check whether an operation `G` is equivalent
+/// to identity up to a global phase.
+///
+/// # Arguments
+///
+/// * `tr_over_dim`: `|Tr(G)| / dim(G)`.
+/// * `dim`: `dim(G)`.
+/// * `tol`: tolerance.
+///
+/// # Returns
+///
+/// * `Some(update to the global phase)` if the operation can be removed.
+/// * `None` if the operation cannot be removed.
+pub fn average_gate_fidelity_below_tol(tr_over_dim: Complex64, dim: f64, tol: f64) -> Option<f64> {
+    let f_pro = tr_over_dim.abs().powi(2);
+    let gate_fidelity = (dim * f_pro + 1.) / (dim + 1.);
+    if (1. - gate_fidelity).abs() < tol {
+        Some(tr_over_dim.arg())
+    } else {
+        None
+    }
+}
+
+/// For a given angle, if it is a multiple of PI/k, calculate the multiple mod (4*k),
+/// Otherwise, return `None`.
+/// E.g, if the angle is a multiple m of PI/4 then it returns m, where 0 <= m < 16,
+/// and if the angle is a multiple m of PI/2 then it returns m, where 0 <= m < 8.
+pub fn is_angle_close_to_multiple_of_pi_k(
+    gate: StandardGate,
+    k: usize,
+    angle: f64,
+    tol: f64,
+) -> Option<usize> {
+    let closest_ratio = angle * (k as f64) / PI;
+    let closest_integer = closest_ratio.round();
+    let closest_angle = closest_integer * PI / (k as f64);
+    let theta = angle - closest_angle;
+
+    // Trace and dimension calculation of rotation matrices
+    let (tr_over_dim, dim) = rotation_trace_and_dim(gate, theta)
+        .expect("Since only supported rotation gates are given, the result is not None");
+
+    // fidelity-based tolerance
+    let f_pro = tr_over_dim.abs().powi(2);
+    let gate_fidelity = (dim * f_pro + 1.) / (dim + 1.);
+    let rem = 4 * k as i64;
+    if (1. - gate_fidelity).abs() < tol {
+        Some((closest_integer as i64).rem_euclid(rem) as usize)
+    } else {
+        None
+    }
+}

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -21,9 +21,8 @@ use qiskit_circuit::instruction::Parameters;
 use smallvec::smallvec;
 
 use crate::commutation_checker::{CommutationChecker, try_matrix_with_definition};
-use crate::passes::remove_identity_equiv::{
-    MINIMUM_TOL, average_gate_fidelity_below_tol, is_identity_equiv,
-};
+use crate::passes::common::{MINIMUM_TOL, average_gate_fidelity_below_tol};
+use crate::passes::remove_identity_equiv::is_identity_equiv;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -22,8 +22,9 @@ use qiskit_circuit::operations::{
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use qiskit_circuit::{BlocksMode, Qubit, VarsMode};
 
-use super::remove_identity_equiv::average_gate_fidelity_below_tol; // ToDo: move to a shared file
-use super::substitute_pi4_rotations::is_angle_close_to_multiple_of_pi_k; // ToDo: move to a shared file
+use super::common::{
+    MINIMUM_TOL, average_gate_fidelity_below_tol, is_angle_close_to_multiple_of_pi_k,
+};
 use crate::TranspilerError;
 use num_complex::Complex64;
 use qiskit_quantum_info::clifford::{Clifford, Pauli1q};
@@ -77,8 +78,6 @@ static HANDLED_INSTRUCTION_NAMES: [&str; 10] = [
     "pauli_product_rotation",
     "pauli_product_measurement",
 ];
-
-const MINIMUM_TOL: f64 = 1e-12;
 
 #[pyfunction]
 #[pyo3(signature = (dag, fix_clifford=true, insert_barrier=false, use_ppr=false, approximation_degree=1.0))]

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -25,6 +25,7 @@ mod apply_layout;
 mod barrier_before_final_measurement;
 mod basis_translator;
 mod check_map;
+pub mod common;
 mod commutation_analysis;
 mod commutation_cancellation;
 mod commutative_optimization;

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 use num_complex::Complex64;
-use num_complex::ComplexFloat;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
@@ -18,6 +17,7 @@ use rustworkx_core::petgraph::visit::NodeIndexable;
 
 use crate::commutation_checker::try_matrix_with_definition;
 use crate::gate_metrics::rotation_trace_and_dim;
+use crate::passes::common::{MINIMUM_TOL, average_gate_fidelity_below_tol};
 use crate::target::Target;
 use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
@@ -33,31 +33,6 @@ use qiskit_util::getenv_use_multiple_threads;
 // https://github.com/Qiskit/qiskit/pull/14719 it can be tweaked
 // if the performance of this pass changes over time.
 const PARALLEL_THRESHOLD: usize = 50_000;
-
-pub const MINIMUM_TOL: f64 = 1e-12;
-
-/// Fidelity-based computation to check whether an operation `G` is equivalent
-/// to identity up to a global phase.
-///
-/// # Arguments
-///
-/// * `tr_over_dim`: `|Tr(G)| / dim(G)`.
-/// * `dim`: `dim(G)`.
-/// * `tol`: tolerance.
-///
-/// # Returns
-///
-/// * `Some(update to the global phase)` if the operation can be removed.
-/// * `None` if the operation cannot be removed.
-pub fn average_gate_fidelity_below_tol(tr_over_dim: Complex64, dim: f64, tol: f64) -> Option<f64> {
-    let f_pro = tr_over_dim.abs().powi(2);
-    let gate_fidelity = (dim * f_pro + 1.) / (dim + 1.);
-    if (1. - gate_fidelity).abs() < tol {
-        Some(tr_over_dim.arg())
-    } else {
-        None
-    }
-}
 
 /// Fidelity-based computation to check whether an operation `inst` is equivalent
 /// to identity up to a global phase.

--- a/crates/transpiler/src/passes/substitute_pi4_rotations.rs
+++ b/crates/transpiler/src/passes/substitute_pi4_rotations.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use num_complex::ComplexFloat;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use qiskit_circuit::bit::ShareableQubit;
@@ -19,7 +18,7 @@ use qiskit_circuit::operations::Operation;
 use qiskit_circuit::packed_instruction::PackedOperation;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_8, PI};
 
-use crate::gate_metrics::rotation_trace_and_dim;
+use crate::passes::common::{MINIMUM_TOL, is_angle_close_to_multiple_of_pi_k};
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedInstruction;
@@ -30,8 +29,6 @@ static ROTATION_GATE_NAMES: [&str; 14] = [
 
 type SubstituteSequencePi4<'a> = [(&'a [(StandardGate, &'a [u32])], f64); 16];
 type SubstituteSequencePi2<'a> = [(&'a [(StandardGate, &'a [u32])], f64); 8];
-
-const MINIMUM_TOL: f64 = 1e-12;
 
 /// Table for RZ(k * pi / 4) substitutions, with 0 <= k < 16
 static RZ_SUBSTITUTIONS: [(&[StandardGate], f64); 16] = [
@@ -977,36 +974,6 @@ static CRY_SUBSTITUTIONS: SubstituteSequencePi2 = [
         0.0,
     ),
 ];
-
-/// For a given angle, if it is a multiple of PI/k, calculate the multiple mod (4*k),
-/// Otherwise, return `None`.
-/// E.g, if the angle is a multiple m of PI/4 then it returns m, where 0 <= m < 16,
-/// and if the angle is a multiple m of PI/2 then it returns m, where 0 <= m < 8.
-pub fn is_angle_close_to_multiple_of_pi_k(
-    gate: StandardGate,
-    k: usize,
-    angle: f64,
-    tol: f64,
-) -> Option<usize> {
-    let closest_ratio = angle * (k as f64) / PI;
-    let closest_integer = closest_ratio.round();
-    let closest_angle = closest_integer * PI / (k as f64);
-    let theta = angle - closest_angle;
-
-    // Trace and dimension calculation of rotation matrices
-    let (tr_over_dim, dim) = rotation_trace_and_dim(gate, theta)
-        .expect("Since only supported rotation gates are given, the result is not None");
-
-    // fidelity-based tolerance
-    let f_pro = tr_over_dim.abs().powi(2);
-    let gate_fidelity = (dim * f_pro + 1.) / (dim + 1.);
-    let rem = 4 * k as i64;
-    if (1. - gate_fidelity).abs() < tol {
-        Some((closest_integer as i64).rem_euclid(rem) as usize)
-    } else {
-        None
-    }
-}
 
 /// The following two functions get a rotation gate and outputs an equivalent vector of
 /// standard gates in {Clifford, T, Tdg} and a global phase.


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

There are some helper functions:
- `average_gate_fidelity_below_tol`
- `is_angle_close_to_multiple_of_pi_k`

and a constant `MINIMUM_TOL = 1e-12`

that are used in several transpiler passes in rust:
- `commutative_optimization.rs`
- `remove_identity_equiv.rs`
- `litinski_transformation.rs`
- `substitute_pi4_rotation.rs`

These functions and constant are moved to a new `common.rs` file for a better code organization.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Sonnet 4.6

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
