### PR TITLE
Use target error rates when selecting Euler basis in Optimize1qGatesDecomposition

### DIFF
--- a/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
+++ b/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::cmp::Ordering;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
@@ -33,11 +34,34 @@ use qiskit_circuit::instruction::Instruction;
 use qiskit_circuit::{PhysicalQubit, gate_matrix};
 use qiskit_synthesis::euler_one_qubit_decomposer::{
     EULER_BASES, EULER_BASIS_NAMES, EulerBasis, EulerBasisSet, OneQubitGateSequence,
-    unitary_to_gate_sequence_inner,
+    angles_from_unitary, generate_circuit,
 };
 
 fn compute_error_term_from_target(gate: &str, target: &Target, qubit: PhysicalQubit) -> f64 {
     1. - target.get_error(gate, &[qubit]).unwrap_or(0.)
+}
+
+/// Resynthesize a 1q unitary in each Euler basis of the set and return the candidate with the
+/// lowest error for the target (falling back to the lowest gate count when there is no target).
+/// Unlike selecting on gate count alone, this accounts for otherwise-tied candidates having
+/// very different error rates on the target.
+fn resynthesize_run_min_error(
+    operator: ArrayView2<Complex64>,
+    target_basis_set: &EulerBasisSet,
+    qubit: PhysicalQubit,
+    target: Option<&Target>,
+) -> Option<OneQubitGateSequence> {
+    target_basis_set
+        .get_bases()
+        .map(|target_basis| {
+            let [theta, phi, lam, phase] = angles_from_unitary(operator, target_basis);
+            generate_circuit(&target_basis, theta, phi, lam, phase, true, None).unwrap()
+        })
+        .min_by(|a, b| {
+            let error_a = compute_error_from_target_one_qubit_sequence(a, qubit, target);
+            let error_b = compute_error_from_target_one_qubit_sequence(b, qubit, target);
+            error_a.partial_cmp(&error_b).unwrap_or(Ordering::Equal)
+        })
 }
 
 fn compute_error_from_target_one_qubit_sequence(
@@ -417,14 +441,8 @@ pub fn run_optimize_1q_gates_decomposition(
             } else {
                 (error, raw_run.len())
             };
-            let sequence = unitary_to_gate_sequence_inner(
-                aview2(&operator),
-                target_basis_set,
-                qubit.index(),
-                None,
-                true,
-                None,
-            );
+            let sequence =
+                resynthesize_run_min_error(aview2(&operator), target_basis_set, qubit, target);
             let Some(sequence) = sequence else {
                 return Ok(None);
             };

--- a/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
+++ b/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
@@ -42,26 +42,25 @@ fn compute_error_term_from_target(gate: &str, target: &Target, qubit: PhysicalQu
 }
 
 /// Resynthesize a 1q unitary in each Euler basis of the set and return the candidate with the
-/// lowest error for the target (falling back to the lowest gate count when there is no target).
-/// Unlike selecting on gate count alone, this accounts for otherwise-tied candidates having
-/// very different error rates on the target.
+/// lowest error for the target (falling back to the lowest gate count when there is no target),
+/// together with its computed error.  Unlike selecting on gate count alone, this accounts for
+/// otherwise-tied candidates having very different error rates on the target.
 fn resynthesize_run_min_error(
     operator: ArrayView2<Complex64>,
     target_basis_set: &EulerBasisSet,
     qubit: PhysicalQubit,
     target: Option<&Target>,
-) -> Option<OneQubitGateSequence> {
+) -> Option<(OneQubitGateSequence, (f64, usize))> {
     target_basis_set
         .get_bases()
         .map(|target_basis| {
             let [theta, phi, lam, phase] = angles_from_unitary(operator, target_basis);
-            generate_circuit(&target_basis, theta, phi, lam, phase, true, None).unwrap()
+            let sequence =
+                generate_circuit(&target_basis, theta, phi, lam, phase, true, None).unwrap();
+            let error = compute_error_from_target_one_qubit_sequence(&sequence, qubit, target);
+            (sequence, error)
         })
-        .min_by(|a, b| {
-            let error_a = compute_error_from_target_one_qubit_sequence(a, qubit, target);
-            let error_b = compute_error_from_target_one_qubit_sequence(b, qubit, target);
-            error_a.partial_cmp(&error_b).unwrap_or(Ordering::Equal)
-        })
+        .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal))
 }
 
 fn compute_error_from_target_one_qubit_sequence(
@@ -441,12 +440,11 @@ pub fn run_optimize_1q_gates_decomposition(
             } else {
                 (error, raw_run.len())
             };
-            let sequence =
-                resynthesize_run_min_error(aview2(&operator), target_basis_set, qubit, target);
-            let Some(sequence) = sequence else {
+            let Some((sequence, new_error)) =
+                resynthesize_run_min_error(aview2(&operator), target_basis_set, qubit, target)
+            else {
                 return Ok(None);
             };
-            let new_error = compute_error_from_target_one_qubit_sequence(&sequence, qubit, target);
 
             let mut outside_basis = false;
             if let BasisGatesPerQubit::Gates(basis) = basis_gates {

--- a/releasenotes/notes/fix-1q-decomposition-target-errors-2ee08a438c55e081.yaml
+++ b/releasenotes/notes/fix-1q-decomposition-target-errors-2ee08a438c55e081.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.Optimize1qGatesDecomposition` where the choice
+    among the possible Euler bases for a resynthesized run ignored the error
+    rates of the ``target`` and was made on gate count alone, with ties broken
+    by an internal fixed ordering.  The pass now selects the candidate
+    decomposition with the lowest total error according to the ``target``, as
+    it did before the pass was ported to Rust.  When no ``target`` is given
+    (or it has no error rates), the selection still minimizes the gate count.
+    Fixed `#16460 <https://github.com/Qiskit/qiskit/issues/16460>`__.

--- a/test/c/test_optimize_1q_sequences.c
+++ b/test/c/test_optimize_1q_sequences.c
@@ -164,12 +164,15 @@ static int run_optimize_h_gates(optimize_h_gates_fn optimize_fn) {
         get_u1_u2_u3_target(), get_rz_rx_target(),           get_rz_sx_target(),
         get_rz_ry_u_target(),  get_rz_ry_u_noerror_target(),
     };
+    // For the rz_ry_u target, RY(pi/2)-RZ(pi) has a lower total error than the single U gate
+    // (~3e-4 vs 5e-4), so the error-aware basis selection picks it; without error rates
+    // (rz_ry_u_noerror) the single U gate still wins on gate count.
     char *gates[5][2] = {{
                              "u2",
                          },
                          {"rz", "rx"},
                          {"rz", "sx"},
-                         {"u"},
+                         {"ry", "rz"},
                          {"u"}};
 
     uint32_t freq[5][2] = {
@@ -178,11 +181,11 @@ static int run_optimize_h_gates(optimize_h_gates_fn optimize_fn) {
         },
         {2, 1},
         {2, 1},
-        {1},
+        {1, 1},
         {1},
     };
 
-    size_t num_gates[5] = {1, 2, 2, 1, 1};
+    size_t num_gates[5] = {1, 2, 2, 2, 1};
     char *names[5] = {"u1_u2_u3", "rz_rx", "rz_sx", "rz_ry_u", "rz_ry_u_noerror"};
     printf("Optimize h gates tests.\n");
     for (int idx = 0; idx < 5; idx++) {

--- a/test/python/transpiler/test_optimize_1q_decomposition.py
+++ b/test/python/transpiler/test_optimize_1q_decomposition.py
@@ -155,6 +155,46 @@ class TestOptimize1qGatesDecomposition(QiskitTestCase):
         result = passmanager.run(circuit)
         self.assertEqual(QuantumCircuit(1), result)
 
+    def test_optimize_error_over_target_basis_choice(self):
+        """Euler basis selection must use target error rates, not just gate count.
+
+        Regression test of gh-16460: with rz and rx both available, the pass
+        must pick the basis with the lowest total error for the target at
+        hand, so flipping which gate is expensive must flip the chosen basis.
+        """
+
+        def make_target(rx_error, rz_error):
+            target = Target(num_qubits=1)
+            target.add_instruction(RXGate(theta), {(0,): InstructionProperties(error=rx_error)})
+            target.add_instruction(RZGate(theta), {(0,): InstructionProperties(error=rz_error)})
+            return target
+
+        def total_error(circuit, target):
+            fidelity = 1.0
+            for instruction in circuit.data:
+                fidelity *= 1.0 - target[instruction.operation.name][(0,)].error
+            return 1.0 - fidelity
+
+        circuit = QuantumCircuit(1)
+        circuit.rz(0.2, 0)
+        circuit.rx(0.3, 0)
+        circuit.rz(0.4, 0)
+        circuit.rx(0.5, 0)
+        circuit.rz(0.6, 0)
+
+        for rx_error, rz_error in [(1e-2, 1e-6), (1e-6, 1e-2)]:
+            with self.subTest(rx_error=rx_error, rz_error=rz_error):
+                target = make_target(rx_error, rz_error)
+                result = PassManager([Optimize1qGatesDecomposition(target=target)]).run(circuit)
+                self.assertEqual(Operator(circuit), Operator(result))
+                # the alternative Euler basis (rx<->rz swapped roles) must not
+                # have been cheaper than what the pass selected
+                swapped = QuantumCircuit(1)
+                for instruction in result.data:
+                    other = "rx" if instruction.operation.name == "rz" else "rz"
+                    getattr(swapped, other)(*instruction.operation.params, 0)
+                self.assertLessEqual(total_error(result, target), total_error(swapped, target))
+
     def test_optimize_error_over_target_3(self):
         """U is shorter than RZ-RY-RZ or RY-RZ-RY so use it when no error given."""
         qr = QuantumRegister(1, "qr")

--- a/test/python/transpiler/test_optimize_1q_decomposition.py
+++ b/test/python/transpiler/test_optimize_1q_decomposition.py
@@ -195,6 +195,30 @@ class TestOptimize1qGatesDecomposition(QiskitTestCase):
                     getattr(swapped, other)(*instruction.operation.params, 0)
                 self.assertLessEqual(total_error(result, target), total_error(swapped, target))
 
+    def test_optimize_basis_choice_no_error_uses_gate_count(self):
+        """Without target error rates, basis selection falls back to gate count.
+
+        Companion to test_optimize_error_over_target_basis_choice for the rz/rx
+        family: when the target carries no error rates the pass must still return
+        a correct, minimal-length decomposition rather than erroring.
+        """
+        target = Target(num_qubits=1)
+        target.add_instruction(RXGate(theta), {(0,): None})
+        target.add_instruction(RZGate(theta), {(0,): None})
+
+        circuit = QuantumCircuit(1)
+        circuit.rz(0.2, 0)
+        circuit.rx(0.3, 0)
+        circuit.rz(0.4, 0)
+        circuit.rx(0.5, 0)
+        circuit.rz(0.6, 0)
+
+        result = PassManager([Optimize1qGatesDecomposition(target=target)]).run(circuit)
+        self.assertEqual(Operator(circuit), Operator(result))
+        # a generic 1q run is three gates in either rz/rx Euler basis; the pass must
+        # not return something longer than the original run when it resynthesizes
+        self.assertLessEqual(sum(result.count_ops().values()), len(circuit.data))
+
     def test_optimize_error_over_target_3(self):
         """U is shorter than RZ-RY-RZ or RY-RZ-RY so use it when no error given."""
         qr = QuantumRegister(1, "qr")


### PR DESCRIPTION
### Summary

Fixes #16460.

`Optimize1qGatesDecomposition` chose among the candidate Euler-basis decompositions of a 1q run by gate count alone, with ties broken by the fixed internal ordering of the bases, ignoring the error rates of the `target`. With e.g. `rz` expensive and `rx` cheap, the ZXZ and XZX candidates are usually tied at three gates, so the pass always returned the ZXZ sequence even when XZX had substantially lower total error.

### Details and comments

Error-aware basis selection was originally introduced in #8917: the Python pass built a `OneQubitGateErrorMap` from the target and passed it to `unitary_to_gate_sequence`, whose `min_by` then compared candidates by `(error, gate_count)`. When the pass was fully ported to Rust in #12959, the call to `unitary_to_gate_sequence_inner` hardcoded `error_map=None`, which silently degraded the comparison to `(gate_count, gate_count)`. (The regression tests covering this, `test_optimize_error_over_target_{1,2}`, had been removed earlier in #9578.)

This PR restores the old behavior without reconstructing the error-map indirection: a small helper in the pass generates the candidate sequence for each Euler basis (exactly as `unitary_to_gate_sequence_inner` does) and picks the minimum using the same target-aware `(error, gate_count)` metric the pass already uses for its replace/keep decision. When no `target` is given, the comparison degenerates to the previous gate-count behavior, so nothing changes for the `basis_gates` code path.

The re-added regression test checks both cost orderings (`rx` cheap / `rz` cheap) and asserts the selected decomposition is never more expensive than its role-swapped counterpart, plus unitary equivalence.

Note: `unitary_synthesis/mod.rs` has the same latent pattern (`unitary_to_gate_sequence_inner(..., None, ...)` with a target available in scope); I've left it untouched to keep this change focused, but can follow up if desired.

---

*Per the contributing guidelines' AI disclosure requirement: this PR was developed with the assistance of Claude Code (model Opus 4.8). I have reviewed the changes and can explain and defend them in review.*
