### PR TITLE
Fix commuting2q block parameter preservation

### DIFF
--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from qiskit.exceptions import QiskitError
-from qiskit.circuit import Clbit, Gate, Parameter, Qubit
+from qiskit.circuit import Clbit, Gate, Parameter, ParameterExpression, Qubit
 from qiskit.dagcircuit import DAGOpNode
 
 
@@ -47,7 +47,7 @@ class Commuting2qBlock(Gate):
             cbits.update(node.cargs)
 
             for param in node.op.params:
-                if isinstance(param, Parameter):
+                if isinstance(param, ParameterExpression):
                     params_set.update(param.parameters)
         params_list = list(params_set)
 

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from qiskit.exceptions import QiskitError
-from qiskit.circuit import Gate, Qubit, Clbit
+from qiskit.circuit import Clbit, Gate, ParameterExpression, Qubit
 from qiskit.dagcircuit import DAGOpNode
 
 
@@ -37,6 +37,8 @@ class Commuting2qBlock(Gate):
         """
         qubits: set[Qubit] = set()
         cbits: set[Clbit] = set()
+        params_set: set[ParameterExpression] = set()
+
         for node in node_block:
             if len(node.qargs) != 2:
                 raise QiskitError(f"Node {node.name} does not apply to two-qubits.")
@@ -44,13 +46,19 @@ class Commuting2qBlock(Gate):
             qubits.update(node.qargs)
             cbits.update(node.cargs)
 
+            # Collect parameters from the node's operation
+            for param in node.op.params:
+                if isinstance(param, ParameterExpression):
+                    params_set.update(param.parameters)
+        params_list = sorted(params_set, key=lambda p: p.name)   
+
         if cbits:
             raise QiskitError(
                 f"{self.__class__.__name__} does not accept nodes with classical bits."
             )
 
         super().__init__(
-            "commuting_2q_block", num_qubits=len(qubits), params=[], label="Commuting 2q gates"
+            "commuting_2q_block", num_qubits=len(qubits), params=params_list, label="Commuting 2q gates"
         )
         self.node_block = node_block
         self.qubits = qubits

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from qiskit.exceptions import QiskitError
-from qiskit.circuit import Clbit, Gate, ParameterExpression, Qubit
+from qiskit.circuit import Clbit, Gate, Parameter, Qubit
 from qiskit.dagcircuit import DAGOpNode
 
 
@@ -37,7 +37,7 @@ class Commuting2qBlock(Gate):
         """
         qubits: set[Qubit] = set()
         cbits: set[Clbit] = set()
-        params_set: set[ParameterExpression] = set()
+        params_set: set[Parameter] = set()
 
         for node in node_block:
             if len(node.qargs) != 2:
@@ -47,7 +47,7 @@ class Commuting2qBlock(Gate):
             cbits.update(node.cargs)
 
             for param in node.op.params:
-                if isinstance(param, ParameterExpression):
+                if isinstance(param, Parameter):
                     params_set.update(param.parameters)
         params_list = list(params_set)
 

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -46,7 +46,6 @@ class Commuting2qBlock(Gate):
             qubits.update(node.qargs)
             cbits.update(node.cargs)
 
-            # Collect parameters from the node's operation
             for param in node.op.params:
                 if isinstance(param, ParameterExpression):
                     params_set.update(param.parameters)

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -25,6 +25,9 @@ class Commuting2qBlock(Gate):
 
     This gate is intended for use with commuting swap strategies to make it convenient
     for the swap strategy router to identify which blocks of operations commute.
+    
+    Note that :attr:`params` of this gate reports the free parameters the nodes contain.
+    There is no guaranteed order they are stored in.
     """
 
     def __init__(self, node_block: Iterable[DAGOpNode]) -> None:

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -49,7 +49,7 @@ class Commuting2qBlock(Gate):
             for param in node.op.params:
                 if isinstance(param, ParameterExpression):
                     params_set.update(param.parameters)
-        params_list = sorted(params_set, key=lambda p: p.name)
+        params_list = list(params_set)
 
         if cbits:
             raise QiskitError(

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -25,7 +25,7 @@ class Commuting2qBlock(Gate):
 
     This gate is intended for use with commuting swap strategies to make it convenient
     for the swap strategy router to identify which blocks of operations commute.
-    
+
     Note that :attr:`params` of this gate reports the free parameters the nodes contain.
     There is no guaranteed order they are stored in.
     """

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_block.py
@@ -50,7 +50,7 @@ class Commuting2qBlock(Gate):
             for param in node.op.params:
                 if isinstance(param, ParameterExpression):
                     params_set.update(param.parameters)
-        params_list = sorted(params_set, key=lambda p: p.name)   
+        params_list = sorted(params_set, key=lambda p: p.name)
 
         if cbits:
             raise QiskitError(
@@ -58,7 +58,10 @@ class Commuting2qBlock(Gate):
             )
 
         super().__init__(
-            "commuting_2q_block", num_qubits=len(qubits), params=params_list, label="Commuting 2q gates"
+            "commuting_2q_block",
+            num_qubits=len(qubits),
+            params=params_list,
+            label="Commuting 2q gates",
         )
         self.node_block = node_block
         self.qubits = qubits

--- a/releasenotes/notes/fix-commuting2qblock-parameters-bc0ad1c462ad72d6.yaml
+++ b/releasenotes/notes/fix-commuting2qblock-parameters-bc0ad1c462ad72d6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - Fixed parameter loss in :class:`~.Commuting2qBlock` where the ``params``
+    attribute was hardcoded to an empty list, causing all parameters from
+    input parametric gates to be lost. 
+    The fix properly extracts and preserves parameters from gate operations,
+    including those in :class:`~.ParameterExpression` objects.

--- a/releasenotes/notes/fix-commuting2qblock-parameters-bc0ad1c462ad72d6.yaml
+++ b/releasenotes/notes/fix-commuting2qblock-parameters-bc0ad1c462ad72d6.yaml
@@ -5,3 +5,4 @@ fixes:
     input parametric gates to be lost. 
     The fix properly extracts and preserves parameters from gate operations,
     including those in :class:`~.ParameterExpression` objects.
+    Fixed `#16456 <https://github.com/Qiskit/qiskit/issues/16456>`__.

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -718,10 +718,6 @@ class TestSwapRouterExceptions(QiskitTestCase):
         expected_params = {theta[0], theta[1], theta[2]}
         self.assertEqual(circuit_params, expected_params)
 
-        # Verify parameters are in correct order (respecting ParameterVector indices)
-        params_list = list(circuit_with_block.parameters)
-        self.assertEqual(params_list, [theta[0], theta[1], theta[2]])
-
         # Assign parameters and verify the circuit has no parameters after assignment
         param_values = {theta[0]: 0.5, theta[1]: 1.0, theta[2]: 1.5}
         assigned_circuit = circuit_with_block.assign_parameters(param_values)

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -14,7 +14,7 @@
 
 from ddt import ddt, data
 
-from qiskit.circuit import QuantumCircuit, Qubit, QuantumRegister, Parameter
+from qiskit.circuit import QuantumCircuit, Qubit, QuantumRegister, Parameter, ParameterVector
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler import PassManager, CouplingMap, Layout, TranspilerError
 from qiskit.circuit.library import PauliEvolutionGate, CXGate
@@ -696,3 +696,58 @@ class TestSwapRouterExceptions(QiskitTestCase):
         self.assertEqual(len(block.params), 3)
         param_names = {p.name for p in block.params}
         self.assertEqual(param_names, {"c_0", "gamma", "c_1"})
+
+    def test_parameters_when_appending_commuting2qblock_to_a_circuit(self):
+        """Test that a circuit appended with Commuting2qBlock knows about its parameters."""
+
+        theta = ParameterVector("theta", 3)
+        qc = QuantumCircuit(3)
+        qc.rzz(theta[0], 0, 1)
+        qc.rzz(theta[1], 1, 2)
+        qc.rzz(theta[2], 0, 2)
+
+        dag = circuit_to_dag(qc)
+        nodes = list(dag.topological_op_nodes())
+        block = Commuting2qBlock(nodes)
+
+        circuit_with_block = QuantumCircuit(3)
+        self.assertEqual(circuit_with_block.parameters, {})
+        circuit_with_block.append(block, range(3))
+
+        circuit_params = set(circuit_with_block.parameters)
+        expected_params = {theta[0], theta[1], theta[2]}
+        self.assertEqual(circuit_params, expected_params)
+
+        # Verify parameters are in correct order (respecting ParameterVector indices)
+        params_list = list(circuit_with_block.parameters)
+        self.assertEqual(params_list, [theta[0], theta[1], theta[2]])
+
+        # Assign parameters and verify the circuit has no parameters after assignment
+        param_values = {theta[0]: 0.5, theta[1]: 1.0, theta[2]: 1.5}
+        assigned_circuit = circuit_with_block.assign_parameters(param_values)
+        self.assertEqual(assigned_circuit.parameters, {})
+
+    def test_commuting2qblock_parameter_reuse(self):
+        """Test that reusing the same parameter multiple times within a block works correctly."""
+
+        gamma = Parameter("gamma")
+        c_0 = Parameter("c_0")
+        qc = QuantumCircuit(3)
+        qc.rzz(gamma, 0, 1)
+        qc.rzz(2 * gamma, 1, 2)
+        qc.rzz(gamma + c_0, 0, 2)  # Reuse gamma
+
+        dag = circuit_to_dag(qc)
+        nodes = list(dag.topological_op_nodes())
+        block = Commuting2qBlock(nodes)
+
+        self.assertEqual(len(block.params), 2)
+        self.assertEqual(set(block.params), {c_0, gamma})
+
+        circuit_with_block = QuantumCircuit(3)
+        circuit_with_block.append(block, range(3))
+
+        self.assertEqual(set(circuit_with_block.parameters), {gamma, c_0})
+
+        assigned_circuit = circuit_with_block.assign_parameters({gamma: 0.7})
+        self.assertEqual(len(assigned_circuit.parameters), 1)

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -14,7 +14,7 @@
 
 from ddt import ddt, data
 
-from qiskit.circuit import QuantumCircuit, Qubit, QuantumRegister
+from qiskit.circuit import QuantumCircuit, Qubit, QuantumRegister, Parameter
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler import PassManager, CouplingMap, Layout, TranspilerError
 from qiskit.circuit.library import PauliEvolutionGate, CXGate
@@ -676,3 +676,23 @@ class TestSwapRouterExceptions(QiskitTestCase):
 
         with self.assertRaises(QiskitError):
             Commuting2qBlock(circuit_to_dag(circ).op_nodes())
+
+    def test_commuting2qblock_preserves_parameters(self):
+        """Test that Commuting2qBlock preserves parameters from parametric gates."""
+
+        c_0 = Parameter("c_0")
+        c_1 = Parameter("c_1")
+        gamma = Parameter("gamma")
+
+        qc = QuantumCircuit(3)
+        qc.rzz(c_0 * gamma, 0, 1)
+        qc.rzz(c_1, 1, 2)
+
+        dag = circuit_to_dag(qc)
+        nodes = list(dag.topological_op_nodes())
+        block = Commuting2qBlock(nodes)
+
+        # Check that both parameters are preserved
+        self.assertEqual(len(block.params), 3)
+        param_names = {p.name for p in block.params}
+        self.assertEqual(param_names, {"c_0", "gamma", "c_1"})


### PR DESCRIPTION
This PR fixes parameter loss in `Commuting2qBlock` where `params` was hardcoded to an empty list, breaking parametric circuits.

Fix issue #16456 

### Details

**Problem:** `Commuting2qBlock.__init__` hardcoded `params=[]`, losing all parameters from input gates.

**Solution:** Extract parameters from gate operations.

**Changes:**
- Modified `__init__` to collect parameters from `ParameterExpression` objects
- Added two tests in `test_swap_strategy_router.py`

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [X] I used the following tool to help write this PR description: IBM Bob
- [X] I used the following tool to generate or modify code: IBM Bob
