### PR TITLE
Fix new lints in Clippy for Rust 1.97

### DIFF
--- a/crates/bindgen-cli/src/abi.rs
+++ b/crates/bindgen-cli/src/abi.rs
@@ -165,7 +165,7 @@ impl SlotsLists {
 }
 impl fmt::Display for SlotsLists {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "__version__ = \"{}\"", &self.api_version)?;
+        writeln!(f, "__version__ = \"{}\"", self.api_version)?;
         for (name, slots) in self.slots.iter() {
             writeln!(f, "{name} = {slots}")?;
         }
@@ -257,12 +257,12 @@ impl Changes {
         if self.is_allowed() {
             return format!(
                 "Current slots list for version {} is compatible with previous version {}.",
-                &self.version_cur, &self.version_prev,
+                self.version_cur, self.version_prev,
             );
         }
         let mut explanation = format!(
             "Current slots list for version {} is incompatible with previous version {}.",
-            &self.version_cur, &self.version_prev,
+            self.version_cur, self.version_prev,
         );
         write!(
             explanation,

--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -342,7 +342,7 @@ mod export {
     /// the variants for ease of use in Python space, but in actual function interfaces we have to use
     /// the raw `ctypes` backing type to get the ABI correct.
     pub fn r#enum(val: &simple_ir::Enum) -> String {
-        let mut out = format!("\nclass {}(enum.Enum):", &val.name);
+        let mut out = format!("\nclass {}(enum.Enum):", val.name);
         if val.variants.is_empty() {
             out.push_str("\n    pass");
             return out;
@@ -360,8 +360,8 @@ mod export {
     /// If `dllname` name is given, we assume the function is an attribute on an object with that
     /// name.
     pub fn function(val: &simple_ir::Function<Primitive>, dllname: &str) -> String {
-        let prefix = format!("{}.{}", dllname, &val.name);
-        let mut out = format!("\n{}.argtypes = [", &prefix);
+        let prefix = format!("{}.{}", dllname, val.name);
+        let mut out = format!("\n{}.argtypes = [", prefix);
         if let Some((first, rest)) = val.args.split_first() {
             render_type(&first.ty, &mut out);
             for arg in rest {
@@ -389,7 +389,7 @@ mod export {
     pub fn r#struct(val: &simple_ir::Struct<Primitive>) -> String {
         // TODO: this doesn't handle the case of (mutually) recursive `struct` definitions; we
         // assume that all the `_fields_` will refer to fully defined `ctypes` objects.
-        let mut out = format!("\nclass {}(ctypes.Structure):\n", &val.name);
+        let mut out = format!("\nclass {}(ctypes.Structure):\n", val.name);
         let Some(fields) = val.fields.as_ref() else {
             out.push_str("    pass\n");
             return out;
@@ -408,7 +408,7 @@ mod export {
 
     /// Get a string representing the declaration of this `union`` as a Python `ctypes.Union`.
     pub fn r#union(val: &simple_ir::Union<Primitive>) -> String {
-        let mut out = format!("\nclass {}(ctypes.Union):\n", &val.name);
+        let mut out = format!("\nclass {}(ctypes.Union):\n", val.name);
         out.push_str("    _fields_ = [\n");
 
         for simple_ir::StructField { name, ty } in &val.fields {
@@ -437,15 +437,15 @@ mod export {
         writeln!(out)?;
 
         writeln!(out, "__all__ = [")?;
-        writeln!(out, "    \"{}\",", &config.dll.name)?;
+        writeln!(out, "    \"{}\",", config.dll.name)?;
         for val in &items.enums {
-            writeln!(out, "    \"{}\",", &val.name)?;
+            writeln!(out, "    \"{}\",", val.name)?;
         }
         for val in &items.structs {
-            writeln!(out, "    \"{}\",", &val.name)?;
+            writeln!(out, "    \"{}\",", val.name)?;
         }
         for val in &items.functions {
-            writeln!(out, "    \"{}\",", &val.name)?;
+            writeln!(out, "    \"{}\",", val.name)?;
         }
         writeln!(out, "]")?;
         writeln!(out)?;
@@ -463,7 +463,7 @@ mod export {
         writeln!(
             out,
             "{} = ctypes.PyDLL({})",
-            &config.dll.name, &config.dll.expr
+            config.dll.name, config.dll.expr
         )?;
 
         writeln!(out)?;

--- a/crates/bindgen/src/simple_ir.rs
+++ b/crates/bindgen/src/simple_ir.rs
@@ -67,7 +67,7 @@ impl Enum {
             .iter()
             .map(|variant| -> anyhow::Result<_> {
                 let Some(ir::Literal::Expr(discriminant)) = &variant.discriminant else {
-                    bail!("unhandled discriminant: {:?}", &variant.discriminant);
+                    bail!("unhandled discriminant: {:?}", variant.discriminant);
                 };
                 Ok(EnumVariant {
                     name: variant.name.clone(),

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3156,7 +3156,7 @@ impl DAGCircuit {
             if input_dag_var_set.difference(&var_set).count() > 0 {
                 return Err(DAGCircuitError::new_err(format!(
                     "Cannot replace a node with a DAG with more variables. Variables in node: {:?}. Variables in dag: {:?}",
-                    &var_set, &input_dag_var_set,
+                    var_set, input_dag_var_set,
                 )));
             }
             var_set

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -1868,7 +1868,7 @@ impl PyParameterVector {
         // `ParameterVector` was first introduced.
         format!(
             "{}, [{}]",
-            &self.base.name,
+            self.base.name,
             self.base
                 .iter()
                 .map(|s| format!("'{}'", s.fullname()))
@@ -1879,7 +1879,7 @@ impl PyParameterVector {
     fn __repr__(&self) -> String {
         format!(
             "ParameterVector(name='{}', length={})",
-            &self.base.name,
+            self.base.name,
             self.base.len.load(atomic::Ordering::Relaxed)
         )
     }

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -104,7 +104,7 @@ impl Symbol {
     pub fn fullname(&self) -> Cow<'_, str> {
         match self {
             Self::Standalone { name, uuid: _ } => Cow::Borrowed(name.as_str()),
-            Self::Element { base, index } => Cow::Owned(format!("{}[{}]", &base.name, index)),
+            Self::Element { base, index } => Cow::Owned(format!("{}[{}]", base.name, index)),
         }
     }
 
@@ -419,18 +419,14 @@ impl SymbolExpr {
             SymbolExpr::Symbol(_) => None,
             SymbolExpr::Value(e) => Some(*e),
             SymbolExpr::Unary { op, expr } => {
-                let val: Value;
-                if recurse {
-                    match expr.eval(recurse) {
-                        Some(v) => val = v,
-                        None => return None,
-                    }
+                let val = if recurse {
+                    expr.eval(recurse)?
                 } else {
                     match expr.as_ref() {
-                        SymbolExpr::Value(e) => val = *e,
+                        SymbolExpr::Value(e) => *e,
                         _ => return None,
                     }
-                }
+                };
                 let ret = match op {
                     UnaryOp::Abs => val.abs(),
                     UnaryOp::Neg => -val,

--- a/crates/qasm2/src/expr.rs
+++ b/crates/qasm2/src/expr.rs
@@ -621,7 +621,7 @@ impl ExprParser<'_> {
     }
 
     #[inline]
-    fn cur_position_of(&self, token: &Token) -> Position {
+    fn cur_position_of(&self, token: &Token) -> Position<'_> {
         Position::new(self.current_filename(), token.line, token.col)
     }
 

--- a/crates/qasm2/src/parse.rs
+++ b/crates/qasm2/src/parse.rs
@@ -303,7 +303,7 @@ impl State {
                     None,
                     &format!(
                         "cannot override builtin classical function '{}'",
-                        &classical.name
+                        classical.name
                     ),
                 )));
             }
@@ -315,11 +315,11 @@ impl State {
                     let message = match classical.name.as_str() {
                         "U" | "CX" => format!(
                             "custom classical instructions cannot shadow built-in gates, but got '{}'",
-                            &classical.name,
+                            classical.name,
                         ),
                         _ => format!(
                             "custom classical instruction '{}' has a naming clash with a custom gate",
-                            &classical.name,
+                            classical.name,
                         ),
                     };
                     return Err(QASM2ParseError::new_err(message_generic(None, &message)));
@@ -327,7 +327,7 @@ impl State {
                 Some(GlobalSymbol::Classical { .. }) => {
                     return Err(QASM2ParseError::new_err(message_generic(
                         None,
-                        &format!("duplicate custom classical function '{}'", &classical.name,),
+                        &format!("duplicate custom classical function '{}'", classical.name,),
                     )));
                 }
                 _ => (),
@@ -1052,7 +1052,7 @@ impl State {
                 )),
                 &format!(
                     "'{}' takes {} parameter{}, but got {}",
-                    &name_token.text(&self.context),
+                    name_token.text(&self.context),
                     num_params,
                     if num_params == 1 { "" } else { "s" },
                     seen_params
@@ -1608,7 +1608,7 @@ impl State {
                             filename_token.line,
                             filename_token.col,
                         )),
-                        &format!("unable to open file '{}' for reading: {}", &filename, err),
+                        &format!("unable to open file '{}' for reading: {}", filename, err),
                     ))
                 })?;
             self.tokens.push(new_stream);

--- a/crates/qasm3/src/circuit.rs
+++ b/crates/qasm3/src/circuit.rs
@@ -118,7 +118,7 @@ impl PyGate {
         } else {
             Err(QASM3ImporterError::new_err(format!(
                 "internal error: wrong number of params for {} (got {}, expected {})",
-                &self.name, received_num_params, self.num_params
+                self.name, received_num_params, self.num_params
             )))
         }
     }

--- a/crates/qasm3/src/lib.rs
+++ b/crates/qasm3/src/lib.rs
@@ -150,7 +150,7 @@ pub fn load(
                 .call1((pathlike_or_filelike,))?
                 .extract::<OsString>()?;
             ::std::fs::read_to_string(&path).map_err(|err| {
-                QASM3ImporterError::new_err(format!("failed to read file '{:?}': {:?}", &path, err))
+                QASM3ImporterError::new_err(format!("failed to read file '{:?}': {:?}", path, err))
             })?
         };
     loads(py, source, custom_gates, include_path)

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -132,7 +132,7 @@ pub(crate) fn pack_expression_var(
                 || {
                     QpyError::InvalidParameter(format!(
                         "Could not find standalone variable {:?} in the qpy data",
-                        &name
+                        name
                     ))
                 },
             )?),

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -525,13 +525,13 @@ pub(crate) fn unpack_parameter_vector(
     if vector.name != pack.name || vector_len != pack.vector_size as usize {
         return Err(QpyError::InvalidParameter(format!(
             "'{}[{}]' has a base vector ('{}[{}]') that disagrees with another ('{}[{}]')",
-            &pack.name, pack.index, &pack.name, pack.vector_size, &vector.name, vector_len,
+            pack.name, pack.index, pack.name, pack.vector_size, vector.name, vector_len,
         )));
     }
     vector.get(pack.index as usize).ok_or_else(|| {
         QpyError::InvalidParameter(format!(
             "index {} is out of range for vector '{}[{}]'",
-            pack.index, &vector.name, vector_len
+            pack.index, vector.name, vector_len
         ))
     })
 }

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -81,14 +81,14 @@ pub(crate) fn recognize_custom_operation(
         {
             // Assign a uuid to each instance of a custom operation
             let new_name = if !["ucrx_dg", "ucry_dg", "ucrz_dg"].contains(&op.name()) {
-                format!("{}_{}", &op.name(), Uuid::new_v4().as_simple())
+                format!("{}_{}", op.name(), Uuid::new_v4().as_simple())
             } else {
                 // ucr*_dg gates can have different numbers of parameters,
                 // the uuid is appended to avoid storing a single definition
                 // in circuits with multiple ucr*_dg gates. For legacy reasons
                 // the uuid is stored in a different format as this was done
                 // prior to QPY 11.
-                format!("{}_{}", &op.name(), Uuid::new_v4())
+                format!("{}_{}", op.name(), Uuid::new_v4())
             };
             return Ok(Some(new_name));
         }

--- a/crates/quantum_info/src/unitary_compose.rs
+++ b/crates/quantum_info/src/unitary_compose.rs
@@ -14,15 +14,8 @@ use ndarray::{Array, Array2, ArrayView, ArrayView2, IxDyn};
 use ndarray_einsum::*;
 use num_complex::{Complex, Complex64};
 
-static LOWERCASE: [u8; 26] = [
-    b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p',
-    b'q', b'r', b's', b't', b'u', b'v', b'w', b'x', b'y', b'z',
-];
-
-static _UPPERCASE: [u8; 26] = [
-    b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P',
-    b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z',
-];
+static LOWERCASE: [u8; 26] = *b"abcdefghijklmnopqrstuvwxyz";
+static _UPPERCASE: [u8; 26] = *b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 // Compose the operators given by `gate_unitary` and `overall_unitary`, i.e. apply one to the other
 // as specified by the involved qubits given in `qubits` and the `front` parameter


### PR DESCRIPTION
Minor only: it now complains about unnecessary borrowing in `format!`-like macros.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
