### PR TITLE
Fix link in release notes

### DIFF
--- a/releasenotes/notes/fix-underflow-constrained-reschedule-0c2df99fd6aae5a3.yaml
+++ b/releasenotes/notes/fix-underflow-constrained-reschedule-0c2df99fd6aae5a3.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Ensure no subtraction panic happens via underflow in :class:`.ConstrainedReschedule`.
-    Fixed `#16231 <https://github.com/Qiskit/qiskit/issues/16231>__`.
+    Fixed `#16231 <https://github.com/Qiskit/qiskit/issues/16231>`__.
 


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Our translation pipeline broke due to a misplaced tick in a link:

``` 
Fixed `#16231 <https://github.com/Qiskit/qiskit/issues/16231>__` 
```
It should be (I think):
```
Fixed `#16231 <https://github.com/Qiskit/qiskit/issues/16231>`__
```

Thanks!
### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
