### PR TITLE
Allow 32-bit registers in `classical.expr` system

### DIFF
--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -101,7 +101,7 @@ pub struct CExprTypeInfo {
     /// The expression type
     ty: CExprType,
     /// Bit width for the Uint expression type
-    width: u16,
+    width: u32,
 }
 
 impl From<CExprTypeInfo> for Type {

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -30,7 +30,7 @@ pub enum Type {
     Bool,
     Duration,
     Float,
-    Uint(u16),
+    Uint(u32),
 }
 
 impl<'py> IntoPyObject<'py> for Type {
@@ -236,17 +236,17 @@ impl PyFloat {
     from_py_object
 )]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
-struct PyUint(u16);
+struct PyUint(u32);
 
 #[pymethods]
 impl PyUint {
     #[new]
-    fn new(py: Python, width: u16) -> Py<Self> {
+    fn new(py: Python, width: u32) -> Py<Self> {
         Py::new(py, (PyUint(width), PyType(TypeKind::Uint))).unwrap()
     }
 
     #[getter]
-    fn get_width(&self) -> u16 {
+    fn get_width(&self) -> u32 {
         self.0
     }
 

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1371,7 +1371,7 @@ fn add_standalone_vars(
             ExpressionType::Bool => classical::types::Type::Bool,
             ExpressionType::Duration => classical::types::Type::Duration,
             ExpressionType::Float => classical::types::Type::Float,
-            ExpressionType::Uint(val) => classical::types::Type::Uint(val.try_into()?),
+            ExpressionType::Uint(val) => classical::types::Type::Uint(val),
         };
         let uuid = u128::from_be_bytes(packed_var.uuid_bytes);
         let name = packed_var.name.clone();

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -33,7 +33,7 @@ use std::io::{Read, Seek, Write};
 pub(crate) fn pack_expression_type(ty: &Type) -> ExpressionTypePack {
     match ty {
         Type::Bool => ExpressionTypePack::Bool,
-        Type::Uint(width) => ExpressionTypePack::Int(*width as u32),
+        Type::Uint(width) => ExpressionTypePack::Int(*width),
         Type::Duration => ExpressionTypePack::Duration,
         Type::Float => ExpressionTypePack::Float,
     }
@@ -44,7 +44,7 @@ pub(crate) fn unpack_expression_type(type_pack: ExpressionTypePack) -> Type {
         ExpressionTypePack::Bool => Type::Bool,
         ExpressionTypePack::Duration => Type::Duration,
         ExpressionTypePack::Float => Type::Float,
-        ExpressionTypePack::Int(width) => Type::Uint(width as u16),
+        ExpressionTypePack::Int(width) => Type::Uint(width),
     }
 }
 

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -872,7 +872,7 @@ fn pack_expression_type(exp_type: &Type, version: u32) -> Result<ExpressionType,
                 })
             }
         }
-        Type::Uint(width) => Ok(ExpressionType::Uint(*width as u32)),
+        Type::Uint(width) => Ok(ExpressionType::Uint(*width)),
     }
 }
 

--- a/releasenotes/notes/expr-register-width-6ebe9e13fee97279.yaml
+++ b/releasenotes/notes/expr-register-width-6ebe9e13fee97279.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    :class:`.ClassicalRegister` objects with more than 65,535 bits can now be used with the
+    :mod:`qiskit.circuit.classical` expression system.

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -513,7 +513,7 @@ static int test_expr_value(void) {
             }
 
             if (value_type_info.width != 4) {
-                printf("Expected Uint width to be 4, got %" PRIu16 "\n", value_type_info.width);
+                printf("Expected Uint width to be 4, got %" PRIu32 "\n", value_type_info.width);
                 result = EqualityError;
                 goto cleanup;
             }

--- a/test/python/circuit/classical/test_expr_constructors.py
+++ b/test/python/circuit/classical/test_expr_constructors.py
@@ -62,6 +62,9 @@ class TestExprConstructors(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         self.assertEqual(expr.lift(cr), expr.Var(cr, types.Uint(cr.size)))
 
+        big = ClassicalRegister((1 << 32) - 1, "BIG")  # Limit is 32-bit.
+        self.assertEqual(expr.lift(big), expr.Var(big, types.Uint(big.size)))
+
         clbit = Clbit()
         self.assertEqual(expr.lift(clbit), expr.Var(clbit, types.Bool()))
 


### PR DESCRIPTION
The current limit in `Type` limits `Uint` sizes to 16-bit (65,535).  We want to do scaling tests storing one million or more bits, so we need to widen the type.  QPY already uses a 32-bit width in this location, and the 16-bit internal limit was just a memory optimisation.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

~This is a convenience for the work that #16273 enabled, but there's no need to rush this into 2.5 - it can go in 2.6 without causing problems.~  Since this got exposed through the C API, it's actually a bit more important to get it out before a release.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
