### PR TITLE
Add QkParam symbol enumeration C API

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -247,6 +247,8 @@ mod param {
             export_fn!(qk_param_conjugate),
             export_fn!(qk_param_equal),
             export_fn!(qk_param_as_real),
+            export_fn!(qk_param_num_symbols),
+            export_fn!(qk_param_symbol_name_at),
         ]
     });
 }

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -211,6 +211,93 @@ pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
     out.into_raw()
 }
 
+fn sorted_param_symbols(expr: &ParameterExpression) -> Vec<&Symbol> {
+    let mut symbols: Vec<_> = expr.iter_symbols().collect();
+    symbols.sort_unstable();
+    symbols
+}
+
+/// @ingroup QkParam
+/// Get the number of unbound parameter symbols contained in a ``QkParam``.
+///
+/// This returns ``0`` for numeric parameters.
+///
+/// @param param A pointer to the ``QkParam``.
+///
+/// @return The number of unbound symbols in ``param``.
+///
+/// # Example
+///
+/// ```c
+/// QkParam *theta = qk_param_new_symbol("theta");
+/// size_t num_symbols = qk_param_num_symbols(theta); // == 1
+/// qk_param_free(theta);
+/// ```
+///
+/// # Safety
+///
+/// The behavior is undefined if ``param`` is not a valid pointer to a non-null ``QkParam``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_param_num_symbols(param: *const Param) -> usize {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let param = unsafe { const_ptr_as_ref(param) };
+
+    match param {
+        Param::ParameterExpression(expr) => expr.num_symbols(),
+        Param::Float(_) => 0,
+        Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+    }
+}
+
+/// @ingroup QkParam
+/// Get the name of an unbound parameter symbol contained in a ``QkParam``.
+///
+/// The symbol order is deterministic, but callers should not attach semantic meaning to the order
+/// beyond using indices in the range ``0 <= index < qk_param_num_symbols(param)``.
+///
+/// @param param A pointer to the ``QkParam``.
+/// @param index The symbol index to read.
+///
+/// @return A pointer to the symbol name, or null if ``index`` is out of range or ``param`` is
+/// numeric.
+///
+/// # Example
+///
+/// ```c
+/// QkParam *theta = qk_param_new_symbol("theta");
+/// char *name = qk_param_symbol_name_at(theta, 0);
+///
+/// if (name != NULL) {
+///     printf("%s\n", name);
+///     qk_str_free(name);
+/// }
+///
+/// qk_param_free(theta);
+/// ```
+///
+/// # Safety
+///
+/// The behavior is undefined if ``param`` is not a valid pointer to a non-null ``QkParam``.
+///
+/// The returned string must not be freed with the normal C free, you must use ``qk_str_free`` to
+/// free the memory consumed by the String. Not calling ``qk_str_free`` will lead to a memory leak.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_param_symbol_name_at(param: *const Param, index: usize) -> *mut c_char {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let param = unsafe { const_ptr_as_ref(param) };
+    let expr = match param {
+        Param::ParameterExpression(expr) => expr,
+        Param::Float(_) => return std::ptr::null_mut(),
+        Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+    };
+
+    let symbols = sorted_param_symbols(expr);
+    let Some(symbol) = symbols.get(index) else {
+        return std::ptr::null_mut();
+    };
+    CString::new(symbol.repr(false)).unwrap().into_raw()
+}
+
 /// @ingroup QkParam
 /// Add two ``QkParam``.
 ///

--- a/test/c/test_param.c
+++ b/test/c/test_param.c
@@ -92,6 +92,127 @@ static int test_param_to_real(void) {
     return Ok;
 }
 
+static int expect_param_symbol_name_at(const QkParam *param, size_t index,
+                                       const char *expected) {
+    char *name = qk_param_symbol_name_at(param, index);
+    if (name == NULL) {
+        printf("Expected parameter symbol %s at index %zu, found NULL.\n", expected, index);
+        return NullptrError;
+    }
+
+    int result = Ok;
+    if (strcmp(name, expected) != 0) {
+        printf("Expected parameter symbol %s at index %zu, found %s.\n", expected, index, name);
+        result = EqualityError;
+    }
+
+    qk_str_free(name);
+    return result;
+}
+
+/**
+ * Test enumerating parameter symbols from standalone symbols, expressions, and numeric values.
+ */
+static int test_param_symbol_enumeration(void) {
+    QkParam *a = qk_param_new_symbol("a");
+    QkParam *b = qk_param_new_symbol("b");
+    QkParam *sum = qk_param_zero();
+    QkParam *nested = qk_param_zero();
+    QkParam *value = qk_param_from_double(1.25);
+    char *missing = NULL;
+    int result = Ok;
+
+    if (qk_param_num_symbols(a) != 1) {
+        printf("Expected 1 symbol for standalone symbol.\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    result = expect_param_symbol_name_at(a, 0, "a");
+    if (result != Ok) {
+        goto cleanup;
+    }
+
+    missing = qk_param_symbol_name_at(a, 1);
+    if (missing != NULL) {
+        printf("Expected NULL for out-of-range standalone symbol, found %s.\n", missing);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    if (qk_param_add(sum, a, b) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    if (qk_param_num_symbols(sum) != 2) {
+        printf("Expected 2 symbols for parameter expression.\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    result = expect_param_symbol_name_at(sum, 0, "a");
+    if (result != Ok) {
+        goto cleanup;
+    }
+    result = expect_param_symbol_name_at(sum, 1, "b");
+    if (result != Ok) {
+        goto cleanup;
+    }
+
+    if (qk_param_sin(nested, sum) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    if (qk_param_num_symbols(nested) != 2) {
+        printf("Expected 2 symbols for nested parameter expression.\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    result = expect_param_symbol_name_at(nested, 0, "a");
+    if (result != Ok) {
+        goto cleanup;
+    }
+    result = expect_param_symbol_name_at(nested, 1, "b");
+    if (result != Ok) {
+        goto cleanup;
+    }
+
+    missing = qk_param_symbol_name_at(sum, 2);
+    if (missing != NULL) {
+        printf("Expected NULL for out-of-range expression symbol, found %s.\n", missing);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    if (qk_param_num_symbols(value) != 0) {
+        printf("Expected 0 symbols for numeric value.\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    missing = qk_param_symbol_name_at(value, 0);
+    if (missing != NULL) {
+        printf("Expected NULL symbol name for numeric value, found %s.\n", missing);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+cleanup:
+    if (missing != NULL) {
+        qk_str_free(missing);
+    }
+    qk_param_free(a);
+    qk_param_free(b);
+    qk_param_free(sum);
+    qk_param_free(nested);
+    qk_param_free(value);
+
+    return result;
+}
+
 /**
  * Test calling all binary operations and verify their string representation.
  */
@@ -506,6 +627,7 @@ int test_param(void) {
     num_failed += RUN_TEST(test_param_new);
     num_failed += RUN_TEST(test_param_new_values);
     num_failed += RUN_TEST(test_param_to_real);
+    num_failed += RUN_TEST(test_param_symbol_enumeration);
     num_failed += RUN_TEST(test_param_equal);
     num_failed += RUN_TEST(test_param_copy);
     num_failed += RUN_TEST(test_param_binary_ops);


### PR DESCRIPTION
Add QkParam-level free-symbol enumeration to the C API.

This adds:
    size_t qk_param_num_symbols(const QkParam *param);
    char *qk_param_symbol_name_at(const QkParam *param, size_t index);

The functions expose the free symbols already tracked by ParameterExpression,
including symbols nested inside expressions, without requiring consumers to parse
qk_param_str(). Numeric parameters return zero symbols. Out-of-range symbol-name
access returns NULL, and returned names are owned C strings freed with qk_str_free.

This is intentionally attached to QkParam rather than to circuit instructions, so
it handles both simple symbols and multi-symbol expressions.

Full C suite passed with local loader path fix: 30/30 tests passed
