### PR TITLE
fix(dagcircuit): avoid copying global_phase into layer DAGs

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4093,6 +4093,7 @@ impl DAGCircuit {
             }
 
             let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
+            new_layer.global_phase = Param::Float(0.);
             let mut block_map = BlockMapper::new();
             let data: Vec<_> = op_nodes
                 .iter()
@@ -4135,6 +4136,7 @@ impl DAGCircuit {
                 _ => unreachable!("A non-operation node was obtained from topological_op_nodes."),
             };
             let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop);
+            new_layer.global_phase = Param::Float(0.);
             let mut block_map = BlockMapper::new();
 
             // Save the support of the operation we add to the layer

--- a/releasenotes/notes/fix-basicswap-global-phase-16271.yaml
+++ b/releasenotes/notes/fix-basicswap-global-phase-16271.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue where the layer-returning methods
+    :meth:`.DAGCircuit.layers` and :meth:`.DAGCircuit.serial_layers`
+    copied the parent DAG ``global_phase`` into each yielded layer DAG.
+    Rebuilding a circuit from those layer DAGs could then accumulate the
+    original phase more than once, including in
+    :class:`~qiskit.transpiler.passes.BasicSwap`. This fixes `#16271
+    <https://github.com/Qiskit/qiskit/issues/16271>`__.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1465,6 +1465,34 @@ class TestDagLayers(DAGTest):
             ]
             self.assertEqual(comp, truth)
 
+    def test_serial_layers_do_not_copy_global_phase(self):
+        """serial_layers() should not copy the parent DAG global phase."""
+        qc = QuantumCircuit(2, global_phase=math.pi / 7)
+        qc.h(0)
+        qc.cx(0, 1)
+        dag = circuit_to_dag(qc)
+
+        layers = list(dag.serial_layers())
+
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(dag.global_phase, math.pi / 7)
+        self.assertEqual(layers[0]["graph"].global_phase, 0.0)
+        self.assertEqual(layers[1]["graph"].global_phase, 0.0)
+
+    def test_layers_do_not_copy_global_phase(self):
+        """layers() should not copy the parent DAG global phase."""
+        qc = QuantumCircuit(2, global_phase=math.pi / 7)
+        qc.h(0)
+        qc.cx(0, 1)
+        dag = circuit_to_dag(qc)
+
+        layers = list(dag.layers())
+
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(dag.global_phase, math.pi / 7)
+        self.assertEqual(layers[0]["graph"].global_phase, 0.0)
+        self.assertEqual(layers[1]["graph"].global_phase, 0.0)
+
 
 def _sort_key(indices: dict[Qubit, int]):
     """Return key function for sorting DAGCircuits, given a global qubit mapping."""

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -408,6 +408,39 @@ class TestBasicSwap(QiskitTestCase):
         self.assertIsInstance(fake_pm.property_set["final_layout"], Layout)
         self.assertEqual(fake_pm.property_set["final_layout"], real_pm.property_set["final_layout"])
 
+    def test_preserves_global_phase(self):
+        """The global phase is preserved when no swaps are needed."""
+        coupling = CouplingMap.from_line(3)
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = 0.5
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+
+        dag = circuit_to_dag(circuit)
+        after = BasicSwap(coupling).run(dag)
+
+        self.assertEqual(after.global_phase, dag.global_phase)
+
+    def test_preserves_global_phase_when_swaps_inserted(self):
+        """The global phase is preserved when routing inserts swaps."""
+        coupling = CouplingMap.from_line(3)
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = 0.5
+        circuit.cx(qr[0], qr[2])
+
+        dag = circuit_to_dag(circuit)
+        pass_ = BasicSwap(coupling)
+        after = pass_.run(dag)
+
+        self.assertEqual(after.global_phase, dag.global_phase)
+        self.assertEqual(after.count_ops().get("swap", 0), 1)
+        self.assertIsInstance(pass_.property_set["final_layout"], Layout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
`BasicSwap` could inflate `global_phase` when rebuilding a circuit from
`DAGCircuit.serial_layers()`, even when no swaps were inserted (#16271).

## Root Cause
`layers()` and `serial_layers()` created each layer DAG with
`copy_empty_like()`, which copied the parent `global_phase`. Composing those
layer DAGs back together accumulated the phase once per layer.

## Solution
Reset `global_phase` to zero on layer DAGs returned by `layers()` and
`serial_layers()`, matching the existing pattern in `separable_circuits()`.

## Tests Added
- `test_serial_layers_do_not_copy_global_phase`
- `test_layers_do_not_copy_global_phase`
- `test_preserves_global_phase` (BasicSwap, no swaps)
- `test_preserves_global_phase_when_swaps_inserted` (BasicSwap, with swap)

Fixes #16271

### AI/LLM disclosure
- [x] I used Cursor (agent) to help implement and test-plan this fix.
- I reviewed the diff, traced the failure through `serial_layers()` → `compose()`,
  and verified the fix matches the existing `separable_circuits()` pattern.