### PR TITLE
Add DAG-based variant of BasisTranslator transpiler pass and opaque EquivalenceLibrary type in C Api

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -352,6 +352,19 @@ mod transpiler {
             .add_child(50, &FUNCTIONS_TARGET_ENTRY);
     }
 
+    mod equivalence_library {
+        use crate::impl_::prelude::*;
+        #[cfg(feature = "addr")]
+        use qiskit_cext::transpiler::equivalence_library::*;
+
+        pub static FUNCTIONS: ExportedFunctions = ExportedFunctions::leaves(10, || {
+            vec![
+                export_fn!(qk_equivalence_library_new_standard),
+                export_fn!(qk_equivalence_library_free),
+            ]
+        });
+    }
+
     mod passes {
         use crate::impl_::prelude::*;
         #[cfg(feature = "addr")]
@@ -423,7 +436,8 @@ mod transpiler {
         .add_child(35, &TRANSPILE_LAYOUT)
         .add_child(50, &TRANSPILE_STATE)
         .add_child(150, &target::FUNCTIONS)
-        .add_child(250, &passes::FUNCTIONS);
+        .add_child(250, &passes::FUNCTIONS)
+        .add_child(500, &equivalence_library::FUNCTIONS);
 }
 
 mod classical_expr {

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -380,6 +380,7 @@ mod transpiler {
                 export_fn!(remove_identity_equiv::qk_transpiler_pass_remove_identity_equivalent),
                 export_fn!(split_2q_unitaries::qk_transpiler_pass_split_2q_unitaries),
                 export_fn!(two_qubit_peephole::qk_transpiler_pass_2q_peephole_optimization),
+                export_fn!(basis_translator::qk_transpiler_pass_basis_translator),
             ]
         });
         static FUNCTIONS_STANDALONE: ExportedFunctions = ExportedFunctions::leaves(50, || {

--- a/crates/cext/src/transpiler/equivalence_library.rs
+++ b/crates/cext/src/transpiler/equivalence_library.rs
@@ -1,0 +1,62 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use qiskit_transpiler::equivalence::EquivalenceLibrary;
+use qiskit_transpiler::standard_equivalence_library::generate_standard_equivalence_library;
+
+/// @ingroup QkEquivalenceLibrary
+/// Construct a new ``QkEquivalenceLibrary`` populated with Qiskit's standard
+/// equivalences between gates.
+///
+/// @return A pointer to the new ``QkEquivalenceLibrary``.
+///
+/// # Example
+///
+/// ```c
+///     QkEquivalenceLibrary *lib = qk_equivalence_library_new_standard();
+///     qk_equivalence_library_free(lib);
+/// ```
+#[unsafe(no_mangle)]
+pub extern "C" fn qk_equivalence_library_new_standard() -> *mut EquivalenceLibrary {
+    Box::into_raw(Box::new(generate_standard_equivalence_library()))
+}
+
+/// @ingroup QkEquivalenceLibrary
+/// Free the ``QkEquivalenceLibrary``.
+///
+/// @param library A pointer to the ``QkEquivalenceLibrary`` to free.
+///
+/// # Example
+///
+/// ```c
+///     QkEquivalenceLibrary *lib = qk_equivalence_library_new_standard();
+///     qk_equivalence_library_free(lib);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``library`` is not a valid, non-null pointer to a
+/// ``QkEquivalenceLibrary``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_equivalence_library_free(library: *mut EquivalenceLibrary) {
+    if !library.is_null() {
+        if !library.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+
+        // SAFETY: We have verified the pointer is non-null and aligned, so it should be
+        // readable by Box.
+        unsafe {
+            let _ = Box::from_raw(library);
+        }
+    }
+}

--- a/crates/cext/src/transpiler/mod.rs
+++ b/crates/cext/src/transpiler/mod.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+pub mod equivalence_library;
 pub mod neighbors;
 pub mod passes;
 pub mod target;

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -13,6 +13,7 @@
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_transpiler::equivalence::EquivalenceLibrary;
 use qiskit_transpiler::passes::run_basis_translator;
 use qiskit_transpiler::standard_equivalence_library::generate_standard_equivalence_library;
 use qiskit_transpiler::target::Target;
@@ -20,8 +21,7 @@ use qiskit_transpiler::target::Target;
 /// @ingroup QkTranspilerPassesStandalone
 /// Run the BasisTranslator transpiler pass on a circuit.
 ///
-/// The BasisTranslator transpiler pass translates gates to a target basis by
-/// searching for a set of translations from the standard EquivalenceLibrary.
+/// Refer to the ``qk_transpiler_pass_basis_translator`` function for more details about the pass.
 ///
 /// @param circuit A pointer to the circuit to run BasisTranslator on.
 /// The circuit will be mutated in-place, unless the circuit is already
@@ -29,29 +29,6 @@ use qiskit_transpiler::target::Target;
 /// @param target The target where we will obtain basis gates from.
 /// @param min_qubits The minimum number of qubits for operations in the input
 /// circuit to translate.
-///
-/// # Example
-///
-/// ```c
-///    #include <qiskit.h>
-///
-///    QkCircuit *circuit = qk_circuit_new(3, 0);
-///    qk_circuit_gate(circuit, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL);
-///
-///    // Create a Target with global properties.
-///    QkTarget *target = qk_target_new(3);
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
-///
-///    // Run pass
-///    qk_transpiler_pass_standalone_basis_translator(circuit, target, 0);
-///
-///    // Free the circuit and target pointers once you're done
-///    qk_circuit_free(circuit);
-///    qk_target_free(target);
-/// ```
 ///
 /// # Safety
 ///
@@ -82,4 +59,80 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_basis_translator(
     let result_circ =
         CircuitData::from_dag_ref(&result_dag).expect("DAG to Circuit conversion failed");
     *circ_from_ptr = result_circ;
+}
+
+/// @ingroup QkTranspilerPasses
+/// Run the BasisTranslator transpiler pass on a DAG circuit.
+///
+/// The BasisTranslator transpiler pass translates gates to a target basis by
+/// searching for a set of translations from the supplied ``QkEquivalenceLibrary``.
+/// The DAG will be mutated in-place, unless the DAG is already in the target
+/// basis, in which case the DAG remains unchanged.
+///
+/// Unlike :c:func:`qk_transpiler_pass_standalone_basis_translator`, this
+/// function takes the equivalence library from the outside. This avoids
+/// regenerating it on every call when running the pass inside a custom
+/// transpiler stage, e.g. within a loop.
+///
+/// @param dag A pointer to the DAG to run BasisTranslator on.
+/// @param equiv_lib A pointer to the equivalence library to use as the source
+/// of translations.
+/// @param target The target where we will obtain basis gates from.
+/// @param min_qubits The minimum number of qubits for operations in the input
+/// DAG to translate.
+///
+/// # Example
+///
+/// ```c
+/// QkDag *dag = qk_dag_new();
+/// QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
+/// qk_dag_add_quantum_register(dag, qr);
+/// uint32_t qargs[3] = {0, 1, 2};
+/// qk_dag_apply_gate(dag, QkGate_CCX, qargs, NULL, false);
+///
+/// // Create a Target with global properties.
+/// QkTarget *target = qk_target_new(3);
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
+///
+/// // Build the equivalence library to use for the translation
+/// QkEquivalenceLibrary *equiv_lib = qk_equivalence_library_new_standard();
+///
+/// // Run pass
+/// qk_transpiler_pass_basis_translator(dag, equiv_lib, target, 0);
+///
+/// // Free the resources once you're done
+/// qk_equivalence_library_free(equiv_lib);
+/// qk_quantum_register_free(qr);
+/// qk_dag_free(dag);
+/// qk_target_free(target);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``dag``, ``equiv_lib`` and/or ``target`` are not
+/// valid, non-null pointers to a ``QkDag``, ``QkEquivalenceLibrary`` or
+/// ``QkTarget``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_transpiler_pass_basis_translator(
+    dag: *mut DAGCircuit,
+    equiv_lib: *mut EquivalenceLibrary,
+    target: *const Target,
+    min_qubits: usize,
+) {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let dag = unsafe { mut_ptr_as_ref(dag) };
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let equiv_lib = unsafe { mut_ptr_as_ref(equiv_lib) };
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let target = unsafe { const_ptr_as_ref(target) };
+
+    let result_dag = match run_basis_translator(dag, equiv_lib, min_qubits, Some(target), None) {
+        Ok(Some(result)) => result,
+        Ok(None) => return,
+        Err(e) => panic!("{}", e),
+    };
+    *dag = result_dag;
 }

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -9,6 +9,7 @@
  * @defgroup QkClassicalRegister QkClassicalRegister
  * @defgroup QkComplex64 QkComplex64
  * @defgroup QkDag QkDag
+ * @defgroup QkEquivalenceLibrary QkEquivalenceLibrary
  * @defgroup QkNeighbors QkNeighbors
  * @defgroup QkObs QkObs
  * @defgroup QkObsTerm QkObsTerm

--- a/releasenotes/notes/basis-translator-dag-pass-capi-aec35f37df1ea52e.yaml
+++ b/releasenotes/notes/basis-translator-dag-pass-capi-aec35f37df1ea52e.yaml
@@ -1,0 +1,16 @@
+---
+features_c:
+  - |
+    Added a new C API function :c:func:`qk_transpiler_pass_basis_translator`,
+    which runs the :class:`.BasisTranslator` transpiler pass on a ``QkDag``
+    in place. Unlike the standalone variant
+    :c:func:`qk_transpiler_pass_standalone_basis_translator`, this function
+    takes the equivalence library as an input parameter so callers can build
+    it once and reuse it across repeated calls (for example, when running
+    the pass inside a custom transpiler stage).
+  - |
+    Added a new opaque type ``QkEquivalenceLibrary`` together with the
+    constructor :c:func:`qk_equivalence_library_new_standard` and the
+    destructor :c:func:`qk_equivalence_library_free`. These let C callers
+    obtain Qiskit's standard library of gate equivalences for use with the
+    basis translator pass.

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -152,11 +152,146 @@ cleanup:
     return result;
 }
 
+static int test_dag_in_basis(void) {
+    int result = Ok;
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(2, "qr");
+    qk_dag_add_quantum_register(dag, qr);
+    qk_dag_apply_gate(dag, QkGate_H, (uint32_t[1]){0}, NULL, false);
+    qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[2]){0, 1}, NULL, false);
+
+    // Create Target already compatible with the DAG.
+    QkTarget *target = qk_target_new(1);
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
+
+    // Run pass with the standard equivalence library.
+    QkEquivalenceLibrary *equiv_lib = qk_equivalence_library_new_standard();
+    qk_transpiler_pass_basis_translator(dag, equiv_lib, target, 0);
+
+    size_t num_ops = qk_dag_num_op_nodes(dag);
+    if (num_ops != 2) {
+        result = EqualityError;
+        printf(
+            "The number of gates resulting from the translation is incorrect. Expected 2, got %zu",
+            num_ops);
+    }
+
+    qk_equivalence_library_free(equiv_lib);
+    qk_dag_free(dag);
+    qk_quantum_register_free(qr);
+    qk_target_free(target);
+    return result;
+}
+
+static int test_basic_dag_basis_translator(void) {
+    int result = Ok;
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(1, "qr");
+    qk_dag_add_quantum_register(dag, qr);
+    qk_dag_apply_gate(dag, QkGate_H, (uint32_t[1]){0}, NULL, false);
+
+    // Create Target compatible with only U gates, with global props.
+    QkTarget *target = qk_target_new(1);
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_U));
+
+    // Run pass with the standard equivalence library.
+    QkEquivalenceLibrary *equiv_lib = qk_equivalence_library_new_standard();
+    qk_transpiler_pass_basis_translator(dag, equiv_lib, target, 0);
+
+    size_t num_ops = qk_dag_num_op_nodes(dag);
+    if (num_ops != 1) {
+        result = EqualityError;
+        printf(
+            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
+            num_ops);
+    }
+
+    qk_equivalence_library_free(equiv_lib);
+    qk_dag_free(dag);
+    qk_quantum_register_free(qr);
+    qk_target_free(target);
+    return result;
+}
+
+static int test_toffoli_dag_basis_translator(void) {
+    int result = Ok;
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
+    qk_dag_add_quantum_register(dag, qr);
+    qk_dag_apply_gate(dag, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL, false);
+
+    // Create Target compatible with H, T, Tdg, CX gates, with global props.
+    QkTarget *target = qk_target_new(3);
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
+
+    // Run pass with the standard equivalence library, demonstrating that the
+    // same library instance can be reused across calls (e.g. when the pass is
+    // run in a loop within a custom transpiler stage).
+    QkEquivalenceLibrary *equiv_lib = qk_equivalence_library_new_standard();
+    qk_transpiler_pass_basis_translator(dag, equiv_lib, target, 0);
+
+    size_t num_ops = qk_dag_num_op_nodes(dag);
+    // CCX decomposes into 6 CX + 4 T + 3 Tdg + 2 H = 15 gates
+    if (num_ops != 15) {
+        result = EqualityError;
+        printf(
+            "The number of gates resulting from the translation is incorrect. Expected 15, got %zu",
+            num_ops);
+    }
+
+    qk_equivalence_library_free(equiv_lib);
+    qk_dag_free(dag);
+    qk_quantum_register_free(qr);
+    qk_target_free(target);
+    return result;
+}
+
+static int test_dag_basis_translator_reused_library(void) {
+    int result = Ok;
+    // Run the pass twice on different DAGs sharing the same equivalence
+    // library, mimicking the custom-stage loop use-case the API is designed
+    // for.
+    QkEquivalenceLibrary *equiv_lib = qk_equivalence_library_new_standard();
+
+    QkTarget *target = qk_target_new(1);
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_U));
+
+    for (int iter = 0; iter < 2; iter++) {
+        QkDag *dag = qk_dag_new();
+        QkQuantumRegister *qr = qk_quantum_register_new(1, "qr");
+        qk_dag_add_quantum_register(dag, qr);
+        qk_dag_apply_gate(dag, QkGate_H, (uint32_t[1]){0}, NULL, false);
+
+        qk_transpiler_pass_basis_translator(dag, equiv_lib, target, 0);
+
+        size_t num_ops = qk_dag_num_op_nodes(dag);
+        if (num_ops != 1) {
+            result = EqualityError;
+            printf("Iteration %d: expected 1 gate after translation, got %zu", iter, num_ops);
+        }
+
+        qk_dag_free(dag);
+        qk_quantum_register_free(qr);
+    }
+
+    qk_equivalence_library_free(equiv_lib);
+    qk_target_free(target);
+    return result;
+}
+
 int test_basis_translator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_circuit_in_basis);
     num_failed += RUN_TEST(test_basic_basis_translator);
     num_failed += RUN_TEST(test_toffoli_basis_translator);
+    num_failed += RUN_TEST(test_dag_in_basis);
+    num_failed += RUN_TEST(test_basic_dag_basis_translator);
+    num_failed += RUN_TEST(test_toffoli_dag_basis_translator);
+    num_failed += RUN_TEST(test_dag_basis_translator_reused_library);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
Continuation of #15783 and #16261

@eliarbel: please review

### Summary

Adds `qk_transpiler_pass_basis_translator()`, the DAG-based variant of the BasisTranslator standalone transpiler pass in the C API. This function operates directly on a `QkDag`  instead of a `QkCircuit`, avoiding circuit↔DAG round-trip conversions when chaining multiple passes together.

Introduces `QkEquivalenceLibrary`, a new opaque C type that wraps Qiskit's standard gate equivalence library. `qk_transpiler_pass_basis_translator()` accepts the equivalence library as an explicit input parameter. This PR implements only `qk_equivalence_library_new_standard()` and `qk_equivalence_library_free()`. 

The key improvement over the standalone variant (qk_transpiler_pass_standalone_basis_translator) is that callers can construct the equivalence library once and reuse it across repeated pass invocations, avoiding the cost of regenerating it on every call.

### Tests
4 new C tests in test/c/test_basis_translator.c:
- test_dag_in_basis: DAG already in the target basis is left unchanged
- test_basic_dag_basis_translator: H gate translated to U gate basis
- test_toffoli_dag_basis_translator: CCX decomposed into {H, T, Tdg, CX} (15 gates total)
- test_dag_basis_translator_reused_library: Run the pass twice on different DAGs sharing the same equivalence library

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Claude Sonnet 4.6
- [x] I used the following tool to generate or modify code: Review code, improve it Sonnet 4.6
