### PR TITLE
Add upgrade note for unitary plugin usage in Clifford+T transpilation

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -12,6 +12,7 @@
 
 
 """Circuit transpile function"""
+
 import logging
 import os
 from time import time
@@ -87,9 +88,11 @@ def transpile(
     .. note::
 
         When the target basis consists of Clifford+T gates, this function constructs
-        a specialized Clifford+T transpiler pipeline, see :func:`.clifford_t_pass_manager`
-        for documentation. The arguments that apply to transpiling into continuous basis sets
-        are ignored in this flow.
+        a specialized Clifford+T transpiler pipeline, see
+        :func:`.generate_preset_clifford_t_pass_manager` for more detailed documentation. Arguments
+        that apply only to transpiling into continuous basis sets are ignored in this flow.
+        For example, the ``"unitary_synthesis_method"`` is not taken into account when synthesizing
+        single-qubit unitaries into a Clifford+T sequence.
 
     Args:
         circuits: Circuit(s) to transpile

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -78,13 +78,13 @@ sample transpilation looks like::
     # ... and use it (as many times as you like).
     physical = pm.run(abstract)
 
-For early experiments towards fault tolerance, the function :func:`.generate_preset_pass_manager`
+For early experiments towards fault tolerance, the functions :func:`.generate_preset_pass_manager`
 and :func:`.transpile` invoke a specialized transpilation pipeline when the target basis consists of 
 Clifford+T gates, see :func:`.generate_preset_clifford_t_pass_manager` for documentation.
 It is recommended to use the latter for a detailed configuration of Clifford+T pipelines. 
-For example, setting the :math:`R_Z` synthesis accuracy cannot be set via 
+For example, the :math:`R_Z` synthesis accuracy cannot be set via 
 ``"unitary_synthesis_method"`` in :func:`.generate_preset_pass_manager` but can only be globally
-set via the ``"approximation_degree"`` -- however, :func:`.generate_preset_clifford_t_pass_manager`
+set via the ``"approximation_degree"``. However, :func:`.generate_preset_clifford_t_pass_manager`
 exposes ``"rz_synthesis_config"`` for this matter.
 
 For example::

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -79,8 +79,15 @@ sample transpilation looks like::
     physical = pm.run(abstract)
 
 For early experiments towards fault tolerance, the function :func:`.generate_preset_pass_manager`
-invokes a specialized transpilation pipeline when the target basis consists of Clifford+T gates,
-see :func:`.clifford_t_pass_manager` for documentation. For example::
+and :func:`.transpile` invoke a specialized transpilation pipeline when the target basis consists of 
+Clifford+T gates, see :func:`.generate_preset_clifford_t_pass_manager` for documentation.
+It is recommended to use the latter for a detailed configuration of Clifford+T pipelines. 
+For example, setting the :math:`R_Z` synthesis accuracy cannot be set via 
+``"unitary_synthesis_method"`` in :func:`.generate_preset_pass_manager` but can only be globally
+set via the ``"approximation_degree"`` -- however, :func:`.generate_preset_clifford_t_pass_manager`
+exposes ``"rz_synthesis_config"`` for this matter.
+
+For example::
 
     from qiskit.circuit import QuantumCircuit
     from qiskit.circuit.library import QFTGate

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -13,6 +13,7 @@
 """
 Preset pass manager generation function
 """
+
 from __future__ import annotations
 
 import copy
@@ -109,9 +110,11 @@ def generate_preset_pass_manager(
     .. note::
 
         When the target basis consists of Clifford+T gates, this function constructs
-        a specialized Clifford+T transpiler pipeline, see :func:`.clifford_t_pass_manager`
-        for documentation. The arguments that apply to transpiling into continuous basis sets
-        are ignored in this flow.
+        a specialized Clifford+T transpiler pipeline, see
+        :func:`.generate_preset_clifford_t_pass_manager` for more detailed documentation. Arguments
+        that apply only to transpiling into continuous basis sets are ignored in this flow.
+        For example, the ``"unitary_synthesis_method"`` is not taken into account when synthesizing
+        single-qubit unitaries into a Clifford+T sequence.
 
     Args:
         optimization_level: The optimization level to generate a

--- a/releasenotes/notes/unitary-synthesis-transpile-clifford-t-6fa8e5f7dd04028a.yaml
+++ b/releasenotes/notes/unitary-synthesis-transpile-clifford-t-6fa8e5f7dd04028a.yaml
@@ -6,8 +6,8 @@ upgrade_transpiler:
     relies on compiling to :math:`R_Z` gates and directly synthesizing these, which allows for
     better quality and runtime performance.
 
-    This implies that the Clifford+T synthesis options can no longer be passed into :func:`.transpile`
-    via the ``unitary_synthesis_method`` and ``unitary_synthesis_plugin_config``. Instead, the
+    As the result, the ``"unitary_synthesis_method"`` and ``"unitary_synthesis_plugin_config"``
+    arguments no longer affect Clifford+T synthesis in :func:`.transpile`. Instead, the
     accuracy can either be set globally by setting the ``approximation_degree``, or
     by using :func:`.generate_preset_clifford_t_pass_manager` which exposes
     ``rz_synthesis_config`` argument to pass a configuration for the :math:`R_Z` synthesis.

--- a/releasenotes/notes/unitary-synthesis-transpile-clifford-t-6fa8e5f7dd04028a.yaml
+++ b/releasenotes/notes/unitary-synthesis-transpile-clifford-t-6fa8e5f7dd04028a.yaml
@@ -1,0 +1,13 @@
+---
+upgrade_transpiler:
+  - The :func:`.transpile` function now uses a different, more efficient compiler workflow
+    when compiling to a Clifford+T basis.  In this workflow, it no longer uses the generic unitary
+    synthesis plugins to synthesize single-qubit unitaries into Clifford+T sequences. Newly, it
+    relies on compiling to :math:`R_Z` gates and directly synthesizing these, which allows for
+    better quality and runtime performance.
+
+    This implies that the Clifford+T synthesis options can no longer be passed into :func:`.transpile`
+    via the ``unitary_synthesis_method`` and ``unitary_synthesis_plugin_config``. Instead, the
+    accuracy can either be set globally by setting the ``approximation_degree``, or
+    by using :func:`.generate_preset_clifford_t_pass_manager` which exposes
+    ``rz_synthesis_config`` argument to pass a configuration for the :math:`R_Z` synthesis.


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

In Qiskit v2.5 we upgraded how to transpile to Clifford+T sequences when using the `transpile` function. We no longer rely on collecting single qubit gates into a `UGate` and then run the unitary synthesis plugins, but rather compile to `RZGate`s and then directly synthesize these. This has a better quality, since we don't need to decompose U->RX RZ RX or similar, and performance, since we can also properly cache previously computed angles.

This, however, means that if a user specifies a unitary synthesis plugin config, that might no longer be used to the Clifford+T synthesis. Note that it will still be used for any `UnitaryGate` the user might have added. This upgrade reno clarifies this new behavior and specifies how to set the Clifford+T synthesis options, if required.

We could still decide to change the behavior here and default back to the old, inefficient pipeline if _any_ unitary synthesis plugin is set, but this makes it easy to write less efficient code and implies more hidden switching logic which would be nice to avoid.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
