### PR TITLE
Always reconfigure CMake for `make ctest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ c: cheader clib
 .PHONY: ctest
 # Use ctest to run C API tests.
 ctest: cheader build-clib-dev
+# Clear the CMake build cache so any reconfiguration (e.g. `CFLAGS` environment) is always
+# recalculated.  CMake 3.24+ has a `--fresh` argument, but since the intent is full-rebuild here
+# anyway, no need to bump our version from 3.20.  The re-configuration time is short.
+	rm -rf $(C_DIR_TEST_BUILD)
 # `-S` specifies the source (including the `CMakeLists.txt` file, `-B` is where
 # to put the build files, including the generated CMake stuff.  See the
 # `CMakeLists.txt` file for the build variables.


### PR DESCRIPTION
The goal is making it easier to pass `CFLAGS=...` and the like through a `make ctest` command without accidentally ignoring them.  We had various cleaners, but they tend to clean too much, and our reconfigure/rebuild time for the test suite is so short it shouldn't be too onerous.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
