### PR TITLE
Fix Windows stestr invocation

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -71,11 +71,11 @@ jobs:
           python tools/report_numpy_state.py
           $Env:PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run --slowest --abbreviate
+          python -m stestr run --slowest --abbreviate
       - name: Filter stestr history
         run: |
           .\test-job\Scripts\activate
-          stestr history remove all
+          python -m stestr history remove all
         env:
           LANG: "C.UTF-8"
           PYTHONIOENCODING: "utf-8:backslashreplace"


### PR DESCRIPTION
Windows Python 3.10 jobs install stestr successfully but then fail before test discovery because the bare stestr console-script command is not found.

Invoke stestr through the active virtual environment interpreter for the test run and history cleanup. This preserves the existing stestr subcommands and arguments while avoiding reliance on PATH propagation from activation.

Validated on Windows with stestr 4.2.1 using python -m stestr run --help and python -m stestr history remove --help.

Observed failing jobs: https://github.com/Qiskit/qiskit/actions/runs/29154862979/job/86550235938 and https://github.com/Qiskit/qiskit/actions/runs/29154377072/job/86548991719
