### PR TITLE
Fix for QPY backwards compatibility numpy 2.0 clash

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -469,19 +469,19 @@ fn unpack_pauli_product_rotation(
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 3 {
         return Err(QpyError::InvalidParameter(
-            "No matrix for unitary op".to_string(),
+            "No angle for pauli product rotation".to_string(),
         ));
     }
     let z_values = unpack_generic_value(&instruction.params[0], qpy_data, Endian::Big)?;
     let z = z_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(
-            "Pauli product measurement z parameter should be a boolean vector".to_string(),
+            "Pauli product rotation z parameter should be a boolean vector".to_string(),
         )
     })?;
     let x_values = unpack_generic_value(&instruction.params[1], qpy_data, Endian::Big)?;
     let x = x_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(
-            "Pauli product measurement x parameter should be a boolean vector".to_string(),
+            "Pauli product rotation x parameter should be a boolean vector".to_string(),
         )
     })?;
     let angle_value = unpack_generic_value(&instruction.params[2], qpy_data, Endian::Little)?;

--- a/test/qpy_compat/dockerfile
+++ b/test/qpy_compat/dockerfile
@@ -7,7 +7,7 @@ ARG CONSTRAINTS_FILE=qpy_test_constraints.txt
 
 ENV PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1 PYTHONDONTWRITEBYTECODE=1
 WORKDIR /work
-COPY ${CONSTRAINTS_FILE}
-RUN python -m pip install --upgrade pip && pip install -c constraints.txt packaging "${PACKAGE_NAME}==${PACKAGE_VERSION}";
+COPY ${CONSTRAINTS_FILE} qpy_test_constraints.txt
+RUN python -m pip install --upgrade pip && pip install -c qpy_test_constraints.txt packaging "${PACKAGE_NAME}==${PACKAGE_VERSION}";
 
 CMD ["python", "-c", "import qiskit; import sys; print(f'Qiskit version: {qiskit.__version__}'); print(f'Python version: {sys.version}')"]

--- a/test/qpy_compat/dockerfile
+++ b/test/qpy_compat/dockerfile
@@ -3,10 +3,11 @@ FROM python:${PYTHON_VERSION}-slim
 
 ARG PACKAGE_NAME=qiskit
 ARG PACKAGE_VERSION=
+ARG CONSTRAINTS_FILE=qpy_test_constraints.txt
 
 ENV PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1 PYTHONDONTWRITEBYTECODE=1
 WORKDIR /work
-COPY qpy_test_constraints.txt .
-RUN python -m pip install --upgrade pip && pip install -c qpy_test_constraints.txt packaging "${PACKAGE_NAME}==${PACKAGE_VERSION}";
+COPY ${CONSTRAINTS_FILE}
+RUN python -m pip install --upgrade pip && pip install -c constraints.txt packaging "${PACKAGE_NAME}==${PACKAGE_VERSION}";
 
 CMD ["python", "-c", "import qiskit; import sys; print(f'Qiskit version: {qiskit.__version__}'); print(f'Python version: {sys.version}')"]

--- a/test/qpy_compat/process_forward_version.sh
+++ b/test/qpy_compat/process_forward_version.sh
@@ -52,7 +52,12 @@ venv_dir="$(pwd -P)/venvs/qiskit-$qiskit_version"
 
 # Use the updated constraints file for qiskit >= 2.5
 constraints_file="qpy_test_constraints.txt"
-if "$python" -c "from packaging.version import Version; v = Version('$qiskit_version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
+
+major=${qiskit_version%%.*}
+rest=${qiskit_version#*.}
+minor=${rest%%[^0-9]*}
+
+if (( major > 2 || (major == 2 && minor >= 5) )); then
     constraints_file="qpy_test_constraints25.txt"
 fi
 

--- a/test/qpy_compat/process_forward_version.sh
+++ b/test/qpy_compat/process_forward_version.sh
@@ -50,6 +50,12 @@ files_dir="$(pwd -P)/forward-qpy-files/qpy${qpy_version}"
 our_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 venv_dir="$(pwd -P)/venvs/qiskit-$qiskit_version"
 
+# Use the updated constraints file for qiskit >= 2.5
+constraints_file="qpy_test_constraints.txt"
+if "$python" -c "from packaging.version import Version; v = Version('$qiskit_version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
+    constraints_file="qpy_test_constraints25.txt"
+fi
+
 if [[ ! -d "$files_dir" ]]; then
     echo "Error: QPY files directory not found: $files_dir" 1>&2
     echo "Please run run_tests.sh first to generate QPY files" 1>&2
@@ -60,7 +66,7 @@ fi
 echo "Building venv for qiskit==$qiskit_version"
 "$python" -m venv "$venv_dir"
 "$venv_dir/bin/pip" install --upgrade pip setuptools wheel
-"$venv_dir/bin/pip" install -c "${our_dir}/qpy_test_constraints.txt" "qiskit==${qiskit_version}" packaging
+"$venv_dir/bin/pip" install -c "${our_dir}/${constraints_file}" "qiskit==${qiskit_version}" packaging
 
 # Step 2: Load the pre-generated QPY files using the venv.
 pushd "$files_dir"

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -48,9 +48,9 @@ our_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 cache_dir="$(pwd -P)/qpy_cache/$version"
 venv_dir="$(pwd -P)/venvs/$package-$version"
 
-# Use the updated constraints file for qiskit >= 2.5 (numpy >= 2.0.0 requirement)
+# Use the updated constraints file for qiskit >= 2.5 (numpy >= 2.0.0 requirement).
 constraints_file="qpy_test_constraints.txt"
-if "$python" -c "from packaging.version import Version; exit(0 if Version('$version') >= Version('2.5') else 1)" 2>/dev/null; then
+if "$python" -c "from packaging.version import Version; v = Version('$version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
     constraints_file="qpy_test_constraints25.txt"
 fi
 

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -48,8 +48,14 @@ our_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 cache_dir="$(pwd -P)/qpy_cache/$version"
 venv_dir="$(pwd -P)/venvs/$package-$version"
 
+# Use the updated constraints file for qiskit >= 2.5 (numpy >= 2.0.0 requirement)
+constraints_file="qpy_test_constraints.txt"
+if "$python" -c "from packaging.version import Version; exit(0 if Version('$version') >= Version('2.5') else 1)" 2>/dev/null; then
+    constraints_file="qpy_test_constraints25.txt"
+fi
+
 if [[ ! -d $cache_dir ]] ; then
-    docker build -t $package:$version --build-arg PYTHON_VERSION=$python_version --build-arg PACKAGE_NAME=$package --build-arg PACKAGE_VERSION=$version .
+    docker build -t $package:$version --build-arg PYTHON_VERSION=$python_version --build-arg PACKAGE_NAME=$package --build-arg PACKAGE_VERSION=$version --build-arg CONSTRAINTS_FILE=$constraints_file .
     mkdir -p "$cache_dir"
     pushd "$cache_dir"
     echo "Generating QPY files with $package==$version"

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -50,7 +50,12 @@ venv_dir="$(pwd -P)/venvs/$package-$version"
 
 # Use the updated constraints file for qiskit >= 2.5 (numpy >= 2.0.0 requirement).
 constraints_file="qpy_test_constraints.txt"
-if "$python" -c "from packaging.version import Version; v = Version('$version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
+
+major=${qiskit_version%%.*}
+rest=${qiskit_version#*.}
+minor=${rest%%[^0-9]*}
+
+if (( major > 2 || (major == 2 && minor >= 5) )); then
     constraints_file="qpy_test_constraints25.txt"
 fi
 

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -51,8 +51,8 @@ venv_dir="$(pwd -P)/venvs/$package-$version"
 # Use the updated constraints file for qiskit >= 2.5 (numpy >= 2.0.0 requirement).
 constraints_file="qpy_test_constraints.txt"
 
-major=${qiskit_version%%.*}
-rest=${qiskit_version#*.}
+major=${version%%.*}
+rest=${version#*.}
 minor=${rest%%[^0-9]*}
 
 if (( major > 2 || (major == 2 && minor >= 5) )); then

--- a/test/qpy_compat/process_version_with_venv.sh
+++ b/test/qpy_compat/process_version_with_venv.sh
@@ -46,10 +46,16 @@ our_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 cache_dir="$(pwd -P)/qpy_cache/$version"
 venv_dir="$(pwd -P)/venvs/$package-$version"
 
+# Use the updated constraints file for qiskit >= 2.5
+constraints_file="qpy_test_constraints.txt"
+if "$python" -c "from packaging.version import Version; v = Version('$version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
+    constraints_file="qpy_test_constraints25.txt"
+fi
+
 if [[ ! -d $cache_dir ]] ; then
     echo "Building venv for $package==$version"
     "$python" -m venv "$venv_dir"
-    "$venv_dir/bin/pip" install -c "${our_dir}/qpy_test_constraints.txt" "${package}==${version}" packaging
+    "$venv_dir/bin/pip" install -c "${our_dir}/${constraints_file}" "${package}==${version}" packaging
     mkdir -p "$cache_dir"
     pushd "$cache_dir"
     echo "Generating QPY files with $package==$version"

--- a/test/qpy_compat/process_version_with_venv.sh
+++ b/test/qpy_compat/process_version_with_venv.sh
@@ -48,7 +48,12 @@ venv_dir="$(pwd -P)/venvs/$package-$version"
 
 # Use the updated constraints file for qiskit >= 2.5
 constraints_file="qpy_test_constraints.txt"
-if "$python" -c "from packaging.version import Version; v = Version('$version'); exit(0 if Version(f'{v.major}.{v.minor}') >= Version('2.5') else 1)" 2>/dev/null; then
+
+major=${qiskit_version%%.*}
+rest=${qiskit_version#*.}
+minor=${rest%%[^0-9]*}
+
+if (( major > 2 || (major == 2 && minor >= 5) )); then
     constraints_file="qpy_test_constraints25.txt"
 fi
 

--- a/test/qpy_compat/process_version_with_venv.sh
+++ b/test/qpy_compat/process_version_with_venv.sh
@@ -49,8 +49,8 @@ venv_dir="$(pwd -P)/venvs/$package-$version"
 # Use the updated constraints file for qiskit >= 2.5
 constraints_file="qpy_test_constraints.txt"
 
-major=${qiskit_version%%.*}
-rest=${qiskit_version#*.}
+major=${version%%.*}
+rest=${version#*.}
 minor=${rest%%[^0-9]*}
 
 if (( major > 2 || (major == 2 && minor >= 5) )); then

--- a/test/qpy_compat/qpy_test_constraints25.txt
+++ b/test/qpy_compat/qpy_test_constraints25.txt
@@ -1,5 +1,5 @@
 numpy>=2.0.0
-scipy===1.10.1
+scipy>=1.14
 
 # This is a loose constraint because we want to test different versions,
 # as defined in 'test/qpy_compat/run_tests.sh', but any symengine version 

--- a/test/qpy_compat/qpy_test_constraints25.txt
+++ b/test/qpy_compat/qpy_test_constraints25.txt
@@ -1,0 +1,7 @@
+numpy>=2.0.0
+scipy===1.10.1
+
+# This is a loose constraint because we want to test different versions,
+# as defined in 'test/qpy_compat/run_tests.sh', but any symengine version 
+# above (and including) 0.14 will be incompatible with qpy.
+symengine<0.14

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -1099,7 +1099,9 @@ def generate_circuits(
         generating_version.release >= (2, 4, 0)
         and current_version.release >= (2, 4, 0)
         and (not forward_tests or current_version.release[1] != 4)
-        and (qpy_version >= 17) # PPR gates are not supported in Python QPY, which currently handles qpy versions up to 16
+        and (
+            qpy_version is None or qpy_version >= 17
+        )  # PPR gates are not supported in Python QPY, which currently handles qpy versions up to 16
     ):
         output_circuits["ppr.qpy"] = generate_pauli_product_rotation()
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -1099,6 +1099,7 @@ def generate_circuits(
         generating_version.release >= (2, 4, 0)
         and current_version.release >= (2, 4, 0)
         and (not forward_tests or current_version.release[1] != 4)
+        and (qpy_version >= 17) # PPR gates are not supported in Python QPY, which currently handles qpy versions up to 16
     ):
         output_circuits["ppr.qpy"] = generate_pauli_product_rotation()
 


### PR DESCRIPTION
# Summary
In qiskit 2.5, the numpy and scipy minimum versions were increased. However, the QPY backwards compatibility tests still rely on older versions when running old qiskit instances.

This PR adds a new constraint file with updated versions for numpy and scipy for 2.5 onwards.

Another problem that came up as part of the backwards compatibility tests is that the Pauli Product Rotation fails for QPY versions < 17 since those versions are currently serialized with the python QPY component, which is obsolete and does not support PPR gates. The test was disabled and some relevant typos were fixed.


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
