### PR TITLE
docs(passmanager): expand multi-IR staged pass manager docs

### DIFF
--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -72,6 +72,38 @@ also be grouped inside a :class:`BasePassManager`.
 The stages must be set up such that the output IR of the current stage matches the input IR
 of the next stage, there are (currently) no automatic translations.
 
+Multi-IR staged workflows
+-------------------------
+
+:class:`MultiStagePassManager` chains named compilation stages where each stage can
+preserve or lower the intermediate representation. Unlike
+:class:`~qiskit.transpiler.StagedPassManager`, which is specialized for
+:class:`~.DAGCircuit` pipelines with implicit :class:`~.QuantumCircuit`
+conversion, :class:`MultiStagePassManager` accepts an arbitrary sequence of IR
+types as long as each stage's output matches the next stage's input.
+
+A stage may be:
+
+* a single :class:`.GenericPass` (or other :class:`~.passmanager.Task`) instance,
+* an iterable of tasks executed in order, or
+* a :class:`BasePassManager` used as a *task container*. When a pass manager is
+  provided as a stage, only its scheduled tasks are executed; the stage does not
+  invoke :meth:`~.BasePassManager._passmanager_frontend` or
+  :meth:`~.BasePassManager._passmanager_backend`.
+
+.. note::
+
+    It is the user's responsibility to connect compatible stages. The pass
+    manager does not insert automatic IR conversion passes between stages.
+
+When embedding existing transpiler pipelines, a pass manager returned by
+:func:`~qiskit.transpiler.generate_preset_pass_manager` may be used directly as
+a DAG stage.
+
+The :class:`~.passmanager.Task` interface is internal. Custom compilation steps
+should subclass :class:`.GenericPass` and declare input and output IR types via
+type parameters, for example ``GenericPass[PauliIR, QuantumCircuit]``.
+
 
 Examples
 ========
@@ -201,6 +233,125 @@ values, which have more than six digits.
 With the pass manager framework, a developer can flexibly customize
 the optimization task by combining multiple passes and flow controllers.
 See details in the following class API documentation.
+
+Multi-IR staged pipelines
+-------------------------
+
+The following example shows a minimal multi-IR pipeline. A custom Pauli-string
+IR is optimized, lowered to a :class:`~.QuantumCircuit`, decomposed, and
+finally converted to a :class:`~.DAGCircuit`.
+
+.. plot::
+   :include-source:
+   :nofigs:
+   :context:
+
+    from qiskit.circuit import QuantumCircuit
+    from qiskit.converters import circuit_to_dag
+    from qiskit.dagcircuit import DAGCircuit
+    from qiskit.passmanager import BasePassManager, GenericPass, MultiStagePassManager
+
+    class PauliIR:
+        """A toy IR storing global Pauli strings."""
+
+        def __init__(self, num_qubits: int):
+            self.num_qubits = num_qubits
+            self.instructions = []
+
+        def apply(self, pauli: str):
+            if len(pauli) != self.num_qubits:
+                raise ValueError("Incompatible number of qubits")
+            self.instructions.append(pauli)
+
+    class PauliPM(BasePassManager):
+        """A pass manager used only as a task container for the Pauli IR."""
+
+        def _passmanager_frontend(self, input_program, **kwargs):
+            return input_program
+
+        def _passmanager_backend(self, passmanager_ir, in_program, **kwargs):
+            return passmanager_ir
+
+    class RemovePauliIdentities(GenericPass[PauliIR, PauliIR]):
+        """Remove all-identity Pauli strings from the IR."""
+
+        def run(self, passmanager_ir: PauliIR) -> PauliIR:
+            passmanager_ir.instructions = [
+                pauli for pauli in passmanager_ir.instructions if any(p != "I" for p in pauli)
+            ]
+            return passmanager_ir
+
+    class PauliToCircuit(GenericPass[PauliIR, QuantumCircuit]):
+        """Lower PauliIR to QuantumCircuit."""
+
+        def run(self, passmanager_ir: PauliIR) -> QuantumCircuit:
+            circuit = QuantumCircuit(passmanager_ir.num_qubits)
+            for pauli in passmanager_ir.instructions:
+                circuit.pauli(pauli, circuit.qubits)
+            return circuit
+
+    class CircuitDecomposer(GenericPass[QuantumCircuit, QuantumCircuit]):
+        """Decompose the circuit one level."""
+
+        def run(self, passmanager_ir: QuantumCircuit) -> QuantumCircuit:
+            return passmanager_ir.decompose()
+
+    class CircuitToDAG(GenericPass[QuantumCircuit, DAGCircuit]):
+        """Lower QuantumCircuit to DAGCircuit."""
+
+        def run(self, passmanager_ir: QuantumCircuit) -> DAGCircuit:
+            return circuit_to_dag(passmanager_ir)
+
+    pauli_pm = PauliPM([RemovePauliIdentities()])
+    multi_pm = MultiStagePassManager(
+        pauli=pauli_pm,
+        pauli_to_circuit=PauliToCircuit(),
+        circuit=CircuitDecomposer(),
+        circuit_to_dag=CircuitToDAG(),
+    )
+
+    program = PauliIR(3)
+    program.apply("XYZ")
+    program.apply("III")
+    program.apply("ZZI")
+
+    output_dag = multi_pm.run(program)
+
+An existing transpiler pipeline can be embedded as a stage once the program has
+been lowered to a :class:`~.DAGCircuit`:
+
+.. plot::
+   :include-source:
+   :nofigs:
+   :context:
+
+    from qiskit.transpiler import CouplingMap, generate_preset_pass_manager
+
+    dag_pm = generate_preset_pass_manager(
+        coupling_map=CouplingMap.from_line(3), basis_gates=["sx", "x", "rz", "cx"]
+    )
+
+    transpile_pm = MultiStagePassManager(
+        pauli=pauli_pm,
+        pauli_to_circuit=PauliToCircuit(),
+        circuit_to_dag=CircuitToDAG(),
+        dag=dag_pm,
+    )
+
+    transpiled = transpile_pm.run(program)
+
+Stages are fixed at construction time, but their implementations can be replaced
+by assigning to the corresponding attribute:
+
+.. plot::
+   :include-source:
+   :nofigs:
+   :context:
+
+    from qiskit.transpiler.passes import RemoveIdentityEquivalent
+
+    multi_pm.circuit_to_dag = CircuitToDAG()
+    multi_pm.dag_opt = RemoveIdentityEquivalent()
 
 
 Interface

--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -10,7 +10,12 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Base classes for the Qiskit passmanager optimization tasks."""
+"""Base classes for the Qiskit passmanager optimization tasks.
+
+The :class:`Task` interface is internal to Qiskit. When implementing custom
+compilation steps, subclass :class:`GenericPass` and annotate the input and
+output IR types, for example ``GenericPass[PauliIR, QuantumCircuit]``.
+"""
 
 from __future__ import annotations
 

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -954,6 +954,49 @@ instances.  They generate pass managers which provide common functionality used 
 example, :func:`~.generate_embed_passmanager` generates a :class:`~.PassManager` to "embed" a
 selected initial :class:`~.Layout` from a layout pass to the specified target device.
 
+Multi-IR compiler pipelines
+---------------------------
+
+For workflows that start in a representation other than :class:`.QuantumCircuit`
+or :class:`.DAGCircuit`, use :class:`~qiskit.passmanager.MultiStagePassManager`
+from the :mod:`qiskit.passmanager` module. Each stage lowers or optimizes the
+current IR until the pipeline produces the desired output type.
+
+:class:`~.StagedPassManager` and :class:`~qiskit.passmanager.MultiStagePassManager`
+both provide staged execution, but they target different use cases:
+
+* :class:`~.StagedPassManager` operates on :class:`.DAGCircuit`, implicitly
+  converts :class:`.QuantumCircuit` inputs, and supports ``pre_*`` and
+  ``post_*`` stage hooks.
+* :class:`~qiskit.passmanager.MultiStagePassManager` supports arbitrary IR
+  chains. Lowering between IRs must be implemented explicitly as
+  :class:`~qiskit.passmanager.GenericPass` tasks.
+
+A common pattern is to lower a custom IR to a circuit, convert it to a
+:class:`.DAGCircuit`, and then run a preset transpiler pipeline as a stage:
+
+.. plot::
+    :include-source:
+    :nofigs:
+
+    from qiskit.converters import circuit_to_dag
+    from qiskit.passmanager import GenericPass, MultiStagePassManager
+    from qiskit.circuit import QuantumCircuit
+    from qiskit.dagcircuit import DAGCircuit
+    from qiskit.transpiler import generate_preset_pass_manager
+
+    class CircuitToDAG(GenericPass[QuantumCircuit, DAGCircuit]):
+        def run(self, passmanager_ir: QuantumCircuit) -> DAGCircuit:
+            return circuit_to_dag(passmanager_ir)
+
+    pm = MultiStagePassManager(
+        circuit_to_dag=CircuitToDAG(),
+        dag=generate_preset_pass_manager(optimization_level=1),
+    )
+
+See :mod:`qiskit.passmanager` for a full multi-IR example, including writing
+lowering passes and replacing individual stages after construction.
+
 
 .. _transpiler-custom-passes:
 

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -518,7 +518,12 @@ def _optimization_check_minimum_point(prefix: str):
 
 
 class OptimizationPassManager(PassManagerStagePlugin):
-    """Plugin class for optimization stage"""
+    """Preset pass-manager stage plugin for the optimization stage.
+
+    This is not related to :class:`~qiskit.passmanager.MultiStagePassManager`; it
+    only provides the built-in ``optimization`` stage used by
+    :func:`~qiskit.transpiler.generate_preset_pass_manager`.
+    """
 
     def pass_manager(self, pass_manager_config, optimization_level=None):
         """Build pass manager for optimization stage."""

--- a/releasenotes/notes/2.5.1/multi-ir-pm-docs-16297.yaml
+++ b/releasenotes/notes/2.5.1/multi-ir-pm-docs-16297.yaml
@@ -1,0 +1,10 @@
+---
+features_transpiler:
+  - |
+    Expanded the module documentation for multi-IR staged pass managers in
+    :mod:`qiskit.passmanager` and :mod:`qiskit.transpiler`. The documentation
+    now includes examples of writing lowering passes with
+    :class:`.GenericPass`, chaining custom IRs with
+    :class:`.MultiStagePassManager`, and embedding preset transpiler pipelines
+    returned by :func:`.generate_preset_pass_manager` as DAG stages.
+    Fixed `#16297 <https://github.com/Qiskit/qiskit/issues/16297>`__.

--- a/releasenotes/notes/2.5/multi-ir-pm-071edb6f986fcb6b.yaml
+++ b/releasenotes/notes/2.5/multi-ir-pm-071edb6f986fcb6b.yaml
@@ -1,10 +1,29 @@
 ---
 features_transpiler:
-  - Enable multi-IR compiler workflows using the :class:`.MultiStagePassManager`.
-    This pass manager provides a staged execution flow, where each stage can either 
-    preserve the IR or lower into another IR. Stages can be generically defined via 
+  - |
+    Enable multi-IR compiler workflows using the :class:`.MultiStagePassManager`.
+    This pass manager provides a staged execution flow, where each stage can either
+    preserve the IR or lower into another IR. Stages can be generically defined via
     the :class:`~.passmanager.Task` interface (and the base class :class:`.GenericPass`),
     which can be used to lower the IR, or via :class:`.BasePassManager` objects,
     which makes them compatible with existing pipelines such as provided by
     :func:`.generate_preset_pass_manager`.
-    
+
+    For example::
+
+        from qiskit.converters import circuit_to_dag
+        from qiskit.passmanager import GenericPass, MultiStagePassManager
+        from qiskit.circuit import QuantumCircuit
+        from qiskit.dagcircuit import DAGCircuit
+        from qiskit.transpiler import generate_preset_pass_manager
+
+        class CircuitToDAG(GenericPass[QuantumCircuit, DAGCircuit]):
+            def run(self, passmanager_ir: QuantumCircuit) -> DAGCircuit:
+                return circuit_to_dag(passmanager_ir)
+
+        pm = MultiStagePassManager(
+            circuit_to_dag=CircuitToDAG(),
+            dag=generate_preset_pass_manager(optimization_level=1),
+        )
+
+        out = pm.run(QuantumCircuit(2))


### PR DESCRIPTION
## Problem
The multi-IR staged pass manager (`MultiStagePassManager`) shipped in 2.5 with only basic module documentation and a short release note. Issue #16297 tracks expanding the user-facing documentation before the 2.5.1 release.

## Solution
- Expand `qiskit.passmanager` with a multi-IR overview and runnable examples
- Add cross-linked guidance in `qiskit.transpiler` for `MultiStagePassManager` vs `StagedPassManager`
- Clarify `OptimizationPassManager` is a preset stage plugin
- Expand the 2.5 feature release note and add a 2.5.1 documentation note

## Tests
Documentation-only change; no runtime code changes.

Fixes #16297