### PR TITLE
Make PyO3 and Python optional for quantum-info crate

### DIFF
--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 qiskit-util = { workspace = true, features = ["py"] }
-qiskit-quantum-info.workspace = true
+qiskit-quantum-info = { workspace = true, features = ["python"] }
 rayon.workspace = true
 foldhash.workspace = true
 rustworkx-core.workspace = true

--- a/crates/pyext/Cargo.toml
+++ b/crates/pyext/Cargo.toml
@@ -39,6 +39,6 @@ qiskit-qpy.workspace = true
 qiskit-cext = { workspace = true, features = ["python_binding"] }
 qiskit-cext-vtable = { workspace = true, features = ["python_binding", "addr"] }
 qiskit-transpiler.workspace = true
-qiskit-quantum-info.workspace = true
+qiskit-quantum-info = { workspace = true, features = ["python"] }
 qiskit-synthesis.workspace = true
 mimalloc = { workspace = true, optional = true }

--- a/crates/quantum_info/Cargo.toml
+++ b/crates/quantum_info/Cargo.toml
@@ -10,8 +10,8 @@ name = "qiskit_quantum_info"
 doctest = false
 
 [dependencies]
-qiskit-util = { workspace = true, features = ["py"] }
-numpy.workspace = true
+qiskit-util = { workspace = true }
+numpy = { workspace = true, optional = true}
 num-complex.workspace = true
 num-traits.workspace = true
 nalgebra.workspace = true
@@ -41,10 +41,15 @@ features = ["rayon"]
 
 [dependencies.pyo3]
 workspace = true
+optional = true
 features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [lints]
 workspace = true
+
+[features]
+python = ["qiskit-util/py", "dep:pyo3", "dep:numpy"]
+
 
 [dev-dependencies]
 qiskit-circuit.workspace = true

--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -13,16 +13,20 @@
 pub mod clifford;
 pub mod pauli_lindblad_map;
 pub mod sparse_observable;
+#[cfg(feature = "python")]
 pub mod sparse_pauli_op;
 pub mod unitary_compose;
 pub mod versor_u2;
 
+#[cfg(feature = "python")] // Only currently used by python remove if needed from rust
 mod rayon_ext;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "python")]
 use pyo3::import_exception;
 
+#[cfg(feature = "python")]
 pub(crate) mod imports {
     use qiskit_util::py::ImportOnceCell;
 
@@ -30,5 +34,5 @@ pub(crate) mod imports {
     pub static PAULI_LIST_TYPE: ImportOnceCell =
         ImportOnceCell::new("qiskit.quantum_info", "PauliList");
 }
-
+#[cfg(feature = "python")]
 import_exception!(qiskit.exceptions, QiskitError);

--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -10,15 +10,20 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pauli_lindblad_map_class::PyPauliLindbladMap;
-use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
-use pyo3::prelude::*;
-use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
-
 pub mod pauli_lindblad_map_class;
 pub mod phased_qubit_sparse_pauli;
 pub mod qubit_sparse_pauli;
 
+#[cfg(feature = "python")]
+use pauli_lindblad_map_class::PyPauliLindbladMap;
+#[cfg(feature = "python")]
+use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
+
+#[cfg(feature = "python")]
 pub fn pauli_lindblad_map(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyPauliLindbladMap>()?;
     m.add_class::<PyQubitSparsePauli>()?;

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -11,7 +11,9 @@
 // that they have been altered from the originals.
 
 use hashbrown::HashSet;
+#[cfg(feature = "python")]
 use numpy::{PyArray1, PyArray2, PyArrayMethods, ToPyArray};
+#[cfg(feature = "python")]
 use pyo3::{
     IntoPyObjectExt, PyErr,
     exceptions::{PyTypeError, PyValueError},
@@ -19,22 +21,28 @@ use pyo3::{
     prelude::*,
     types::{PyList, PyString, PyTuple, PyType},
 };
-use std::{
-    collections::btree_map,
-    sync::{Arc, RwLock},
-};
+use std::collections::btree_map;
+
+#[cfg(feature = "python")]
+use std::sync::{Arc, RwLock};
 
 use rand::prelude::*;
 use rand::rngs::SysRng;
 use rand_distr::Bernoulli;
 use rand_pcg::Pcg64Mcg;
 
+#[cfg(feature = "python")]
 use qiskit_util::py::{PySequenceIndex, SequenceIndex};
 
 use super::qubit_sparse_pauli::{
-    ArithmeticError, CoherenceError, InnerReadError, InnerWriteError, LabelError, Pauli,
-    PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli, QubitSparsePauliList,
-    QubitSparsePauliView, raw_parts_from_sparse_list,
+    ArithmeticError, CoherenceError, LabelError, Pauli, QubitSparsePauli, QubitSparsePauliList,
+    QubitSparsePauliView,
+};
+
+#[cfg(feature = "python")]
+use super::qubit_sparse_pauli::{
+    InnerReadError, InnerWriteError, PyQubitSparsePauli, PyQubitSparsePauliList,
+    raw_parts_from_sparse_list,
 };
 
 /// A Pauli Lindblad map that stores its data in a qubit-sparse format. Note that gamma,
@@ -607,6 +615,7 @@ impl GeneratorTerm {
 /// A single term from a complete :class:`PauliLindbladMap`.
 ///
 /// These are typically created by indexing into or iterating through a :class:`PauliLindbladMap`.
+#[cfg(feature = "python")]
 #[pyclass(
     name = "GeneratorTerm",
     frozen,
@@ -617,6 +626,8 @@ impl GeneratorTerm {
 struct PyGeneratorTerm {
     inner: GeneratorTerm,
 }
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyGeneratorTerm {
     // Mark the Python class as being defined "within" the `PauliLindbladMap` class namespace.
@@ -909,6 +920,7 @@ impl PyGeneratorTerm {
 ///   :meth:`to_sparse_list`       Express the map in a sparse list format with elements
 ///                                ``(paulis, indices, rate)``.
 ///   ===========================  =================================================================
+#[cfg(feature = "python")]
 #[pyclass(name = "PauliLindbladMap", module = "qiskit.quantum_info", sequence)]
 #[derive(Debug)]
 pub struct PyPauliLindbladMap {
@@ -916,6 +928,7 @@ pub struct PyPauliLindbladMap {
     inner: Arc<RwLock<PauliLindbladMap>>,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyPauliLindbladMap {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -1934,6 +1947,7 @@ impl PyPauliLindbladMap {
     }
 }
 
+#[cfg(feature = "python")]
 impl From<PauliLindbladMap> for PyPauliLindbladMap {
     fn from(val: PauliLindbladMap) -> PyPauliLindbladMap {
         PyPauliLindbladMap {
@@ -1941,6 +1955,8 @@ impl From<PauliLindbladMap> for PyPauliLindbladMap {
         }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for PauliLindbladMap {
     type Target = PyPauliLindbladMap;
     type Output = Bound<'py, Self::Target>;
@@ -1963,6 +1979,7 @@ impl<'py> IntoPyObject<'py> for PauliLindbladMap {
 ///
 /// The purpose of this is for conversion the arithmetic operations, which should return
 /// [PyNotImplemented] if the type is not valid for coercion.
+#[cfg(feature = "python")]
 fn coerce_to_map<'py>(
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Option<Bound<'py, PyPauliLindbladMap>>> {

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -10,7 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#[cfg(feature = "python")]
 use numpy::{PyArray1, PyArrayMethods, PyReadonlyArray1};
+#[cfg(feature = "python")]
 use pyo3::{
     IntoPyObjectExt, PyErr,
     exceptions::{PyTypeError, PyValueError},
@@ -18,18 +20,27 @@ use pyo3::{
     prelude::*,
     types::{PyInt, PyList, PyString, PyTuple, PyType},
 };
+
+#[cfg(feature = "python")]
 use std::{
     collections::btree_map,
     sync::{Arc, RwLock},
 };
 
+#[cfg(feature = "python")]
 use qiskit_util::py::{PySequenceIndex, SequenceIndex};
 
 use super::qubit_sparse_pauli::{
-    ArithmeticError, CoherenceError, InnerReadError, InnerWriteError, LabelError, Pauli,
-    PyQubitSparsePauli, QubitSparsePauli, QubitSparsePauliList, QubitSparsePauliView,
-    raw_parts_from_sparse_list,
+    ArithmeticError, CoherenceError, LabelError, Pauli, QubitSparsePauli, QubitSparsePauliList,
+    QubitSparsePauliView,
 };
+
+#[cfg(feature = "python")]
+use super::qubit_sparse_pauli::{
+    InnerReadError, InnerWriteError, PyQubitSparsePauli, raw_parts_from_sparse_list,
+};
+
+#[cfg(feature = "python")]
 use crate::imports;
 
 /// A list of Pauli operators stored in a qubit-sparse format.
@@ -166,6 +177,7 @@ impl PhasedQubitSparsePauliList {
     }
 
     // Check equality of operators
+    #[cfg(feature = "python")] // Only currently used by python remove if needed from rust
     fn eq(&self, other: &PhasedQubitSparsePauliList) -> bool {
         if self.qubit_sparse_pauli_list != other.qubit_sparse_pauli_list {
             return false;
@@ -387,6 +399,7 @@ impl PhasedQubitSparsePauli {
     }
 
     // Check equality of operators
+    #[cfg(feature = "python")] // Only currently used by python remove if needed from rust
     fn eq(&self, other: &PhasedQubitSparsePauli) -> bool {
         ((self.phase - other.phase).rem_euclid(4) == 0)
             && self.qubit_sparse_pauli == other.qubit_sparse_pauli
@@ -453,6 +466,7 @@ impl PhasedQubitSparsePauli {
 ///     :param int|None num_qubits: Optional number of qubits for the operator.  For most data
 ///         inputs, this can be inferred and need not be passed.  It is only necessary for the
 ///         sparse-label format.  If given unnecessarily, it must match the data input.
+#[cfg(feature = "python")]
 #[pyclass(
     name = "PhasedQubitSparsePauli",
     frozen,
@@ -464,12 +478,14 @@ pub struct PyPhasedQubitSparsePauli {
     inner: PhasedQubitSparsePauli,
 }
 
+#[cfg(feature = "python")]
 impl PyPhasedQubitSparsePauli {
     pub fn inner(&self) -> &PhasedQubitSparsePauli {
         &self.inner
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyPhasedQubitSparsePauli {
     #[new]
@@ -997,6 +1013,7 @@ impl PyPhasedQubitSparsePauli {
 ///   :meth:`to_sparse_list`       Express the observable in a sparse list format with elements
 ///                                ``(phase, paulis, indices)``.
 ///   ===========================  =================================================================
+#[cfg(feature = "python")]
 #[pyclass(
     name = "PhasedQubitSparsePauliList",
     module = "qiskit.quantum_info",
@@ -1007,6 +1024,8 @@ pub struct PyPhasedQubitSparsePauliList {
     // This class keeps a pointer to a pure Rust-SparseTerm and serves as interface from Python.
     pub inner: Arc<RwLock<PhasedQubitSparsePauliList>>,
 }
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyPhasedQubitSparsePauliList {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -1577,11 +1596,14 @@ impl PyPhasedQubitSparsePauliList {
     }
 }
 
+#[cfg(feature = "python")]
 impl From<PhasedQubitSparsePauli> for PyPhasedQubitSparsePauli {
     fn from(val: PhasedQubitSparsePauli) -> PyPhasedQubitSparsePauli {
         PyPhasedQubitSparsePauli { inner: val }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for PhasedQubitSparsePauli {
     type Target = PyPhasedQubitSparsePauli;
     type Output = Bound<'py, Self::Target>;
@@ -1591,6 +1613,8 @@ impl<'py> IntoPyObject<'py> for PhasedQubitSparsePauli {
         PyPhasedQubitSparsePauli::from(self).into_pyobject(py)
     }
 }
+
+#[cfg(feature = "python")]
 impl From<PhasedQubitSparsePauliList> for PyPhasedQubitSparsePauliList {
     fn from(val: PhasedQubitSparsePauliList) -> PyPhasedQubitSparsePauliList {
         PyPhasedQubitSparsePauliList {
@@ -1598,6 +1622,8 @@ impl From<PhasedQubitSparsePauliList> for PyPhasedQubitSparsePauliList {
         }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for PhasedQubitSparsePauliList {
     type Target = PyPhasedQubitSparsePauliList;
     type Output = Bound<'py, Self::Target>;

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -13,7 +13,9 @@
 use hashbrown::HashSet;
 
 use ndarray::Array2;
+#[cfg(feature = "python")]
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
+#[cfg(feature = "python")]
 use pyo3::{
     IntoPyObjectExt, PyErr,
     exceptions::{PyRuntimeError, PyTypeError, PyValueError},
@@ -22,18 +24,24 @@ use pyo3::{
     sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
 };
+use std::collections::btree_map;
+
+#[cfg(feature = "python")]
 use std::{
-    collections::btree_map,
     iter::zip,
     sync::{Arc, RwLock},
 };
 use thiserror::Error;
 
+#[cfg(feature = "python")]
 use qiskit_util::py::{PySequenceIndex, SequenceIndex};
 
+#[cfg(feature = "python")]
 use crate::imports;
 
+#[cfg(feature = "python")]
 static PAULI_PY_ENUM: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+#[cfg(feature = "python")]
 static PAULI_INTO_PY: PyOnceLock<[Option<Py<PyAny>>; 16]> = PyOnceLock::new();
 
 /// Named handle to the alphabet of single-qubit terms.
@@ -906,32 +914,42 @@ impl ::std::fmt::Display for InnerWriteError {
     }
 }
 
+#[cfg(feature = "python")]
 impl From<InnerReadError> for PyErr {
     fn from(value: InnerReadError) -> PyErr {
         PyRuntimeError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<InnerWriteError> for PyErr {
     fn from(value: InnerWriteError) -> PyErr {
         PyRuntimeError::new_err(value.to_string())
     }
 }
 
+#[cfg(feature = "python")]
 impl From<PauliFromU8Error> for PyErr {
     fn from(value: PauliFromU8Error) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<CoherenceError> for PyErr {
     fn from(value: CoherenceError) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<LabelError> for PyErr {
     fn from(value: LabelError) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<ArithmeticError> for PyErr {
     fn from(value: ArithmeticError) -> PyErr {
         PyValueError::new_err(value.to_string())
@@ -940,6 +958,7 @@ impl From<ArithmeticError> for PyErr {
 
 /// The single-character string label used to represent this term in the
 /// :class:`QubitSparsePauliList` alphabet.
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(name = "label")]
 fn pauli_label(py: Python<'_>, slf: Pauli) -> &Bound<'_, PyString> {
@@ -959,6 +978,7 @@ fn pauli_label(py: Python<'_>, slf: Pauli) -> &Bound<'_, PyString> {
 ///
 /// The resulting class is attached to `QubitSparsePauliList` as a class attribute, and its
 /// `__qualname__` is set to reflect this.
+#[cfg(feature = "python")]
 fn make_py_pauli(py: Python) -> PyResult<Py<PyType>> {
     let terms = [Pauli::X, Pauli::Y, Pauli::Z]
         .into_iter()
@@ -995,6 +1015,7 @@ fn make_py_pauli(py: Python) -> PyResult<Py<PyType>> {
 // singletons and subclasses of Python `int`.  We only use this for interaction with "high level"
 // Python space; the efficient Numpy-like array paths use `u8` directly so Numpy can act on it
 // efficiently.
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for Pauli {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -1025,6 +1046,7 @@ impl<'py> IntoPyObject<'py> for Pauli {
     }
 }
 
+#[cfg(feature = "python")]
 impl<'a, 'py> FromPyObject<'a, 'py> for Pauli {
     type Error = PyErr;
 
@@ -1186,6 +1208,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Pauli {
 ///     :param int|None num_qubits: Optional number of qubits for the operator.  For most data
 ///         inputs, this can be inferred and need not be passed.  It is only necessary for the
 ///         sparse-label format.  If given unnecessarily, it must match the data input.
+#[cfg(feature = "python")]
 #[pyclass(
     name = "QubitSparsePauli",
     frozen,
@@ -1197,12 +1220,14 @@ pub struct PyQubitSparsePauli {
     inner: QubitSparsePauli,
 }
 
+#[cfg(feature = "python")]
 impl PyQubitSparsePauli {
     pub fn inner(&self) -> &QubitSparsePauli {
         &self.inner
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyQubitSparsePauli {
     #[new]
@@ -1689,6 +1714,7 @@ impl PyQubitSparsePauli {
 ///   :meth:`to_sparse_list`       Express the observable in a sparse list format with elements
 ///                                ``(paulis, indices)``.
 ///   ===========================  =================================================================
+#[cfg(feature = "python")]
 #[pyclass(
     name = "QubitSparsePauliList",
     module = "qiskit.quantum_info",
@@ -1699,6 +1725,8 @@ pub struct PyQubitSparsePauliList {
     // This class keeps a pointer to a pure Rust-SparseTerm and serves as interface from Python.
     pub inner: Arc<RwLock<QubitSparsePauliList>>,
 }
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PyQubitSparsePauliList {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -2287,11 +2315,14 @@ impl PyQubitSparsePauliList {
     }
 }
 
+#[cfg(feature = "python")]
 impl From<QubitSparsePauli> for PyQubitSparsePauli {
     fn from(val: QubitSparsePauli) -> PyQubitSparsePauli {
         PyQubitSparsePauli { inner: val }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for QubitSparsePauli {
     type Target = PyQubitSparsePauli;
     type Output = Bound<'py, Self::Target>;
@@ -2301,6 +2332,8 @@ impl<'py> IntoPyObject<'py> for QubitSparsePauli {
         PyQubitSparsePauli::from(self).into_pyobject(py)
     }
 }
+
+#[cfg(feature = "python")]
 impl From<QubitSparsePauliList> for PyQubitSparsePauliList {
     fn from(val: QubitSparsePauliList) -> PyQubitSparsePauliList {
         PyQubitSparsePauliList {
@@ -2308,6 +2341,8 @@ impl From<QubitSparsePauliList> for PyQubitSparsePauliList {
         }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for QubitSparsePauliList {
     type Target = PyQubitSparsePauliList;
     type Output = Bound<'py, Self::Target>;

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -15,13 +15,17 @@ mod lookup;
 use hashbrown::HashSet;
 use itertools::Itertools;
 use lookup::conjugate_bitterm;
+#[cfg(feature = "python")]
 use ndarray::Array2;
 use num_complex::Complex64;
+#[cfg(feature = "python")]
 use num_traits::Zero;
+#[cfg(feature = "python")]
 use numpy::{
     PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayLike1, PyArrayMethods,
     PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
 };
+#[cfg(feature = "python")]
 use pyo3::{
     IntoPyObjectExt, PyErr,
     exceptions::{PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError},
@@ -30,22 +34,27 @@ use pyo3::{
     sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
 };
+#[cfg(feature = "python")]
 use qiskit_util::IndexSet;
-use std::{
-    cmp::Ordering,
-    collections::btree_map,
-    ops::{AddAssign, DivAssign, MulAssign, SubAssign},
-    sync::{Arc, RwLock, RwLockReadGuard},
-};
+#[cfg(feature = "python")]
+use qiskit_util::py::{ImportOnceCell, PySequenceIndex, SequenceIndex};
+#[cfg(feature = "python")]
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+#[cfg(feature = "python")]
+use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::{cmp::Ordering, collections::btree_map};
 use thiserror::Error;
 
-use qiskit_util::py::{ImportOnceCell, PySequenceIndex, SequenceIndex};
-
+#[cfg(feature = "python")]
 static PAULI_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "Pauli");
+#[cfg(feature = "python")]
 static PAULI_LIST_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "PauliList");
+#[cfg(feature = "python")]
 static SPARSE_PAULI_OP_TYPE: ImportOnceCell =
     ImportOnceCell::new("qiskit.quantum_info", "SparsePauliOp");
+#[cfg(feature = "python")]
 static BIT_TERM_PY_ENUM: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+#[cfg(feature = "python")]
 static BIT_TERM_INTO_PY: PyOnceLock<[Option<Py<PyAny>>; 16]> = PyOnceLock::new();
 
 /// Named handle to the alphabet of single-qubit terms.
@@ -1808,6 +1817,7 @@ impl SparseTerm {
 #[derive(Error, Debug)]
 pub struct InnerReadError;
 
+#[cfg(feature = "python")] // Only currently used by python, remove if needed from rust
 #[derive(Error, Debug)]
 struct InnerWriteError;
 
@@ -1817,38 +1827,48 @@ impl ::std::fmt::Display for InnerReadError {
     }
 }
 
+#[cfg(feature = "python")] // Only currently used by python, remove if needed from rust
 impl ::std::fmt::Display for InnerWriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "Failed acquiring lock for writing.")
     }
 }
 
+#[cfg(feature = "python")]
 impl From<InnerReadError> for PyErr {
     fn from(value: InnerReadError) -> PyErr {
         PyRuntimeError::new_err(value.to_string())
     }
 }
+#[cfg(feature = "python")]
 impl From<InnerWriteError> for PyErr {
     fn from(value: InnerWriteError) -> PyErr {
         PyRuntimeError::new_err(value.to_string())
     }
 }
 
+#[cfg(feature = "python")]
 impl From<BitTermFromU8Error> for PyErr {
     fn from(value: BitTermFromU8Error) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<CoherenceError> for PyErr {
     fn from(value: CoherenceError) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<LabelError> for PyErr {
     fn from(value: LabelError) -> PyErr {
         PyValueError::new_err(value.to_string())
     }
 }
+
+#[cfg(feature = "python")]
 impl From<ArithmeticError> for PyErr {
     fn from(value: ArithmeticError) -> PyErr {
         PyValueError::new_err(value.to_string())
@@ -1857,6 +1877,8 @@ impl From<ArithmeticError> for PyErr {
 
 /// The single-character string label used to represent this term in the :class:`SparseObservable`
 /// alphabet.
+
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(name = "label")]
 fn bit_term_label(py: Python<'_>, slf: BitTerm) -> &Bound<'_, PyString> {
@@ -1882,6 +1904,7 @@ fn bit_term_label(py: Python<'_>, slf: BitTerm) -> &Bound<'_, PyString> {
 ///
 /// The resulting class is attached to `SparseObservable` as a class attribute, and its
 /// `__qualname__` is set to reflect this.
+#[cfg(feature = "python")]
 fn make_py_bit_term(py: Python) -> PyResult<Py<PyType>> {
     let terms = [
         BitTerm::X,
@@ -1928,6 +1951,7 @@ fn make_py_bit_term(py: Python) -> PyResult<Py<PyType>> {
 // singletons and subclasses of Python `int`.  We only use this for interaction with "high level"
 // Python space; the efficient Numpy-like array paths use `u8` directly so Numpy can act on it
 // efficiently.
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for BitTerm {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
@@ -1958,6 +1982,7 @@ impl<'py> IntoPyObject<'py> for BitTerm {
     }
 }
 
+#[cfg(feature = "python")]
 impl<'a, 'py> FromPyObject<'a, 'py> for BitTerm {
     type Error = PyErr;
 
@@ -1981,6 +2006,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for BitTerm {
 /// A single term from a complete :class:`SparseObservable`.
 ///
 /// These are typically created by indexing into or iterating through a :class:`SparseObservable`.
+#[cfg(feature = "python")]
 #[pyclass(
     name = "Term",
     frozen,
@@ -1991,6 +2017,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for BitTerm {
 struct PySparseTerm {
     inner: SparseTerm,
 }
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PySparseTerm {
     // Mark the Python class as being defined "within" the `SparseObservable` class namespace.
@@ -2622,6 +2650,7 @@ impl PySparseTerm {
 /// observable generate only a small number of duplications, and like-term detection has additional
 /// costs.  If this does not fit your use cases, you can either periodically call :meth:`simplify`,
 /// or discuss further APIs with us for better building of observables.
+#[cfg(feature = "python")]
 #[pyclass(name = "SparseObservable", module = "qiskit.quantum_info", sequence)]
 #[derive(Debug)]
 pub struct PySparseObservable {
@@ -2629,6 +2658,7 @@ pub struct PySparseObservable {
     pub inner: Arc<RwLock<SparseObservable>>,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl PySparseObservable {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -4196,6 +4226,8 @@ impl PySparseObservable {
         py.get_type::<PySparseTerm>()
     }
 }
+
+#[cfg(feature = "python")]
 impl PySparseObservable {
     /// This is an immutable reference as opposed to a `copy`.
     pub fn as_inner(&self) -> Result<RwLockReadGuard<'_, SparseObservable>, InnerReadError> {
@@ -4203,6 +4235,8 @@ impl PySparseObservable {
         Ok(data)
     }
 }
+
+#[cfg(feature = "python")]
 impl From<SparseObservable> for PySparseObservable {
     fn from(val: SparseObservable) -> PySparseObservable {
         PySparseObservable {
@@ -4210,6 +4244,8 @@ impl From<SparseObservable> for PySparseObservable {
         }
     }
 }
+
+#[cfg(feature = "python")]
 impl<'py> IntoPyObject<'py> for SparseObservable {
     type Target = PySparseObservable;
     type Output = Bound<'py, Self::Target>;
@@ -4221,6 +4257,7 @@ impl<'py> IntoPyObject<'py> for SparseObservable {
 }
 
 /// Helper class of `ArrayView` that denotes the slot of the `SparseObservable` we're looking at.
+#[cfg(feature = "python")]
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ArraySlot {
     Coeffs,
@@ -4233,11 +4270,14 @@ enum ArraySlot {
 /// expose Python-managed wrapped pointers without introducing some form of runtime exclusion on the
 /// ability of `SparseObservable` to re-allocate in place; we can't leave dangling pointers for
 /// Python space.
+#[cfg(feature = "python")]
 #[pyclass(frozen, sequence)]
 struct ArrayView {
     base: Arc<RwLock<SparseObservable>>,
     slot: ArraySlot,
 }
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl ArrayView {
     fn __repr__(&self, py: Python) -> PyResult<String> {
@@ -4425,6 +4465,7 @@ impl ArrayView {
 
 /// Use the Numpy Python API to convert a `PyArray` into a dynamically chosen `dtype`, copying only
 /// if required.
+#[cfg(feature = "python")]
 fn cast_array_type<'py, T: numpy::Element>(
     py: Python<'py>,
     array: Bound<'py, PyArray1<T>>,
@@ -4457,6 +4498,7 @@ fn cast_array_type<'py, T: numpy::Element>(
 ///
 /// The purpose of this is for conversion the arithmetic operations, which should return
 /// [PyNotImplemented] if the type is not valid for coercion.
+#[cfg(feature = "python")]
 fn coerce_to_observable<'py>(
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Option<Bound<'py, PySparseObservable>>> {
@@ -4475,6 +4517,8 @@ fn coerce_to_observable<'py>(
         }
     }
 }
+
+#[cfg(feature = "python")]
 pub fn sparse_observable(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PySparseObservable>()?;
     Ok(())


### PR DESCRIPTION
The qiskit-quantum-info crate already has a clean split between the pure Rust component and the Python interface pieces. This means that nothing is blocking us from making the usage pyo3 and python opt-in and conditionally compile the pieces that are there only to interface with Python. This change adds a new feature for the qiskit-quantum-info crate `"python"` that is used to control whether we use pyo3 or rust-numpy in the crate. This new feature is disabled by default and has to be opted into when using the crate. This serves as an incremental step for fixing issue #14240. While we will end up enabling the crate in the crates built on top of qiskit-quantum-info as they don't have a clean split yet, this is an incremental step towards a Python free build as we have to walk up the crate heirarchy to enable a pyo3 free build.

Mechanically this commit is primarily just adding conditional compilation around each part of the crate that depends on Python in some way, or code that exists only to service those python interfacing components. This is just a starting point, in future work when we're in a place where qiskit can be built fully without pyo3 and free of Python then we can look at isolating the python components to a standalone crate (in other words everything that has a conditional compilation now could potentially be moved to qiskit-pyext once we have a python free build path).

Part of #14240

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
