### PR TITLE
Add control-flow checks to Rust check_map

### DIFF
--- a/crates/transpiler/src/passes/check_map.rs
+++ b/crates/transpiler/src/passes/check_map.rs
@@ -19,26 +19,18 @@ use qiskit_circuit::{PhysicalQubit, Qubit};
 
 use crate::target::Target;
 
-fn recurse(
-    dag: &DAGCircuit,
+fn recurse<'a>(
+    dag: &'a DAGCircuit,
     target: &Target,
     wire_map: Option<&[Qubit]>,
-) -> PyResult<Option<(String, [u32; 2])>> {
-    let check_qubits = |qubits: &[Qubit]| -> bool {
+) -> Option<(&'a str, [PhysicalQubit; 2])> {
+    let mapped_qargs = |qubits: &[Qubit]| -> [PhysicalQubit; 2] {
         match wire_map {
-            Some(wire_map) => {
-                let mapped_bits = [
-                    PhysicalQubit(wire_map[qubits[0].index()].0),
-                    PhysicalQubit(wire_map[qubits[1].index()].0),
-                ];
-                target.contains_qargs(&mapped_bits)
-                    || target.contains_qargs(&[mapped_bits[1], mapped_bits[0]])
-            }
-            None => {
-                target.contains_qargs(&[PhysicalQubit(qubits[0].0), PhysicalQubit(qubits[1].0)])
-                    || target
-                        .contains_qargs(&[PhysicalQubit(qubits[1].0), PhysicalQubit(qubits[0].0)])
-            }
+            Some(wire_map) => [
+                PhysicalQubit(wire_map[qubits[0].index()].0),
+                PhysicalQubit(wire_map[qubits[1].index()].0),
+            ],
+            None => [PhysicalQubit(qubits[0].0), PhysicalQubit(qubits[1].0)],
         }
     };
 
@@ -56,30 +48,26 @@ fn recurse(
                     })
                     .collect::<Vec<_>>();
 
-                let res = recurse(block, target, Some(&wire_map))?;
+                let res = recurse(block, target, Some(&wire_map));
                 if res.is_some() {
-                    return Ok(res);
+                    return res;
                 }
             }
-        } else if qubits.len() == 2 && !check_qubits(qubits) {
-            return Ok(Some((
-                inst.op.name().to_string(),
-                [qubits[0].0, qubits[1].0],
-            )));
+        } else if qubits.len() == 2 {
+            let qargs = mapped_qargs(qubits);
+            if !target.contains_qargs(&qargs) && !target.contains_qargs(&[qargs[1], qargs[0]]) {
+                return Some((inst.op.name(), qargs));
+            }
         }
     }
-    Ok(None)
+    None
 }
 
 #[pyfunction]
 #[pyo3(name = "check_map")]
 pub fn py_run_check_map(dag: &DAGCircuit, target: &Target) -> PyResult<Option<(String, [u32; 2])>> {
-    if dag.has_control_flow() {
-        recurse(dag, target, None)
-    } else {
-        Ok(run_check_map(dag, target)
-            .map(|(name, qubits)| (name.to_string(), [qubits[0].0, qubits[1].0])))
-    }
+    Ok(run_check_map(dag, target)
+        .map(|(name, qubits)| (name.to_string(), [qubits[0].0, qubits[1].0])))
 }
 
 /// Check that all 2q gates are in the target
@@ -87,23 +75,141 @@ pub fn run_check_map<'a>(
     dag: &'a DAGCircuit,
     target: &Target,
 ) -> Option<(&'a str, [PhysicalQubit; 2])> {
-    dag.op_nodes(false)
-        .filter(|(_idx, inst)| inst.op.num_qubits() == 2)
-        .find_map(|(_idx, inst)| {
-            let qargs_raw = dag.get_qargs(inst.qubits);
-            let qargs = [
-                PhysicalQubit::new(qargs_raw[0].0),
-                PhysicalQubit::new(qargs_raw[1].0),
-            ];
-            if !target.contains_qargs(&qargs) && !target.contains_qargs(&[qargs[1], qargs[0]]) {
-                Some((inst.op.name(), [qargs[0], qargs[1]]))
-            } else {
-                None
-            }
-        })
+    recurse(dag, target, None)
 }
 
 pub fn check_map_mod(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_run_check_map))?;
     Ok(())
+}
+
+#[cfg(all(test, not(miri)))]
+mod tests {
+    use super::*;
+    use crate::target::InstructionProperties;
+    use qiskit_circuit::circuit_data::CircuitData;
+    use qiskit_circuit::instruction::Parameters;
+    use qiskit_circuit::operations::{
+        ControlFlow, ControlFlowInstruction, ForCollection, Param, StandardGate,
+    };
+    use qiskit_circuit::packed_instruction::PackedOperation;
+    use smallvec::smallvec;
+
+    fn target_with_cx_edges(edges: &[(u32, u32)]) -> Target {
+        let mut target = Target::default();
+        let props = edges
+            .iter()
+            .map(|&(source, target)| {
+                (
+                    [PhysicalQubit(source), PhysicalQubit(target)].into(),
+                    None::<InstructionProperties>,
+                )
+            })
+            .collect();
+        target
+            .add_instruction(StandardGate::CX.into(), None, None, Some(props))
+            .unwrap();
+        target
+    }
+
+    fn cx_body(num_qubits: u32, control: u32, target: u32) -> CircuitData {
+        CircuitData::from_packed_operations(
+            num_qubits,
+            0,
+            [Ok((
+                StandardGate::CX.into(),
+                smallvec![],
+                vec![Qubit(control), Qubit(target)],
+                vec![],
+            ))],
+            Param::Float(0.0),
+        )
+        .unwrap()
+    }
+
+    fn add_for_loop(parent: &mut CircuitData, body: CircuitData, qargs: &[Qubit]) {
+        let block = parent.add_block(body);
+        let control_flow = ControlFlowInstruction {
+            control_flow: ControlFlow::ForLoop {
+                collection: ForCollection::List(vec![0]),
+                loop_param: None,
+            },
+            num_qubits: qargs.len() as u32,
+            num_clbits: 0,
+        };
+        parent
+            .push_packed_operation(
+                PackedOperation::from_control_flow(Box::new(control_flow)),
+                Some(Parameters::Blocks(vec![block])),
+                qargs,
+                &[],
+            )
+            .unwrap();
+    }
+
+    fn circuit_to_dag(circuit: &CircuitData) -> DAGCircuit {
+        DAGCircuit::from_circuit_data(circuit, false, None, None, None, None).unwrap()
+    }
+
+    #[test]
+    fn detects_top_level_violation() {
+        let target = target_with_cx_edges(&[(0, 1), (1, 2)]);
+        let dag = circuit_to_dag(&cx_body(3, 0, 2));
+
+        assert_eq!(
+            run_check_map(&dag, &target),
+            Some(("cx", [PhysicalQubit(0), PhysicalQubit(2)]))
+        );
+    }
+
+    #[test]
+    fn detects_control_flow_violation() {
+        let target = target_with_cx_edges(&[(0, 1), (1, 2)]);
+        let mut circuit = CircuitData::with_capacity(3, 0, 1, Param::Float(0.0)).unwrap();
+        add_for_loop(
+            &mut circuit,
+            cx_body(3, 0, 2),
+            &[Qubit(0), Qubit(1), Qubit(2)],
+        );
+        let dag = circuit_to_dag(&circuit);
+
+        assert_eq!(
+            run_check_map(&dag, &target),
+            Some(("cx", [PhysicalQubit(0), PhysicalQubit(2)]))
+        );
+    }
+
+    #[test]
+    fn maps_control_flow_block_qubits_to_parent_qubits() {
+        let target = target_with_cx_edges(&[(0, 1), (1, 2)]);
+        let mut circuit = CircuitData::with_capacity(3, 0, 1, Param::Float(0.0)).unwrap();
+        add_for_loop(
+            &mut circuit,
+            cx_body(3, 0, 2),
+            &[Qubit(1), Qubit(0), Qubit(2)],
+        );
+        let dag = circuit_to_dag(&circuit);
+
+        assert_eq!(run_check_map(&dag, &target), None);
+    }
+
+    #[test]
+    fn composes_nested_control_flow_qubit_maps() {
+        let target = target_with_cx_edges(&[(0, 1), (1, 2)]);
+        let mut inner = CircuitData::with_capacity(3, 0, 1, Param::Float(0.0)).unwrap();
+        add_for_loop(
+            &mut inner,
+            cx_body(3, 0, 2),
+            &[Qubit(2), Qubit(1), Qubit(0)],
+        );
+
+        let mut outer = CircuitData::with_capacity(3, 0, 1, Param::Float(0.0)).unwrap();
+        add_for_loop(&mut outer, inner, &[Qubit(2), Qubit(1), Qubit(0)]);
+        let dag = circuit_to_dag(&outer);
+
+        assert_eq!(
+            run_check_map(&dag, &target),
+            Some(("cx", [PhysicalQubit(0), PhysicalQubit(2)]))
+        );
+    }
 }


### PR DESCRIPTION
Fixes #16118

### Summary
- Make the native Rust `run_check_map` recurse through control-flow blocks.
- Compose nested control-flow qubit mappings before checking target connectivity.
- Add Rust unit tests for top-level, control-flow, remapped, and nested control-flow checks.

### Tests
- `cargo test -p qiskit-transpiler --lib`
- `uv run --group build --group test python -m unittest test.python.transpiler.test_check_map`

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: ChatGPT, GPT-5.5 Thinking.
- [x] I used the following tool to generate or modify code: ChatGPT, GPT-5.5 Thinking.
