### PR TITLE
Clarify arithmetic API documentation

### DIFF
--- a/qiskit/circuit/library/arithmetic/adders/adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/adder.py
@@ -81,6 +81,10 @@ class HalfAdderGate(Gate):
 
         |a\rangle_n |b\rangle_n |0\rangle \mapsto |a\rangle_n |a + b\rangle_{n + 1}.
 
+    The final input qubit is a clean qubit initialized to :math:`|0\rangle`.
+    It stores the carry-out bit, which is why the output sum register has
+    :math:`n + 1` qubits.
+
     The quantum register :math:`|a\rangle_n` (and analogously :math:`|b\rangle_n`)
 
     .. math::
@@ -99,7 +103,6 @@ class HalfAdderGate(Gate):
         """
         Args:
             num_state_qubits: The number of qubits in each of the registers.
-            name: The name of the circuit.
             label: An optional label for identifying the instruction.
         """
         if num_state_qubits < 1:
@@ -155,7 +158,6 @@ class ModularAdderGate(Gate):
         """
         Args:
             num_state_qubits: The number of qubits in each of the registers.
-            name: The name of the circuit.
             label: An optional label for identifying the instruction.
         """
         if num_state_qubits < 1:
@@ -212,7 +214,6 @@ class FullAdderGate(Gate):
         """
         Args:
             num_state_qubits: The number of qubits in each of the registers.
-            name: The name of the circuit.
             label: An optional label for identifying the instruction.
         """
         if num_state_qubits < 1:

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -134,13 +134,34 @@ def _multinomial_coefficients(m, n):
 class PolynomialPauliRotations(FunctionalPauliRotations):
     r"""A circuit implementing polynomial Pauli rotations.
 
-    For a polynomial :math:`p`, a basis state :math:`|i\rangle` and a target qubit
-    :math:`|0\rangle` this operator acts as:
+    For a polynomial :math:`p`, a basis state :math:`|i\rangle` of the state register,
+    and a target qubit initialized in :math:`|0\rangle`, this operator applies a
+    Pauli rotation to the target qubit by the angle :math:`p(i)`. For the default
+    ``basis="Y"``, this acts as:
 
     .. math::
 
-        |i\rangle |0\rangle \mapsto \cos\left(\frac{p(i)}{2}\right) |i\rangle |0\rangle
-        + \sin\left(\frac{p(i)}{2}\right) |i\rangle |1\rangle
+        |0\rangle |i\rangle \mapsto
+        \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
+        + \sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
+
+    The target qubit is written first in the formula above to match the usual
+    left-to-right ordering of basis states. In the circuit, the state qubits are
+    passed first and the target qubit is the final qubit.
+
+    For ``basis="X"``, the action on the target qubit is:
+
+    .. math::
+
+        |0\rangle |i\rangle \mapsto
+        \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
+        - i\sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
+
+    For ``basis="Z"``, the action on the target qubit is:
+
+    .. math::
+
+        |0\rangle |i\rangle \mapsto e^{-i p(i) / 2} |0\rangle |i\rangle
 
     Let :math:`n` be the number of qubits representing the state, :math:`d` the degree of :math:`p`
     and :math:`q_i` the qubits, where :math:`q_0` is the least significant qubit. Then for
@@ -266,13 +287,34 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
 class PolynomialPauliRotationsGate(Gate):
     r"""A gate implementing polynomial Pauli rotations.
 
-    For a polynomial :math:`p`, a basis state :math:`|i\rangle` and a target qubit
-    :math:`|0\rangle` this operator acts as:
+    For a polynomial :math:`p`, a basis state :math:`|i\rangle` of the state register,
+    and a target qubit initialized in :math:`|0\rangle`, this operator applies a
+    Pauli rotation to the target qubit by the angle :math:`p(i)`. For the default
+    ``basis="Y"``, this acts as:
 
     .. math::
 
-        |i\rangle |0\rangle \mapsto \cos\left(\frac{p(i)}{2}\right) |i\rangle |0\rangle
-        + \sin\left(\frac{p(i)}{2}\right) |i\rangle |1\rangle
+        |0\rangle |i\rangle \mapsto
+        \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
+        + \sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
+
+    The target qubit is written first in the formula above to match the usual
+    left-to-right ordering of basis states. In the circuit, the state qubits are
+    passed first and the target qubit is the final qubit.
+
+    For ``basis="X"``, the action on the target qubit is:
+
+    .. math::
+
+        |0\rangle |i\rangle \mapsto
+        \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
+        - i\sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
+
+    For ``basis="Z"``, the action on the target qubit is:
+
+    .. math::
+
+        |0\rangle |i\rangle \mapsto e^{-i p(i) / 2} |0\rangle |i\rangle
 
     Let :math:`n` be the number of qubits representing the state, :math:`d` the degree of :math:`p`
     and :math:`q_i` the qubits, where :math:`q_0` is the least significant qubit. Then for

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -145,10 +145,6 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
         \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
         + \sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
 
-    The target qubit is written first in the formula above to match the usual
-    left-to-right ordering of basis states. In the circuit, the state qubits are
-    passed first and the target qubit is the final qubit.
-
     For ``basis="X"``, the action on the target qubit is:
 
     .. math::
@@ -297,10 +293,6 @@ class PolynomialPauliRotationsGate(Gate):
         |0\rangle |i\rangle \mapsto
         \cos\left(\frac{p(i)}{2}\right) |0\rangle |i\rangle
         + \sin\left(\frac{p(i)}{2}\right) |1\rangle |i\rangle
-
-    The target qubit is written first in the formula above to match the usual
-    left-to-right ordering of basis states. In the circuit, the state qubits are
-    passed first and the target qubit is the final qubit.
 
     For ``basis="X"``, the action on the target qubit is:
 

--- a/test/python/circuit/library/test_functional_pauli_rotations.py
+++ b/test/python/circuit/library/test_functional_pauli_rotations.py
@@ -31,7 +31,7 @@ from qiskit.circuit.library import (
     ExactReciprocalGate,
     PiecewiseChebyshevGate,
 )
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Operator, Statevector
 from test import QiskitTestCase
 
 
@@ -99,6 +99,35 @@ class TestFunctionalPauliRotations(QiskitTestCase):
 
             with self.subTest(use_gate=use_gate):
                 self.assertFunctionIsCorrect(polynome, poly, num_ancillas)
+
+    @data(
+        ("X", "rx", "crx"),
+        ("Z", "rz", "crz"),
+    )
+    @unpack
+    def test_polynomial_function_x_z_basis(
+        self, basis, rotation_method, controlled_rotation_method
+    ):
+        """Test polynomial rotations with X and Z bases."""
+        coeffs = [0.2, -0.4]
+
+        expected = QuantumCircuit(2)
+        getattr(expected, rotation_method)(coeffs[0], 1)
+        getattr(expected, controlled_rotation_method)(coeffs[1], 0, 1)
+
+        for use_gate in [True, False]:
+            if use_gate:
+                polynomial = PolynomialPauliRotationsGate(1, coeffs, basis=basis)
+            else:
+                with self.assertWarns(DeprecationWarning):
+                    polynomial = PolynomialPauliRotations(1, coeffs, basis=basis)
+
+            with self.subTest(use_gate=use_gate, basis=basis):
+                np.testing.assert_allclose(
+                    Operator(polynomial).data,
+                    Operator(expected).data,
+                    atol=1e-8,
+                )
 
     def test_polynomial_rotations_mutability(self):
         """Test the mutability of the linear rotations circuit."""


### PR DESCRIPTION
### Summary

Fix #15596

This PR clarifies arithmetic API documentation for polynomial Pauli rotations and adder gates.

### Details

This PR updates `PolynomialPauliRotations` and `PolynomialPauliRotationsGate` by adding concise descriptions for the `basis="X"` and `basis="Z"` cases, since these classes support `"X"`, `"Y"`, and `"Z"` bases while the previous documentation mainly described the default Y-basis behavior.

This PR also clarifies the `HalfAdderGate` mapping by explicitly showing the clean input qubit initialized to `|0⟩` and explaining that it stores the carry-out bit, which is why the output sum register has `n + 1` qubits.

Following review feedback, this PR also adds test coverage for the X and Z basis cases in `test_functional_pauli_rotations.py`.

### Changes

* Added concise mappings for `basis="X"` and `basis="Z"` in the polynomial Pauli rotation documentation.
* Kept the existing explanation that `q_0` is the least significant qubit.
* Clarified the `HalfAdderGate` carry-out qubit wording.
* Removed incorrect `name` parameter documentation from adder gate constructors that do not accept `name`.
* Added X/Z basis test coverage for `PolynomialPauliRotationsGate` and `PolynomialPauliRotations`.

### References used

* Qiskit SDK `PolynomialPauliRotations` API documentation.
* Qiskit SDK `PolynomialPauliRotationsGate` API documentation.
* Qiskit SDK bit-ordering guide.
* Qiskit SDK circuit-library arithmetic/adders documentation.
* Qiskit contributing guide and pull request checklist.

### Testing

Not run locally. I added test coverage for the X and Z basis cases in `test_functional_pauli_rotations.py`, but I am working through the browser editor and could not run the test suite locally.

### AI/LLM disclosure

* [ ] I didn't use LLM tooling, or only used it privately.
* [x] I used the following tool to help write this PR description: ChatGPT, GPT-5.5 Thinking.
* [x] I used the following tool to modify code: ChatGPT, GPT-5.5 Thinking. I reviewed and manually applied the final changes.

