### PR TITLE
Add a release note for the Rust circuit drawer

### DIFF
--- a/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
+++ b/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
@@ -5,4 +5,4 @@ features_visualization:
     :class:`.PauliProductRotationGate` gates, improved parameter rendering that displays ``Pi`` fractions in 
     readable format (e.g., ``Rx(π/3)`` instead of ``Rx(1.047...)``), and visual improvements 
     including a more compact measurement box representation and cleaner :class:`.CPhaseGate` gate rendering. 
-    See `issue 15849 <https://github.com/Qiskit/qiskit/issues/15849>`_ for more details.
+    See `#15849 <https://github.com/Qiskit/qiskit/issues/15849>`__ for more details.

--- a/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
+++ b/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
@@ -1,7 +1,7 @@
 ---
-
 features_visualization:
   - The Rust circuit drawer has been enhanced with support for :class:`.PauliProductMeasurement` and 
     :class:`.PauliProductRotationGate` gates, improved parameter rendering that displays ``Pi`` fractions in 
     readable format (e.g., ``Rx(π/3)`` instead of ``Rx(1.047...)``), and visual improvements 
-    including a more compact measurement box representation and cleaner ``CPhase`` gate rendering. 
+    including a more compact measurement box representation and cleaner :class:`.CPhaseGate` gate rendering. 
+    See `issue 15849 <https://github.com/Qiskit/qiskit/issues/15849>`_ for more details.

--- a/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
+++ b/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
@@ -1,0 +1,7 @@
+---
+
+features_visualization:
+  - The Rust circuit drawer has been enhanced with support for :class:`.PauliProductMeasurement` and 
+    :class:`.PauliProductRotationGate` gates, improved parameter rendering that displays ``Pi`` fractions in 
+    readable format (e.g., ``Rx(π/3)`` instead of ``Rx(1.047...)``), and visual improvements 
+    including a more compact measurement box representation and cleaner ``CPhase`` gate rendering. 

--- a/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
+++ b/releasenotes/notes/2.5/rust-circuit-drawer-issue-15849-123e672bf28075e9.yaml
@@ -1,6 +1,7 @@
 ---
 features_visualization:
-  - The Rust circuit drawer has been enhanced with support for :class:`.PauliProductMeasurement` and 
+  - The Rust circuit drawer (accessible e.g., via :c:func:`qk_circuit_draw` in the C API) 
+    has been enhanced with support for :class:`.PauliProductMeasurement` and 
     :class:`.PauliProductRotationGate` gates, improved parameter rendering that displays ``Pi`` fractions in 
     readable format (e.g., ``Rx(π/3)`` instead of ``Rx(1.047...)``), and visual improvements 
     including a more compact measurement box representation and cleaner :class:`.CPhaseGate` gate rendering. 


### PR DESCRIPTION
This PR adds a release note to describe the Rust circuit drawer enhancements in 2.5, tracked in #15849.

- [x] I didn't use LLM tooling, or only used it privately.