### PR TITLE
Bump PyO3 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "nalgebra 0.34.2",
@@ -2168,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
@@ -2188,18 +2188,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2207,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2219,13 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.34"
 faer = "0.24"
-numpy = "0.28"
+numpy = "0.29"
 ndarray = "0.16"
 smallvec = "1.15"
 thiserror = "2.0"
@@ -51,7 +51,7 @@ npyz = {version = "0.9.1", features = ["complex"]}
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.28.3", features = ["abi3-py310"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -443,24 +443,24 @@ macro_rules! create_bit_object {
             fn new(
                 register: Option<Bound<$pyreg_struct>>,
                 index: Option<u32>,
-            ) -> PyResult<(Self, PyBit)> {
-                match (register, index) {
+            ) -> PyResult<PyClassInitializer<Self>> {
+                let bit = match (register, index) {
                     (Some(register), Some(index)) => {
                         let register = &register.borrow().0;
-                        let bit = register.get(index as usize).ok_or_else(|| {
+                        register.get(index as usize).ok_or_else(|| {
                             PyIndexError::new_err(format!(
                                 "index {} out of range for size {}",
                                 index,
                                 register.len()
                             ))
-                        })?;
-                        Ok((Self(bit), PyBit))
+                        })?
                     }
-                    (None, None) => Ok((Self($bit_struct::new_anonymous()), PyBit)),
-                    _ => Err(PyTypeError::new_err(
+                    (None, None) => $bit_struct::new_anonymous(),
+                    _ => return Err(PyTypeError::new_err(
                         "either both 'register' and 'index' are provided, or neither are",
                     )),
-                }
+                };
+                Ok(PyClassInitializer::from(PyBit).add_subclass(Self(bit)))
             }
 
             fn __repr__(slf: Bound<Self>) -> PyResult<String> {
@@ -746,7 +746,7 @@ macro_rules! create_bit_object {
                 size: Option<isize>,
                 name: Option<String>,
                 bits: Option<Vec<$bit_struct>>,
-            ) -> PyResult<(Self, PyRegister)> {
+            ) -> PyResult<PyClassInitializer<Self>> {
                 let name = name.unwrap_or_else(|| {
                     format!(
                         "{}{}",
@@ -754,8 +754,8 @@ macro_rules! create_bit_object {
                         $reg_struct::anonymous_instance_count().fetch_add(1, Ordering::Relaxed)
                     )
                 });
-                match (size, bits) {
-                    (None, None) | (Some(_), Some(_)) => Err(CircuitError::new_err(
+                let register = match (size, bits) {
+                    (None, None) | (Some(_), Some(_)) => return Err(CircuitError::new_err(
                         "Exactly one of the size or bits arguments can be provided.",
                     )),
                     (Some(size), None) => {
@@ -767,7 +767,7 @@ macro_rules! create_bit_object {
                         let Ok(size) = size.try_into() else {
                             return Err(CircuitError::new_err("Register size too large."));
                         };
-                        Ok((Self($reg_struct::new_owning(name, size)), PyRegister))
+                        $reg_struct::new_owning(name, size)
                     }
                     (None, Some(bits)) => {
                         if bits.iter().cloned().collect::<HashSet<_>>().len() != bits.len() {
@@ -775,9 +775,10 @@ macro_rules! create_bit_object {
                                 "Register bits must not be duplicated.",
                             ));
                         }
-                        Ok((Self($reg_struct::new_alias(Some(name), bits)), PyRegister))
+                        $reg_struct::new_alias(Some(name), bits)
                     }
-                }
+                };
+                Ok(PyClassInitializer::from(PyRegister).add_subclass(Self(register)))
             }
 
             /// The name of the register.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -61,9 +61,7 @@ use pyo3::exceptions::{
 use pyo3::intern;
 use pyo3::prelude::*;
 
-use pyo3::types::{
-    IntoPyDict, PyDict, PyInt, PyIterator, PyList, PySet, PyString, PyTuple, PyType,
-};
+use pyo3::types::{IntoPyDict, PyDict, PyInt, PyIterator, PyList, PySet, PyTuple, PyType};
 
 use rustworkx_core::dag_algo::layers;
 use rustworkx_core::err::ContractError;
@@ -4505,10 +4503,10 @@ impl DAGCircuit {
         graph_attrs: Option<BTreeMap<String, String>>,
         node_attrs: Option<Py<PyAny>>,
         edge_attrs: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyString>> {
+    ) -> PyResult<String> {
         let mut buffer = Vec::<u8>::new();
         build_dot(py, self, &mut buffer, graph_attrs, node_attrs, edge_attrs)?;
-        Ok(PyString::new(py, std::str::from_utf8(&buffer)?))
+        Ok(String::from_utf8(buffer)?)
     }
 
     /// Add an input variable to the circuit.

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -459,8 +459,8 @@ impl DAGInNode {
 #[pymethods]
 impl DAGInNode {
     #[new]
-    fn py_new(wire: Py<PyAny>) -> PyResult<(Self, DAGNode)> {
-        Ok((DAGInNode { wire }, DAGNode { node: None }))
+    fn py_new(wire: Py<PyAny>) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(DAGNode { node: None }).add_subclass(Self { wire })
     }
 
     fn __reduce__<'py>(slf: PyRef<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
@@ -517,8 +517,8 @@ impl DAGOutNode {
 #[pymethods]
 impl DAGOutNode {
     #[new]
-    fn py_new(wire: Py<PyAny>) -> PyResult<(Self, DAGNode)> {
-        Ok((DAGOutNode { wire }, DAGNode { node: None }))
+    fn py_new(wire: Py<PyAny>) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(DAGNode { node: None }).add_subclass(Self { wire })
     }
 
     fn __reduce__(slf: PyRef<Self>, py: Python) -> PyResult<Py<PyAny>> {


### PR DESCRIPTION
The relevant changes for us are mostly around the implicit tuple form of subclass initialisation being deprecated in favour of the explicit `PyClassInitializer`.  Our more modern subclass code was already doing this, so the changeset is small.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
