### PR TITLE
Set the C language spec used during C tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -934,6 +934,21 @@ the top-level `Makefile`, which you can run with
 make ctest
 ```
 
+You can pass arbitrary CMake flags to the `ctest` recipe by setting the
+`CMAKE_FLAGS` environment variable, such as:
+
+```bash
+CMAKE_FLAGS='-DCMAKE_C_STANDARD=23 -DCMAKE_C_EXTENSIONS=ON' make ctest
+```
+
+which will run the C API tests in `gnu23` (or equivalent) mode, instead of the
+default.
+
+> [!NOTE]
+> Overriding any `CMAKE_FLAGS` from the command line will cause them to become
+> your new cached default values.  Run `make cclean` to fully clear all caches
+> if you want to reset to the defaults later.
+
 #### Writing C API tests
 
 The C API test suite automatically discovers any files inside `test/c/` matching

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,11 @@ ctest: cheader build-clib-dev
 # `-S` specifies the source (including the `CMakeLists.txt` file, `-B` is where
 # to put the build files, including the generated CMake stuff.  See the
 # `CMakeLists.txt` file for the build variables.
+#
+# The `CMAKE_FLAGS` argument is to allow user insertion of additional flags, such
+# as to override the `CMAKE_C_STANDARD` line.
 	cmake -S$(C_DIR_TEST) -B$(C_DIR_TEST_BUILD) \
+		$(CMAKE_FLAGS) \
 		-DCARGO_LIB_DIR=$(abspath $(C_DIR_CARGO_TARGET))/debug \
 		-DQISKIT_INCLUDE_PATH=$(abspath $(C_DIR_OUT_INCLUDE))
 # Actually build the test.

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -17,6 +17,10 @@ set (
     CACHE FILEPATH "path to the `target/<profile>` directory where the Qiskit library is built"
 )
 
+# Keep in sync with Qiskit's actual C compiler standard. (For search purposes: C11.)
+set (CMAKE_C_STANDARD 11 CACHE STRING "C standard to use for test build.")
+set (CMAKE_C_EXTENSIONS OFF CACHE BOOL "Whether to allow GNU-like C extensions.")
+set (CMAKE_C_STANDARD_REQUIRED ON CACHE BOOL "Whether to fail if we can't set the C standard.")
 
 enable_testing ()
 include_directories (${QISKIT_INCLUDE_PATH})


### PR DESCRIPTION
Our `CMakeLists.txt` file was previously leaving this undefined, and so using the defaults of whatever build tool came along.  This could mean that newer toolchains would build in different modes, and thus see different behaviours.  Here, we set the test defaults to match exactly Qiskit's minimum C compiler requirements without extensions.

This recently occurred for Qiskit v2.5, where the bump to `cbindgen==0.29.3`[^1] changed the behaviour of fixed-width `enum` exports to use the new C23 / C++-like `enum X : <ty>` syntax, gated on the reported language-spec[^2].  Recent `gcc` (15+) default to `-std=gnu23`, so packagers for recent Linux distros saw new build failures in the C test suite that were uncaught by CI[^3].

A follow-up commit can modify our CI to explicitly test a range of C language versions.

[^1]: 3e8d124e0b: Bump cbindgen from 0.29.2 to 0.29.3 (#16300)
[^2]: mozilla/cbindgen@b16c1d2025: Use C++ fixed-type enumeration syntax under C23 (or higher) as well
[^3]: https://github.com/Qiskit/qiskit/issues/16555

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

---

This may fail in CI without #16561.  This commit fails in `make ctest` for me on Linux with `gcc` without that patch, but passes following `CMAKE_FLAGS=-DCMAKE_C_EXTENSIONS=ON make ctest`, which is what's _supposed_ to happen.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
