### PR TITLE
Move examples of Clifford+T PM from release note to documentation

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -316,6 +316,32 @@ def generate_preset_clifford_t_pass_manager(
     default to all of the Clifford+T gates in Qiskit. Note, however, that if basis gates are specified
     but do not represent a Clifford+T basis, then an error will be raised.
 
+    Examples:
+        Generate and use a simple Clifford+T pass manager::
+
+            from qiskit.circuit import QuantumCircuit
+            from qiskit.transpiler import generate_preset_clifford_t_pass_manager
+
+            qc = QuantumCircuit(1)
+            qc.rz(2.3579, 0)
+
+            pm = generate_preset_clifford_t_pass_manager()
+            qct = pm.run(qc)
+
+        Various options are configurable; see the arguments documentation for more detail::
+
+            rz_synthesis_config = {
+                "rz_synthesis_error": 1e-4,
+                "rz_cache_error": 1e-5,
+            }
+
+            basis_gates = ["cx", "s", "sdg", "h", "t", "tdg"]
+            pm = generate_preset_clifford_t_pass_manager(
+                rz_synthesis_config=rz_synthesis_config,
+                basis_gates=basis_gates,
+                optimization_level=3,
+            )
+
     Args:
         optimization_level: The optimization level to generate a
             :class:`~.StagedPassManager` for. By default optimization level 2

--- a/releasenotes/notes/2.5/add-generate-clifford-t-pm-bff15923e04c8fc1.yaml
+++ b/releasenotes/notes/2.5/add-generate-clifford-t-pm-bff15923e04c8fc1.yaml
@@ -3,37 +3,9 @@ features_transpiler:
   - |
     Added a new function :func:`~.generate_preset_clifford_t_pass_manager`, which provides
     a convenient way to construct a preset pass manager for Clifford+T compilation.
-    We recommend using this function instead of :func:`~.transpile` or
+
+    You should prefer this function over :func:`~.transpile` or
     :func:`~.generate_preset_pass_manager` with a Clifford+T basis, as it exposes
-    arguments specifically tailored for Clifford+T compilations. In particular, it supports
+    arguments specifically tailored for Clifford+T compilations. In particular, it supports an
     argument ``rz_synthesis_config`` which controls synthesis of RZ-rotations into Clifford+T
     basis.
-
-    The following example shows how to generate a Clifford+T pass manager with
-    default values for the optimization level, Clifford+T basis gates and RZ-synthesis
-    options::
-
-        from qiskit.circuit import QuantumCircuit
-        from qiskit.transpiler import generate_preset_clifford_t_pass_manager
-
-        qc = QuantumCircuit(1)
-        qc.rz(2.3579, 0)
-
-        pm = generate_preset_clifford_t_pass_manager()
-        qct = pm.run(qc)
-        print(qct.count_ops())
-
-    The following example demonstrates how different options can be provided for
-    greater control::
-
-        rz_synthesis_config = {
-            "rz_synthesis_error": 1e-4,
-            "rz_cache_error": 1e-5,
-        }
-
-        basis_gates = ["cx", "s", "sdg", "h", "t", "tdg"]
-        pm = generate_preset_clifford_t_pass_manager(
-            rz_synthesis_config=rz_synthesis_config,
-            basis_gates=basis_gates,
-            optimization_level=3
-        )


### PR DESCRIPTION
The example given here is useful in a general context; it's better to have this in the permanent API documentation than in the more ephemeral release notes.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
