### PR TITLE
Fail CSPLayout early when a 3+ qubit gate is present

### DIFF
--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -46,6 +46,7 @@ class CSPLayout(AnalysisPass):
         * nonexistent solution: If no perfect layout was found and every combination was checked.
         * call limit reached: If no perfect layout was found and the call limit was reached.
         * time limit reached: If no perfect layout was found and the time limit was reached.
+        * 3-or-more-qubit gate found: If the circuit contains a gate acting on three or more qubits.
 
         Args:
             coupling_map (Union[CouplingMap, Target]): Directed graph representing a coupling map.
@@ -80,6 +81,10 @@ class CSPLayout(AnalysisPass):
                 "map."
             )
         qubits = dag.qubits
+        if dag.multi_qubit_ops():
+            self.property_set["CSPLayout_stop_reason"] = "3-or-more-qubit gate found"
+            return
+
         cxs = set()
 
         from constraint import Problem, AllDifferentConstraint, RecursiveBacktrackingSolver

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -307,6 +307,34 @@ class TestCSPLayout(QiskitTestCase):
             pass_.property_set["CSPLayout_stop_reason"], "3-or-more-qubit gate found"
         )
 
+    def test_issue_7155_reproduction(self):
+        """Reproduce the layout bug reported in Qiskit #7155."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.ccx(2, 0, 1)
+
+        pass_ = CSPLayout(CouplingMap([(0, 1), (1, 2)]))
+        pass_(qc)
+
+        self.assertNotIn("layout", pass_.property_set)
+        self.assertEqual(
+            pass_.property_set["CSPLayout_stop_reason"], "3-or-more-qubit gate found"
+        )
+
+    def test_4q_gate_stops_layout(self):
+        """Gates on four qubits should also stop layout early."""
+        qc = QuantumCircuit(4)
+        qc.mcx([0, 1, 2], 3)
+
+        dag = circuit_to_dag(qc)
+        pass_ = CSPLayout(CouplingMap.from_line(4), seed=self.seed)
+        pass_.run(dag)
+
+        self.assertNotIn("layout", pass_.property_set)
+        self.assertEqual(
+            pass_.property_set["CSPLayout_stop_reason"], "3-or-more-qubit gate found"
+        )
+
     def test_seed(self):
         """Different seeds yield different results"""
         seed_1 = 42

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -292,6 +292,21 @@ class TestCSPLayout(QiskitTestCase):
         self.assertLess(runtime, 1)
         self.assertEqual(pass_.property_set["CSPLayout_stop_reason"], "call limit reached")
 
+    def test_3q_gate_on_linear_coupling(self):
+        """A 3-qubit gate cannot be laid out on a line without native support."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.ccx(2, 0, 1)
+
+        dag = circuit_to_dag(qc)
+        pass_ = CSPLayout(CouplingMap([(0, 1), (1, 2)]), seed=self.seed)
+        pass_.run(dag)
+
+        self.assertNotIn("layout", pass_.property_set)
+        self.assertEqual(
+            pass_.property_set["CSPLayout_stop_reason"], "3-or-more-qubit gate found"
+        )
+
     def test_seed(self):
         """Different seeds yield different results"""
         seed_1 = 42


### PR DESCRIPTION
## Summary

- Stop `CSPLayout` when the DAG contains a gate on three or more qubits.
- Return `CSPLayout_stop_reason = "3-or-more-qubit gate found"` instead of reporting a misleading layout solution.
- Add regression tests for the original #7155 reproduction and a 4-qubit gate case.

Fixes #7155

## Test plan

- [x] `python -m unittest test.python.transpiler.test_csp_layout`


Made with [Cursor](https://cursor.com)