### PR TITLE
Test matrix of C-spec versions in CI

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -36,7 +36,8 @@ jobs:
       - test-macos
       - test-windows
       - test-rust
-      - test-c
+      - test-c-defaults
+      - test-c-versions
       - test-images
       - miri
       - qpy
@@ -164,8 +165,8 @@ jobs:
     with:
       runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
 
-  test-c:
-    name: Unit C / ${{ matrix.runner }}
+  test-c-defaults:
+    name: Unit C / Defaults / ${{ matrix.runner }}
     needs: config
     uses: ./.github/workflows/ctests.yml
     with:
@@ -179,6 +180,25 @@ jobs:
           - ${{ needs.config.outputs.runner-linux-arm64 }}
           - ${{ needs.config.outputs.runner-macos-arm64 }}
           - ${{ needs.config.outputs.runner-windows-x86_64 }}
+
+  test-c-versions:
+    name: Unit C / Versions / ${{ matrix.extensions && 'gnu' || 'c' }}${{ matrix.version }}
+    needs: config
+    uses: ./.github/workflows/ctests.yml
+    with:
+      python-version: ${{ needs.config.outputs.python-new }}
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      name: ${{ matrix.extensions && 'gnu' || 'c' }}${{ matrix.version }}
+      cmake_flags: "-DCMAKE_C_STANDARD=${{ matrix.version }} -DCMAKE_C_EXTENSIONS=${{ matrix.extensions && 'ON' || 'OFF' }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - ${{ needs.config.outputs.c-old }}
+          - ${{ needs.config.outputs.c-new }}
+        extensions:
+          - true
+          - false
 
   test-images:
     name: Image

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -18,6 +18,14 @@ on:
         description: Newest supported version of Python
         value: '3.14'
 
+      c-old:
+        description: Minimum required version of C spec
+        value: '11'
+
+      c-new:
+        description: Latest version of C spec to use in tests
+        value: '23'
+
       runner-linux-x86_64:
         description: Runner image for Linux x86_64 jobs
         value: 'ubuntu-latest'

--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -11,10 +11,17 @@ on:
         description: Runner image to use.
         type: string
         required: true
-
+      name:
+        description: Name to give the job.
+        type: string
+        required: false
+      cmake_flags:
+        description: Additional CMake flags to set.
+        type: string
+        required: false
 jobs:
   tests:
-    name: ${{ inputs.runner }}
+    name: ${{ inputs.name || inputs.runner }}
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -23,3 +30,5 @@ jobs:
           python-version: ${{ inputs.python-version }}
       - name: Run tests
         run: make ctest
+        env:
+          CMAKE_FLAGS: ${{ inputs.cmake_flags }}


### PR DESCRIPTION
We run most C tests with the defaults set in CMake (which should reflect our minimum version required), but we still want coverage of other common versions people might build against, especially since our header files have conditional defines based on version.

Built on #16562.


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
