### PR TITLE
Fix cache and prediction misses in `Target::qargs`

### DIFF
--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -233,7 +233,12 @@ pub struct Target {
     pub concurrent_measurements: Option<Vec<Vec<PhysicalQubit>>>,
     gate_map: IndexMap<String, TargetProperties>,
     global_operations: HashMap<u32, HashSet<String>>,
-    qarg_gate_map: HashMap<Qargs, HashSet<String>>,
+    // This uses `IndexMap` not because it's necessary for determinism (though it will help), but so
+    // it retains the specific iteration order it is constructed with.  The order `qargs` are
+    // encountered during construction are _usually_ going to be quite structured, and structure
+    // here means that graphs built from qargs (like the coupling graph) will have their edges
+    // ordered in much cache- and branch-prediction-friendlier orders than if they are randomised.
+    qarg_gate_map: IndexMap<Qargs, HashSet<String>>,
     has_angle_bounds: bool,
 }
 
@@ -326,7 +331,7 @@ impl Target {
             concurrent_measurements,
             gate_map: IndexMap::default(),
             global_operations: HashMap::default(),
-            qarg_gate_map: HashMap::default(),
+            qarg_gate_map: IndexMap::default(),
             has_angle_bounds: false,
         })
     }
@@ -847,10 +852,7 @@ impl Target {
             );
         }
         self.gate_map = gate_map;
-        self.qarg_gate_map = state
-            .get_item("qarg_gate_map")?
-            .unwrap()
-            .extract::<HashMap<Qargs, HashSet<String>>>()?;
+        self.qarg_gate_map = state.get_item("qarg_gate_map")?.unwrap().extract()?;
         self.global_operations = state
             .get_item("global_operations")?
             .unwrap()

--- a/releasenotes/notes/fix-qargs-cache-prediction-d18992aa885a2353.yaml
+++ b/releasenotes/notes/fix-qargs-cache-prediction-d18992aa885a2353.yaml
@@ -1,0 +1,5 @@
+---
+performance:
+  - |
+    Fixed a performance regression only in v2.5.0rc1 when running :class:`.VF2Layout` and
+    :class:`.VF2PostLayout` on large coupling maps with very high-degree connectivity.


### PR DESCRIPTION
Fix cache and prediction misses in `Target::qargs`

In 2.5.0rc1 we noticed a significant slowdown in VF2-dominated all-to-all connectivity transpilation benchmarks, which this fixes.

## Background

We recently changed the internal hash-map data structures in the `Target` to consolidate various properties, and avoid `IndexSet` tracking overhead in the qargs tracking[^1]; it wasn't generally needed for determinism. However, randomising the iteration order of the `Qargs` means that graphs constructed from them (like `Target::coupling_graph` or VF2's custom graph build) add their edges in random orders. Edge and neighbour search/iteration methods on graphs involve following a linked-list-like edge list, which is highly susceptible to cache and branch-prediction problems; it's far faster if these accesses are predictable. For our purposes here with all-to-all targets, it's the cache properties that matter, and the branch-prediction is about the same.

Swapping the `qargs_gate_map` back to `IndexSet` does not *itself* enforce structure in the edge list, but in practice, a `Target` will be constructed programmatically, and there will be some logical structure in the construction. `IndexMap` preserves this, whereas randomisation is almost guaranteed to be worse. We could attempt to optimise the edge list, but sorting arbitrary lists would likely have worse overhead and not significantly improve on most normal constructions.

## Timing

Using the `wstate_n380.qasm` file from QASMBench[^2], we have the following minimised benchmark reproducing the problem:

``` python
from qiskit.circuit import QuantumCircuit
from qiskit.transpiler import (
    generate_preset_pass_manager,
    CouplingMap,
    passes,
)
from qiskit.providers.fake_provider import GenericBackendV2

cmap = CouplingMap.from_full(380)
backend = GenericBackendV2(
    cmap.size(),
    coupling_map=cmap,
    basis_gates=["id", "sx", "x", "rz", "cz"],
    seed=42,
)
dag = QuantumCircuit.from_qasm_file("wstate_n380.qasm").to_dag()
pm = generate_preset_pass_manager(backend, seed_transpiler=42)
pass_ = passes.VF2Layout(
    coupling_map=cmap,
    seed=-1,
    call_limit=(5_000_000, 10_000),
    target=backend.target,
)
```

We time `pass_.run(dag)`. On 2.4.2, this takes about 250ms on my machine. On 2.5.0rc1, it is about 550ms. This commit reverts the timing back to durations statistically compatible with 2.4.2.

Looking at

    perf -e cache-misses -- python bench.py

the baseline is ~70M cache misses, then with 10 loops of `pass_.run` at the end, we find

- 150M with 2.4.2
- 340M with 2.5.0rc1
- 140M with this patch

Correcting for the baseline, this means 2.5.0rc1 has 3-4x the cache-miss rate on this benchmark, and this patch restores the previous rate.

[^1]: 61e3ca016c: Consolidate `Target` mappings (#15349)
[^2]: <https://github.com/pnnl/QASMBench/blob/357b942396d5c2b7cbc1c229c585a6ef5ccaebac/large/wstate_n380/wstate_n380.qasm>

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
