### PR TITLE
Fix layer collisions in circuit drawer for nested BoxOp instructions

### DIFF
--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -409,7 +409,6 @@ def _get_valid_justify_arg(justify):
 
     return justify
 
-
 def _get_layered_instructions(
     circuit,
     reverse_bits=False,
@@ -418,6 +417,7 @@ def _get_layered_instructions(
     wire_order=None,
     wire_map=None,
     measure_arrows=True,
+    qubit_mapping=None,
 ):
     """
     Given a circuit, return a tuple (qubits, clbits, nodes) where
@@ -436,6 +436,8 @@ def _get_layered_instructions(
         wire_order (list): A list of ints that modifies the order of the bits.
         wire_map (dict): The wire map
         measure_arrows (bool): whether do draw arrows from measurements
+        qubit_mapping (dict): Optional mapping from inner virtual qubits to 
+            outer physical qubits, used to prevent BoxOp layer collisions.
 
     Returns:
         Tuple(list,list,list): To be consumed by the visualizer directly.
@@ -480,10 +482,19 @@ def _get_layered_instructions(
         for node in dag.topological_op_nodes():
             nodes.append([node])
     else:
-        nodes = _LayerSpooler(dag, qubits, clbits, justify, measure_map, measure_arrows)
+        # Passing the qubit_mapping down to the spooler so it can calculate outer spans properly
+        nodes = _LayerSpooler(
+            dag, 
+            qubits, 
+            clbits, 
+            justify, 
+            measure_map, 
+            measure_arrows, 
+            qubit_mapping=qubit_mapping
+        )
 
     if not idle_wires:
-        # Optionally remove all idle wires and instructions that are on them and
+        # Optionally, remove all idle wires and instructions that are on them and
         # on them only.
         for wire in dag.idle_wires(ignore=["barrier", "delay"]):
             if wire in qubits:
@@ -494,7 +505,6 @@ def _get_layered_instructions(
     nodes = [[node for node in layer if any(q in qubits for q in node.qargs)] for layer in nodes]
 
     return qubits, clbits, nodes
-
 
 def _sorted_nodes(dag_layer):
     """Convert DAG layer into list of nodes sorted by node_id

--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -561,7 +561,7 @@ _GLOBAL_NID = 0
 class _LayerSpooler(list):
     """Manipulate list of layer dicts for _get_layered_instructions."""
 
-    def __init__(self, dag, qubits, clbits, justification, measure_map, measure_arrows):
+    def __init__(self, dag, qubits, clbits, justification, measure_map, measure_arrows, qubit_mapping=None):
         """Create spool"""
         super().__init__()
         self.dag = dag
@@ -570,7 +570,22 @@ class _LayerSpooler(list):
         self.justification = justification
         self.measure_map = measure_map
         self.measure_arrows = measure_arrows
+        self.qubit_mapping = qubit_mapping
         self.cregs = [self.dag.cregs[reg] for reg in self.dag.cregs]
+        
+        # Construct a mapped virtual qubit list for crossover checking
+        # This allows nested BoxOps to evaluate their span based on the outer circuit's physical layout.
+        if self.qubit_mapping:
+            max_idx = max((v for v in self.qubit_mapping.values() if isinstance(v, int)), default=len(self.qubits) - 1)
+            self.mapped_qubits = [None] * (max_idx + 1)
+            for q in self.qubits:
+                idx = self.qubit_mapping.get(q)
+                if isinstance(idx, int):
+                    if idx >= len(self.mapped_qubits):
+                        self.mapped_qubits.extend([None] * (idx - len(self.mapped_qubits) + 1))
+                    self.mapped_qubits[idx] = q
+        else:
+            self.mapped_qubits = self.qubits
 
         if self.justification == "left":
             for dag_layer in dag.layers():
@@ -602,7 +617,8 @@ class _LayerSpooler(list):
 
     def insertable(self, node, nodes):
         """True .IFF. we can add 'node' to layer 'nodes'"""
-        return not _any_crossover(self.qubits, node, nodes, self.measure_arrows)
+        # Use the physical mapped_qubits to correctly calculate spans for nested instructions
+        return not _any_crossover(self.mapped_qubits, node, nodes, self.measure_arrows)
 
     def slide_from_left(self, node, index):
         """Insert node into first layer where there is no conflict going l > r"""

--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -409,6 +409,7 @@ def _get_valid_justify_arg(justify):
 
     return justify
 
+
 def _get_layered_instructions(
     circuit,
     reverse_bits=False,
@@ -436,7 +437,7 @@ def _get_layered_instructions(
         wire_order (list): A list of ints that modifies the order of the bits.
         wire_map (dict): The wire map
         measure_arrows (bool): whether do draw arrows from measurements
-        qubit_mapping (dict): Optional mapping from inner virtual qubits to 
+        qubit_mapping (dict): Optional mapping from inner virtual qubits to
             outer physical qubits, used to prevent BoxOp layer collisions.
 
     Returns:
@@ -484,13 +485,7 @@ def _get_layered_instructions(
     else:
         # Passing the qubit_mapping down to the spooler so it can calculate outer spans properly
         nodes = _LayerSpooler(
-            dag, 
-            qubits, 
-            clbits, 
-            justify, 
-            measure_map, 
-            measure_arrows, 
-            qubit_mapping=qubit_mapping
+            dag, qubits, clbits, justify, measure_map, measure_arrows, qubit_mapping=qubit_mapping
         )
 
     if not idle_wires:
@@ -505,6 +500,7 @@ def _get_layered_instructions(
     nodes = [[node for node in layer if any(q in qubits for q in node.qargs)] for layer in nodes]
 
     return qubits, clbits, nodes
+
 
 def _sorted_nodes(dag_layer):
     """Convert DAG layer into list of nodes sorted by node_id
@@ -561,7 +557,9 @@ _GLOBAL_NID = 0
 class _LayerSpooler(list):
     """Manipulate list of layer dicts for _get_layered_instructions."""
 
-    def __init__(self, dag, qubits, clbits, justification, measure_map, measure_arrows, qubit_mapping=None):
+    def __init__(
+        self, dag, qubits, clbits, justification, measure_map, measure_arrows, qubit_mapping=None
+    ):
         """Create spool"""
         super().__init__()
         self.dag = dag
@@ -572,11 +570,14 @@ class _LayerSpooler(list):
         self.measure_arrows = measure_arrows
         self.qubit_mapping = qubit_mapping
         self.cregs = [self.dag.cregs[reg] for reg in self.dag.cregs]
-        
+
         # Construct a mapped virtual qubit list for crossover checking
         # This allows nested BoxOps to evaluate their span based on the outer circuit's physical layout.
         if self.qubit_mapping:
-            max_idx = max((v for v in self.qubit_mapping.values() if isinstance(v, int)), default=len(self.qubits) - 1)
+            max_idx = max(
+                (v for v in self.qubit_mapping.values() if isinstance(v, int)),
+                default=len(self.qubits) - 1,
+            )
             self.mapped_qubits = [None] * (max_idx + 1)
             for q in self.qubits:
                 idx = self.qubit_mapping.get(q)

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1308,7 +1308,6 @@ class TextDrawing:
             layers.append(layer.full_layer)
 
         return layers
-    
 
     def add_control_flow(self, node, layers, wire_map):
         """Add control flow ops to the circuit drawing."""
@@ -1385,13 +1384,13 @@ class TextDrawing:
                 layers.append(flow_layer.full_layer)
 
             # Build the mapping tracking the internal virtual qubits to their outer index positions
-            qubit_mapping = {inner: wire_map[outer] for outer, inner in zip(node.qargs, circuit.qubits)}
+            qubit_mapping = {
+                inner: wire_map[outer] for outer, inner in zip(node.qargs, circuit.qubits)
+            }
 
             # Pass the layout map into the layered instructions resolver
             _, _, nodes = _get_layered_instructions(
-                circuit, 
-                wire_map=flow_wire_map, 
-                qubit_mapping=qubit_mapping
+                circuit, wire_map=flow_wire_map, qubit_mapping=qubit_mapping
             )
             for layer_nodes in nodes:
                 # Limit qubits sent to only ones from main circuit, so qubit_layer is correct length

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1308,10 +1308,10 @@ class TextDrawing:
             layers.append(layer.full_layer)
 
         return layers
+    
 
     def add_control_flow(self, node, layers, wire_map):
         """Add control flow ops to the circuit drawing."""
-
         if (isinstance(node.op, SwitchCaseOp) and isinstance(node.op.target, expr.Expr)) or (
             getattr(node.op, "condition", None) and isinstance(node.op.condition, expr.Expr)
         ):
@@ -1384,7 +1384,15 @@ class TextDrawing:
                 )
                 layers.append(flow_layer.full_layer)
 
-            _, _, nodes = _get_layered_instructions(circuit, wire_map=flow_wire_map)
+            # Build the mapping tracking the internal virtual qubits to their outer index positions
+            qubit_mapping = {inner: wire_map[outer] for outer, inner in zip(node.qargs, circuit.qubits)}
+
+            # Pass the layout map into the layered instructions resolver
+            _, _, nodes = _get_layered_instructions(
+                circuit, 
+                wire_map=flow_wire_map, 
+                qubit_mapping=qubit_mapping
+            )
             for layer_nodes in nodes:
                 # Limit qubits sent to only ones from main circuit, so qubit_layer is correct length
                 flow_layer2 = Layer(


### PR DESCRIPTION
## Description

Hello Team Qiskit! This PR addresses the visual collision bug in the circuit drawer where nested instructions inside block operations (like `BoxOp`) would incorrectly overlap into a single layer. 

**What was happening:**
When the text drawer (and by extension, the MPL drawer) processed the body of a `BoxOp` via `_get_layered_instructions`, it calculated the instruction's span based entirely on the *inner* virtual qubits (e.g., 0, 1, 2). It didn't account for how those qubits were permuted or mapped to the parent circuit's physical wires, causing overlapping gates to mistakenly share the same visual layer.

**How it was fixed:**
I updated the layout resolution logic to make it context-aware:
* Added an optional `qubit_mapping` parameter to `_get_layered_instructions`.
* Passed this mapping down into `_LayerSpooler`, allowing the `insertable` and `_any_crossover` checks to evaluate the true physical span of nested operations based on the outer circuit.
* Updated `add_control_flow` in `text.py` to generate and pass this dictionary mapping when it recursively calls `_get_layered_instructions`.

Fixes #16510

## Use of AI Tools
* **Tool:** Gemini (Version: 3.1 Pro Extended)
* **Usage:** I used Gemini as a conversational tutor to help analyze the repository architecture (specifically locating the nested layout logic inside `_utils.py` and `text.py`) and to troubleshoot local Rust environment compilation issues on Windows. All code changes submitted in this PR are my own original work. I have fully reviewed, tested, and understood the resulting fix, and it complies with the Qiskit license and CLA obligations.

## Pull Request Author Checklist
- [x] The code follows the code style of the project and successfully passes the CI tests (`tox -elint` / `black` / `ruff`).
- [x] The docstrings have been updated to reflect the new `qubit_mapping` parameter.
- [x] I have signed the CLA.
- [x] The PR has a concise and explanatory title.
- [x] This PR addresses an open issue and uses the `Fixes #16510` syntax to link it.