### PR TITLE
Fix formatting in `control_flow.rs`

### DIFF
--- a/crates/cext/src/control_flow.rs
+++ b/crates/cext/src/control_flow.rs
@@ -1619,7 +1619,7 @@ pub unsafe extern "C" fn qk_control_flow_switch_case_labels_clear(labels: *mut C
     if !labels.labels.is_null() && labels.num_labels > 0 {
         drop(unsafe {
             // SAFETY: Per document unsafe, label is a valid CSwitchCaseLabels
-            Box::from_raw(std::slice::from_raw_parts_mut(
+            Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 labels.labels as *mut u64,
                 labels.num_labels,
             ))


### PR DESCRIPTION
The following commit applies an automated formatting fix by clippy caught in our main branch.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
