### PR TITLE
Minor typo / formatting in arithmetic library

### DIFF
--- a/qiskit/circuit/library/arithmetic/adders/adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/adder.py
@@ -79,7 +79,7 @@ class HalfAdderGate(Gate):
 
     .. math::
 
-        |a\rangle_n |b\rangle_n \mapsto |a\rangle_n |a + b\rangle_{n + 1}.
+        |a\rangle_n |b\rangle_n |0\rangle \mapsto |a\rangle_n |a + b\rangle_{n + 1}.
 
     The quantum register :math:`|a\rangle_n` (and analogously :math:`|b\rangle_n`)
 

--- a/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
@@ -77,7 +77,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
         r"""
         Args:
             f_x: the function to be approximated. Constant functions should be specified
-             as f_x = constant.
+             as ``f_x = constant``.
             degree: the degree of the polynomials.
                 Defaults to ``1``.
             breakpoints: the breakpoints to define the piecewise-linear function.
@@ -408,7 +408,7 @@ class PiecewiseChebyshevGate(Gate):
         r"""
         Args:
             f_x: the function to be approximated. Constant functions should be specified
-             as f_x = constant.
+             as ``f_x = constant``.
             num_state_qubits: number of qubits representing the state.
             degree: the degree of the polynomials.
                 Defaults to ``1``.

--- a/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
@@ -77,7 +77,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
         r"""
         Args:
             f_x: the function to be approximated. Constant functions should be specified
-             as ``f_x = constant``.
+                as ``f_x = constant``.
             degree: the degree of the polynomials.
                 Defaults to ``1``.
             breakpoints: the breakpoints to define the piecewise-linear function.
@@ -408,7 +408,7 @@ class PiecewiseChebyshevGate(Gate):
         r"""
         Args:
             f_x: the function to be approximated. Constant functions should be specified
-             as ``f_x = constant``.
+                as ``f_x = constant``.
             num_state_qubits: number of qubits representing the state.
             degree: the degree of the polynomials.
                 Defaults to ``1``.

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -168,8 +168,8 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
         """
         Args:
             num_state_qubits: The number of qubits representing the state.
-            coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of the
-                i-th power of :math:`x`. Defaults to linear: ``[0, 1]``.
+            coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of
+                :math:`x^i`. Defaults to linear: ``[0, 1]``.
             basis: The type of Pauli rotation (``"X"``, ``"Y"``, ``"Z"``).
             name: The name of the circuit.
         """
@@ -300,8 +300,8 @@ class PolynomialPauliRotationsGate(Gate):
         """
         Args:
             num_state_qubits: The number of qubits representing the state.
-            coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of the
-                i-th power of :math:`x`. Defaults to linear: ``[0, 1]``.
+            coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of
+                :math:`x^i`. Defaults to linear: ``[0, 1]``.
             basis: The type of Pauli rotation (``"X"``, ``"Y"``, ``"Z"``).
             label: A label for the gate.
         """

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -134,7 +134,7 @@ def _multinomial_coefficients(m, n):
 class PolynomialPauliRotations(FunctionalPauliRotations):
     r"""A circuit implementing polynomial Pauli rotations.
 
-    For a polynomial :math:`p(x)`, a basis state :math:`|i\rangle` and a target qubit
+    For a polynomial :math:`p`, a basis state :math:`|i\rangle` and a target qubit
     :math:`|0\rangle` this operator acts as:
 
     .. math::
@@ -142,8 +142,8 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
         |i\rangle |0\rangle \mapsto \cos\left(\frac{p(i)}{2}\right) |i\rangle |0\rangle
         + \sin\left(\frac{p(i)}{2}\right) |i\rangle |1\rangle
 
-    Let n be the number of qubits representing the state, d the degree of p(x) and q_i the qubits,
-    where q_0 is the least significant qubit. Then for
+    Let :math:`n` be the number of qubits representing the state, :math:`d` the degree of :math:`p`
+    and :math:`q_i` the qubits, where :math:`q_0` is the least significant qubit. Then for
 
     .. math::
 
@@ -169,8 +169,8 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
         Args:
             num_state_qubits: The number of qubits representing the state.
             coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of the
-                i-th power of x. Defaults to linear: [0, 1].
-            basis: The type of Pauli rotation ('X', 'Y', 'Z').
+                i-th power of :math:`x`. Defaults to linear: ``[0, 1]``.
+            basis: The type of Pauli rotation (``"X"``, ``"Y"``, ``"Z"``).
             name: The name of the circuit.
         """
         # set default internal parameters
@@ -266,7 +266,7 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
 class PolynomialPauliRotationsGate(Gate):
     r"""A gate implementing polynomial Pauli rotations.
 
-    For a polynomial :math:`p(x)`, a basis state :math:`|i\rangle` and a target qubit
+    For a polynomial :math:`p`, a basis state :math:`|i\rangle` and a target qubit
     :math:`|0\rangle` this operator acts as:
 
     .. math::
@@ -274,8 +274,8 @@ class PolynomialPauliRotationsGate(Gate):
         |i\rangle |0\rangle \mapsto \cos\left(\frac{p(i)}{2}\right) |i\rangle |0\rangle
         + \sin\left(\frac{p(i)}{2}\right) |i\rangle |1\rangle
 
-    Let n be the number of qubits representing the state, d the degree of p(x) and q_i the qubits,
-    where q_0 is the least significant qubit. Then for
+    Let :math:`n` be the number of qubits representing the state, :math:`d` the degree of :math:`p`
+    and :math:`q_i` the qubits, where :math:`q_0` is the least significant qubit. Then for
 
     .. math::
 
@@ -297,13 +297,12 @@ class PolynomialPauliRotationsGate(Gate):
         basis: str = "Y",
         label: str | None = None,
     ) -> None:
-        """Prepare an approximation to a state with amplitudes specified by a polynomial.
-
+        """
         Args:
             num_state_qubits: The number of qubits representing the state.
             coeffs: The coefficients of the polynomial. ``coeffs[i]`` is the coefficient of the
-                i-th power of x. Defaults to linear: [0, 1].
-            basis: The type of Pauli rotation ('X', 'Y', 'Z').
+                i-th power of :math:`x`. Defaults to linear: ``[0, 1]``.
+            basis: The type of Pauli rotation (``"X"``, ``"Y"``, ``"Z"``).
             label: A label for the gate.
         """
         self.coeffs = coeffs or [0, 1]


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Fix a typo in the `HalfAdderGate` reported in #15596 and some formatting issues in the arithmetic circuit library.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
