### PR TITLE
Vendor maths constants not in strict C11

### DIFF
--- a/test/c/common.h
+++ b/test/c/common.h
@@ -14,6 +14,27 @@
 #include <qiskit.h>
 #include <stdio.h>
 
+// These constants are technically extensions beyond the raw C11 spec, but we want to run our tests
+// using the most restrictive version of the C spec we require.  It's more convenient to just
+// arrange for them to be defined ourselves.
+#if !defined(M_PI)
+// Prevent MSVC redefining our constants.
+#define _MATH_DEFINES_DEFINED
+#define M_E 2.7182818284590452354
+#define M_LOG2E 1.4426950408889634074
+#define M_LOG10E 0.43429448190325182765
+#define M_LN2 0.69314718055994530942
+#define M_LN10 2.30258509299404568402
+#define M_PI 3.14159265358979323846
+#define M_PI_2 1.57079632679489661923
+#define M_PI_4 0.78539816339744830962
+#define M_1_PI 0.31830988618379067154
+#define M_2_PI 0.63661977236758134308
+#define M_2_SQRTPI 1.12837916709551257390
+#define M_SQRT2 1.41421356237309504880
+#define M_SQRT1_2 0.70710678118654752440
+#endif // !defined(M_PI)
+
 // An enumeration of test results. These should be returned by test functions to
 // indicate what kind of error occurred. This will be used to produce more
 // helpful messages for the developer running the test suite.


### PR DESCRIPTION
Technically these are unrequired extensions to the C spec.  Explicitly listing them in our own test harness is a trade-off between convenience in writing our tests, and entire strict C11 compliance.

CI and local runs typically pass without this change because `gcc`, `clang` and MSVC all default to being a bit more permissive than the spec requires.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
