### PR TITLE
Add duration for reset to GenericBackendV2

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -50,7 +50,7 @@ _NOISE_DEFAULTS = {
     "x": (2.997e-08, 5.994e-08, 9e-5, 1e-4),
     "measure": (6.99966e-07, 1.500054e-06, 1e-5, 5e-3),
     "delay": (None, None),
-    "reset": (None, None),
+    "reset": (2.212008e-06, None),
 }
 
 # Fallback values for gates with unknown noise default ranges.

--- a/releasenotes/notes/reset_duration_genericbackend-6a3be7c7e43ea2d4.yaml
+++ b/releasenotes/notes/reset_duration_genericbackend-6a3be7c7e43ea2d4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Circuits with reset instruction now can be scheduled using :class:`~GenericBackendV2`. The problem was that 
+    :class:`~GenericBackendV2` did not have a duration for `reset`.

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -448,6 +448,17 @@ class TestScheduledCircuit(QiskitTestCase):
         self.assertIsInstance(res, int)
         self.assertEqual(res, 100)
 
+    def test_reset_circ(self):
+        backend = GenericBackendV2(num_qubits=2, seed=42)
+
+        circ = QuantumCircuit(1)
+        circ.reset(0)
+
+        circuit_reset = transpile(circ, backend, scheduling_method="asap")
+        res = circuit_reset.estimate_duration(backend.target, unit="dt")
+        self.assertIsInstance(res, int)
+        self.assertEqual(res, 9964)
+
     def test_estimate_duration_control_flow(self):
         backend = GenericBackendV2(num_qubits=3, seed=42, control_flow=True)
 


### PR DESCRIPTION
For ages, [randomized testing](https://github.com/Qiskit/qiskit/issues/2645) had been failing because GenericBackendV2 does not have duration for reset:

```python
from qiskit import QuantumCircuit, transpile
from qiskit.providers.fake_provider import GenericBackendV2

circuit = QuantumCircuit(1)
circuit.reset(0)

transpile(circuit, backend=GenericBackendV2(2), scheduling_method='alap', seed_transpiler=0)
```
```
Duration of reset on qubits [0] is not found
```


This PR add that duration based on the reset duration from `ibm_kingston`


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
