### PR TITLE
Parallelise wheel builds between all tiers

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,6 @@ jobs:
 
   build-others:
     name: Build others
-    needs: ["upload-core"]
     uses: ./.github/workflows/wheels-build.yml
     with:
       artifact-prefix: "deploy-others-"
@@ -41,7 +40,11 @@ jobs:
       sdist: "skip"
   upload-others:
     name: Deploy other
-    needs: ["build-others"]
+    # The tier 2/3 wheels mustn't block the tier 1 ones on build failures, nor
+    # can they deploy before the tier 1 ones (and sdist) have succeeded, because
+    # we never want to be in a situation where the newest version doesn't have
+    # the top-tier wheels available.
+    needs: ["build-others", "upload-core"]
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
In the wheels-deployment job, we always want the tier-1 wheels and the sdist to deploy simultaneously (to avoid even temporary situations where `pip install qiskit` on a tier-1 platform attempts to build from source), and we don't want any build failures in the tier 2 or 3 wheels to block the release.  We previously achieved this by gated the builds of the later wheels on the _deployment_ of the tier-1 ones, but this causes the entire deployment pipeline to take 2h+.

Instead, we can parallelise the whole _build_, but keep the two separate deployment jobs serialised.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
