### PR TITLE
Harden VF2 layout passes with a finite default call_limit

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -25,6 +25,16 @@ from qiskit._accelerate.vf2_layout import (
     VF2PassConfiguration,
 )
 
+# A finite default budget for the inner VF2 subgraph-isomorphism search.  VF2's
+# worst-case cost is exponential, and a highly symmetric interaction graph on a
+# large, dense coupling graph can have a combinatorial number of embeddings, which
+# an *unbounded* search will enumerate in full -- turning a tiny circuit into an
+# effectively unbounded compilation (a denial-of-service vector for any service
+# that transpiles untrusted circuits).  Defaulting to a finite budget bounds that
+# worst case while remaining generous enough not to affect realistic layouts; pass
+# ``call_limit=None`` explicitly to restore the old fully-unbounded behavior.
+DEFAULT_CALL_LIMIT = 10_000_000
+
 
 class VF2LayoutStopReason(Enum):
     """Stop reasons for VF2Layout pass."""
@@ -76,7 +86,7 @@ class VF2Layout(AnalysisPass):
         coupling_map=None,
         strict_direction=False,
         seed=None,
-        call_limit=None,
+        call_limit=DEFAULT_CALL_LIMIT,
         time_limit=None,
         max_trials=None,
         target=None,
@@ -91,11 +101,15 @@ class VF2Layout(AnalysisPass):
                 coupling graph, using a given pRNG seed.  ``None`` seeds using OS entropy (and so is
                 non-deterministic).  Using ``-1`` disables the shuffling.
             call_limit (None | int | tuple[int | None, int | None]): The maximum number of times
-                that the inner VF2 isomorphism search will attempt to extend the mapping. If
-                ``None``, then no limit.  If a 2-tuple, then the limit starts as the first item, and
-                swaps to the second after the first match is found, without resetting the number of
-                steps taken.  This can be used to allow a long search for any mapping, but still
-                terminate quickly with a small extension budget if one is found.
+                that the inner VF2 isomorphism search will attempt to extend the mapping.  Defaults
+                to a finite budget (``10_000_000``).  If ``None``, then no limit -- but
+                be aware that for a highly symmetric interaction graph on a large, dense coupling
+                graph the search space is combinatorial, so an unbounded search can run effectively
+                forever; only set ``None`` when the input circuits are trusted.  If a 2-tuple, then
+                the limit starts as the first item, and swaps to the second after the first match is
+                found, without resetting the number of steps taken.  This can be used to allow a
+                long search for any mapping, but still terminate quickly with a small extension
+                budget if one is found.
             time_limit (float): The total time limit in seconds to run ``VF2Layout``.  This is not
                 completely strict; execution will finish on the first isomorphism found (if any)
                 _after_ the time limit has been exceeded.  Setting this option breaks determinism of

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -24,6 +24,7 @@ from qiskit._accelerate.vf2_layout import (
     MultiQEncountered,
     VF2PassConfiguration,
 )
+from qiskit.transpiler.passes.layout.vf2_layout import DEFAULT_CALL_LIMIT
 
 
 class VF2PostLayoutStopReason(Enum):
@@ -87,7 +88,7 @@ class VF2PostLayout(AnalysisPass):
         self,
         target=None,
         seed=None,
-        call_limit=None,
+        call_limit=DEFAULT_CALL_LIMIT,
         time_limit=None,
         strict_direction=True,
         max_trials=0,
@@ -98,7 +99,11 @@ class VF2PostLayout(AnalysisPass):
             target (Target): A target representing the backend device to run ``VF2PostLayout`` on.
             seed (int): Sets the seed of the PRNG. -1 Means no node shuffling.
             call_limit (int): The number of state visits to attempt in each execution of
-                VF2.
+                VF2.  Defaults to a finite budget (``10_000_000``).  Passing ``None``
+                removes the limit; combined with the default ``max_trials=0`` ("unlimited") this
+                makes the search fully unbounded, which for a highly symmetric interaction graph on
+                a large, dense coupling graph can run effectively forever.  Only pass ``None`` when
+                the input circuits are trusted.
             time_limit (float): The total time limit in seconds to run ``VF2PostLayout``
             strict_direction (bool): Whether the pass is configured to follow
                 the strict direction in the coupling graph. If this is set to

--- a/releasenotes/notes/harden-vf2-default-call-limit-9b2a7c1d4e6f8a03.yaml
+++ b/releasenotes/notes/harden-vf2-default-call-limit-9b2a7c1d4e6f8a03.yaml
@@ -1,0 +1,26 @@
+---
+upgrade_transpiler:
+  - |
+    The :class:`.VF2Layout` and :class:`.VF2PostLayout` transpiler passes now
+    default their ``call_limit`` argument to a finite value (``10_000_000``)
+    instead of ``None`` (unbounded).  This bounds the worst-case run time of the
+    inner VF2 subgraph-isomorphism search when a pass is constructed directly with
+    default arguments.  The preset pass managers built by :func:`.generate_preset_pass_manager`
+    and used by :func:`.transpile` are unaffected, because they already pass
+    explicit ``call_limit`` values.  To restore the previous fully-unbounded
+    behavior, construct the pass with ``call_limit=None`` explicitly.  The chosen
+    default is generous enough that it does not change the layout found for
+    realistic circuits.
+security:
+  - |
+    Constructing :class:`.VF2Layout` or :class:`.VF2PostLayout` with default
+    arguments previously ran the VF2 subgraph-isomorphism search with no
+    ``call_limit`` (and, for :class:`.VF2PostLayout`, ``max_trials=0`` meaning
+    "unlimited").  Because VF2's worst case is exponential and a highly symmetric
+    interaction graph on a large, dense coupling graph has a combinatorial number
+    of valid embeddings, an unbounded search enumerates them all -- allowing a
+    very small crafted circuit to trigger an effectively unbounded compilation.
+    This is a denial-of-service risk for any service that transpiles untrusted
+    circuits using these passes with default settings.  The passes now default to
+    a finite ``call_limit``; callers that transpile untrusted input should keep a
+    finite ``call_limit`` (and, ideally, a ``time_limit``).

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -25,7 +25,11 @@ from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.circuit import ControlFlowOp, Qubit, library as lib, Parameter
 from qiskit.transpiler import CouplingMap, Target, TranspilerError
 from qiskit.transpiler.passes import ApplyLayout
-from qiskit.transpiler.passes.layout.vf2_layout import VF2Layout, VF2LayoutStopReason
+from qiskit.transpiler.passes.layout.vf2_layout import (
+    VF2Layout,
+    VF2LayoutStopReason,
+    DEFAULT_CALL_LIMIT,
+)
 from qiskit._accelerate.error_map import ErrorMap
 from qiskit.converters import circuit_to_dag
 from qiskit.providers.fake_provider import GenericBackendV2
@@ -234,6 +238,30 @@ class TestVF2LayoutSimple(LayoutTestCase):
         self.assertEqual(
             pass_.property_set["VF2Layout_stop_reason"], VF2LayoutStopReason.NO_SOLUTION_FOUND
         )
+
+    def test_default_call_limit_is_finite(self):
+        """The default ``call_limit`` is a finite budget (not ``None``/unbounded), so a directly
+        constructed pass cannot be driven into an unbounded VF2 search by a crafted circuit.
+        Passing ``call_limit=None`` explicitly restores the fully-unbounded behavior."""
+        cmap = CouplingMap([[0, 1], [1, 2], [2, 0]])
+        self.assertEqual(VF2Layout(cmap).call_limit, DEFAULT_CALL_LIMIT)
+        self.assertIsNotNone(VF2Layout(cmap).call_limit)
+        self.assertIsNone(VF2Layout(cmap, call_limit=None).call_limit)
+
+    def test_default_call_limit_finds_perfect_layout(self):
+        """A directly constructed pass with the default (finite) ``call_limit`` still finds a
+        perfect layout for a symmetric interaction graph on a dense coupling map, and terminates.
+        This guards against a regression back to an unbounded default, which for this class of
+        input would enumerate a combinatorial number of embeddings."""
+        cmap = CouplingMap.from_grid(5, 5)
+        qr = QuantumRegister(6, "qr")
+        circuit = QuantumCircuit(qr)
+        for i in range(0, 6, 2):  # perfect matching -> many symmetric embeddings
+            circuit.cx(qr[i], qr[i + 1])
+        dag = circuit_to_dag(circuit)
+        pass_ = VF2Layout(cmap, seed=-1)  # default finite call_limit
+        pass_.run(dag)
+        self.assertLayout(dag, cmap, pass_.property_set)
 
     def test_coupling_map_and_target(self):
         """Test that a Target is used instead of a CouplingMap if both are specified."""

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -19,6 +19,7 @@ from qiskit.circuit import ControlFlowOp, Parameter, library as lib
 from qiskit.transpiler import Layout, TranspilerError, PassManager, passes
 from qiskit.transpiler.passes import TrivialLayout, ApplyLayout
 from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayout, VF2PostLayoutStopReason
+from qiskit.transpiler.passes.layout.vf2_layout import DEFAULT_CALL_LIMIT
 from qiskit.converters import circuit_to_dag
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.compiler.transpiler import transpile
@@ -33,6 +34,15 @@ class TestVF2PostLayout(QiskitTestCase):
     """Tests the VF2Layout pass"""
 
     seed = 42
+
+    def test_default_call_limit_is_finite(self):
+        """The default ``call_limit`` is a finite budget (not ``None``/unbounded).  Combined with
+        the default ``max_trials=0`` ("unlimited"), a ``None`` call limit would make the VF2 search
+        fully unbounded, so the finite default guards a directly constructed pass against a crafted
+        circuit.  Passing ``call_limit=None`` explicitly restores the old behavior."""
+        self.assertEqual(VF2PostLayout().call_limit, DEFAULT_CALL_LIMIT)
+        self.assertIsNotNone(VF2PostLayout().call_limit)
+        self.assertIsNone(VF2PostLayout(call_limit=None).call_limit)
 
     def assertLayoutV2(self, dag, target, property_set):
         """Checks if the circuit in dag was a perfect layout in property_set for the given


### PR DESCRIPTION
### Summary

Give the `VF2Layout` and `VF2PostLayout` transpiler passes a **finite default `call_limit`** so that a pass constructed directly with default arguments cannot be driven into an unbounded VF2 subgraph-isomorphism search by a crafted circuit.

### Details and comments

**Motivation.** Both passes currently default `call_limit=None` (unbounded), and `VF2PostLayout` additionally defaults `max_trials=0` (which the Rust config interprets as *"unlimited"*, see `crates/transpiler/src/passes/vf2/vf2_layout.rs`). VF2's worst case is exponential, and — crucially — a **sparse, highly symmetric** interaction graph (e.g. a perfect matching) on a **large, dense** coupling graph has a *combinatorial* number of valid embeddings. With no `call_limit`, the search enumerates them all (`vf2.take_while(...).last()` drains the whole iterator), so a **tiny** circuit can trigger an effectively unbounded compilation.

Measured on Qiskit `main`, a directly-constructed `VF2Layout`/`VF2PostLayout` with default args, matching interaction pattern, `seed=-1`:

| coupling map | attack circuit | payload | `call_limit=None` (today) | `call_limit=10_000_000` (this PR) |
|---|---|---|---|---|
| 100-qubit king's-graph lattice | 8-qubit perfect matching | ~102 bytes | **110 s** | **4.1 s** |
| 100-qubit king's-graph lattice | 10-qubit perfect matching | ~116 bytes | **> 300 s (did not finish)** | ~4.2 s |
| IBM heavy-hex (57q) | same | — | 0.6 ms | 0.6 ms |

The finite budget still finds a valid perfect layout in every case above (stop reason `SOLUTION_FOUND`); at `call_limit=100_000` the same worst case already drops to ~0.04 s while still finding the layout — so the default is generous.

This is a denial-of-service risk for any service that transpiles **untrusted** circuits by constructing these passes with default settings. It is *not* reachable through the preset pass managers / `transpile()` — those already inject explicit finite `call_limit` values (`(50_000, 1_000)` / `(5_000_000, 10_000)` / `(30_000_000, 100_000)` at optimization levels 1/2/3) and gate `VF2PostLayout` behind `is_vf2_fully_bounded`. The exposure is specifically the **bare pass constructors** used by custom pass managers, plugins, and hosted services.

**Change.**
- Add a module constant `DEFAULT_CALL_LIMIT = 10_000_000` in `vf2_layout.py`.
- Default `call_limit` to it on both `VF2Layout` and `VF2PostLayout`.
- Passing `call_limit=None` explicitly restores the previous fully-unbounded behavior; docstrings note the DoS caveat for untrusted input.

**Backwards compatibility.** The preset pass managers pass `call_limit` explicitly, so `transpile()` output is unchanged. Only bare/direct constructions are affected, and the default is large enough not to change the layout found for realistic circuits (verified against the existing `test_vf2_layout.py` / `test_vf2_post_layout.py` suites — all pass).

**Testing.** Added regression tests (default is finite; `None` opt-out preserved; default-constructed pass still finds a perfect layout on a symmetric pattern over a dense grid). Locally: the two VF2 test modules pass (78 tests), and `black --check` + `ruff check` are clean.

Note on the security framing: this hardens a documented, opt-in behavior (unbounded search is reachable only by explicitly disabling the limit), so I've opened it as a normal PR with a `security` release note. Happy to move the discussion to a private advisory if the maintainers prefer.
