### PR TITLE
Reverting C API change to `LitinskiTransformation`

### DIFF
--- a/crates/cext/src/transpiler/passes/litinski_transformation.rs
+++ b/crates/cext/src/transpiler/passes/litinski_transformation.rs
@@ -27,9 +27,6 @@ use crate::pointers::mut_ptr_as_ref;
 /// @param circuit A pointer to the circuit on which to run the pass.
 /// @param fix_clifford If ``true``, leave the Clifford gates at the end of the circuit. If
 ///   ``false`` they are omitted.
-/// @param approximation_degree The degree to approximate for the equivalence check,
-///   used, for example, to determine if a rotation gate implements a Clifford.
-///   This is a floating point value between 0 (max. approximation) and 1 (no approximation).
 ///
 /// # Safety
 ///
@@ -38,16 +35,15 @@ use crate::pointers::mut_ptr_as_ref;
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_litinski_transformation(
     circuit: *mut CircuitData,
     fix_clifford: bool,
-    approximation_degree: f64,
 ) {
     // SAFETY: The user guarantees the pointer is safe to read.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
         .expect("Internal Circuit -> DAG conversion failed");
 
-    let maybe_out =
-        run_litinski_transformation(&dag, fix_clifford, false, true, approximation_degree)
-            .expect("Failed running Litinski transformation");
+    // For now, run Litinski transformation with no approximation (to avoid C API change).
+    let maybe_out = run_litinski_transformation(&dag, fix_clifford, false, true, 1.0)
+        .expect("Failed running Litinski transformation");
     // If a DAG is returned, the circuit has been modified. Else just leave it as is.
     if let Some(out) = maybe_out {
         *circuit =

--- a/releasenotes/notes/2.5/extend_litinski-3b56cbe182a5d514.yaml
+++ b/releasenotes/notes/2.5/extend_litinski-3b56cbe182a5d514.yaml
@@ -15,10 +15,6 @@ features_c:
     pass to support single-qubit ``QkGate_RX`` and ``QkGate_RY`` rotation gates,
     as well as ``QkPauliProductRotation`` and ``QkPauliProductMeasurement`` instructions.
   - Single-qubit rotation gates and ``QkPauliProductRotation`` objects with angles
-    that are integer multiples of :math:`\pi/2`, up to the specified approximation, are now
+    that are integer multiples of :math:`\pi/2`, up to the default approximation, are now
     recognized as Clifford gates by the :c:func:`qk_transpiler_pass_standalone_litinski_transformation`
     pass.
-  - Added an ``approximation_degree`` parameter to the
-    :c:func:`qk_transpiler_pass_standalone_litinski_transformation` pass,
-    which sets the allowed approximations of interpreting close-to-Clifford
-    rotations as Clifford gates.

--- a/test/c/test_pbc.c
+++ b/test/c/test_pbc.c
@@ -34,7 +34,7 @@ static int test_counts_litinski(void) {
     qk_circuit_gate(circuit, QkGate_S, (uint32_t[1]){2}, NULL);
     qk_circuit_gate(circuit, QkGate_T, (uint32_t[1]){2}, NULL);
 
-    qk_transpiler_pass_standalone_litinski_transformation(circuit, false, 1.0);
+    qk_transpiler_pass_standalone_litinski_transformation(circuit, false);
     int result = Ok;
     if (qk_circuit_num_instructions(circuit) != 4) {
         result = EqualityError;
@@ -269,7 +269,7 @@ static int test_concrete_litinski(void) {
         qk_circuit_measure(circuit, i, i);
     }
 
-    qk_transpiler_pass_standalone_litinski_transformation(circuit, false, 1.0);
+    qk_transpiler_pass_standalone_litinski_transformation(circuit, false);
 
     int result = Ok;
     result = check_pauli_rotation(circuit, 0, (enum Pauli[1]){PZ}, (uint32_t[1]){0}, 1, M_PI_4);
@@ -350,7 +350,7 @@ static int test_litinski_noop(void) {
     QkCircuit *circuit = qk_circuit_new(1, 0);
     qk_circuit_gate(circuit, QkGate_H, (uint32_t[1]){0}, NULL);
 
-    qk_transpiler_pass_standalone_litinski_transformation(circuit, true, 1.0);
+    qk_transpiler_pass_standalone_litinski_transformation(circuit, true);
 
     int result = Ok;
     if (qk_circuit_num_instructions(circuit) != 1) {


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### Summary

Reverts the C API change to `qk_transpiler_pass_standalone_litinski_transformation`. Fixes #16512.

As discussed offline, In the future it might be worth to add `QkLTConfig`, similar to VF2.


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
