### PR TITLE
Return ExitCode from C API sparse observable arithmetic functions and handle mismatched qubits

### DIFF
--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -535,14 +535,14 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
 ///
 /// @param obs A pointer to the observable.
 /// @param coeff The coefficient to multiply the observable with.
+/// @param out A pointer to store the output observable pointer.
 ///
-/// @return A pointer to the result ``obs * coeff``.
+/// @return An exit code indicating success or failure.
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     QkComplex64 coeff = {2, 0};
-///     QkObs *result = qk_obs_multiply(obs, &coeff);
+///     QkObs *result = NULL;
+///     QkExitCode exit = qk_obs_multiply(obs, &coeff, &result);
 /// ```
 ///
 /// # Safety
@@ -550,17 +550,20 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
 /// Behavior is undefined if any of the following is violated
 /// * ``obs`` is a valid, non-null pointer to a ``QkObs``
 /// * ``coeff`` is a valid, non-null pointer to a ``QkComplex64``
+/// * ``out`` is a valid, non-null pointer to a ``QkObs*``
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_obs_multiply(
     obs: *const SparseObservable,
     coeff: *const Complex64,
-) -> *mut SparseObservable {
+    out: *mut *mut SparseObservable,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
     let coeff = unsafe { const_ptr_as_ref(coeff) };
 
     let result = obs * (*coeff);
-    Box::into_raw(Box::new(result))
+    unsafe { *out = Box::into_raw(Box::new(result)) };
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -569,11 +572,11 @@ pub unsafe extern "C" fn qk_obs_multiply(
 /// @param obs A pointer to the observable.
 /// @param coeff The coefficient to multiply the observable with.
 ///
+/// @return An exit code indicating success or failure.
+///
 /// # Example
 /// ```c
-/// QkObs *obs = qk_obs_identity(100);
-/// QkComplex64 coeff = {2, 0};
-/// qk_obs_multiply_inplace(obs, &coeff);
+/// QkExitCode exit = qk_obs_multiply_inplace(obs, &coeff);
 /// ```
 ///
 /// # Safety
@@ -585,12 +588,13 @@ pub unsafe extern "C" fn qk_obs_multiply(
 pub unsafe extern "C" fn qk_obs_multiply_inplace(
     obs: *mut SparseObservable,
     coeff: *const Complex64,
-) {
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let obs = unsafe { mut_ptr_as_ref(obs) };
     let coeff = unsafe { const_ptr_as_ref(coeff) };
 
     *obs *= *coeff;
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -598,31 +602,37 @@ pub unsafe extern "C" fn qk_obs_multiply_inplace(
 ///
 /// @param left A pointer to the left observable.
 /// @param right A pointer to the right observable.
+/// @param out A pointer to store the output observable pointer.
 ///
-/// @return A pointer to the result ``left + right``.
+/// @return An exit code indicating success or failure.
 ///
 /// # Example
 /// ```c
-///     QkObs *left = qk_obs_identity(100);
-///     QkObs *right = qk_obs_zero(100);
-///     QkObs *result = qk_obs_add(left, right);
+///     QkObs *result = NULL;
+///     QkExitCode exit = qk_obs_add(left, right, &result);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``left`` or ``right`` are not valid, non-null pointers to
-/// ``QkObs``\ s.
+/// ``QkObs``\ s, or if ``out`` is not a valid, non-null pointer to a ``QkObs*``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_obs_add(
     left: *const SparseObservable,
     right: *const SparseObservable,
-) -> *mut SparseObservable {
+    out: *mut *mut SparseObservable,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let left = unsafe { const_ptr_as_ref(left) };
     let right = unsafe { const_ptr_as_ref(right) };
 
+    if left.num_qubits() != right.num_qubits() {
+        return ExitCode::MismatchedQubits;
+    }
+
     let result = left + right;
-    Box::into_raw(Box::new(result))
+    unsafe { *out = Box::into_raw(Box::new(result)) };
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -631,11 +641,13 @@ pub unsafe extern "C" fn qk_obs_add(
 /// @param left A pointer to the left observable.
 /// @param right A pointer to the right observable.
 ///
+/// @return An exit code indicating success or failure.
+///
 /// # Example
 /// ```c
 /// QkObs *left = qk_obs_identity(100);
 /// QkObs *right = qk_obs_zero(100);
-/// qk_obs_add_inplace(left, right);
+/// QkExitCode exit = qk_obs_add_inplace(left, right);
 /// ```
 ///
 /// # Safety
@@ -646,12 +658,17 @@ pub unsafe extern "C" fn qk_obs_add(
 pub unsafe extern "C" fn qk_obs_add_inplace(
     left: *mut SparseObservable,
     right: *const SparseObservable,
-) {
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let left = unsafe { mut_ptr_as_ref(left) };
     let right = unsafe { const_ptr_as_ref(right) };
 
+    if left.num_qubits() != right.num_qubits() {
+        return ExitCode::MismatchedQubits;
+    }
+
     *left += right;
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -660,34 +677,40 @@ pub unsafe extern "C" fn qk_obs_add_inplace(
 /// @param left A pointer to the left observable.
 /// @param right A pointer to the right observable.
 /// @param factor The factor to multiply the coefficients with.
+/// @param out A pointer to store the output observable pointer.
 ///
-/// @return An owned pointer to the result ``left + factor * right``.
+/// @return An exit code indicating success or failure.
 ///
 /// # Example
 /// ```c
-/// QkObs *left = qk_obs_zero(100);
-/// QkObs *right = qk_obs_identity(100);
+/// QkObs *result = NULL;
 /// QkComplex64 factor = {2, 0};
-/// QkObs *result = qk_obs_scaled_add(left, right, &factor);
+/// QkExitCode exit = qk_obs_scaled_add(left, right, &factor, &result);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``left`` or ``right`` are not valid, non-null pointers to
-/// ``QkObs``\ s.
+/// ``QkObs``\ s, or if ``out`` is not a valid, non-null pointer to a ``QkObs*``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_obs_scaled_add(
     left: *const SparseObservable,
     right: *const SparseObservable,
     factor: *const Complex64,
-) -> *mut SparseObservable {
+    out: *mut *mut SparseObservable,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let left = unsafe { const_ptr_as_ref(left) };
     let right = unsafe { const_ptr_as_ref(right) };
     let factor = unsafe { const_ptr_as_ref(factor) };
 
+    if left.num_qubits() != right.num_qubits() {
+        return ExitCode::MismatchedQubits;
+    }
+
     let result = left.scaled_add(right, *factor);
-    Box::into_raw(Box::new(result))
+    unsafe { *out = Box::into_raw(Box::new(result)) };
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -697,12 +720,12 @@ pub unsafe extern "C" fn qk_obs_scaled_add(
 /// @param right A pointer to the right observable.
 /// @param factor The factor to multiply the coefficients with.
 ///
+/// @return An exit code indicating success or failure.
+///
 /// # Example
 /// ```c
-/// QkObs *left = qk_obs_zero(100);
-/// QkObs *right = qk_obs_identity(100);
 /// QkComplex64 factor = {2, 0};
-/// qk_obs_scaled_add_inplace(left, right, &factor);
+/// QkExitCode exit = qk_obs_scaled_add_inplace(left, right, &factor);
 /// ```
 ///
 /// # Safety
@@ -714,13 +737,18 @@ pub unsafe extern "C" fn qk_obs_scaled_add_inplace(
     left: *mut SparseObservable,
     right: *const SparseObservable,
     factor: *const Complex64,
-) {
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let left = unsafe { mut_ptr_as_ref(left) };
     let right = unsafe { const_ptr_as_ref(right) };
     let factor = unsafe { const_ptr_as_ref(factor) };
 
+    if left.num_qubits() != right.num_qubits() {
+        return ExitCode::MismatchedQubits;
+    }
+
     left.scaled_add_inplace(right, *factor);
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -736,24 +764,31 @@ pub unsafe extern "C" fn qk_obs_scaled_add_inplace(
 /// ```c
 ///     QkObs *first = qk_obs_zero(100);
 ///     QkObs *second = qk_obs_identity(100);
-///     QkObs *result = qk_obs_compose(first, second);
+///     QkObs *result = NULL;
+///     QkExitCode exit = qk_obs_compose(first, second, &result);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``first`` or ``second`` are not valid, non-null pointers to
-/// ``QkObs``\ s.
+/// ``QkObs``\ s, or if ``out`` is not a valid, non-null pointer to a ``QkObs*``.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_obs_compose(
     first: *const SparseObservable,
     second: *const SparseObservable,
-) -> *mut SparseObservable {
+    out: *mut *mut SparseObservable,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let first = unsafe { const_ptr_as_ref(first) };
     let second = unsafe { const_ptr_as_ref(second) };
 
+    if first.num_qubits() != second.num_qubits() {
+        return ExitCode::MismatchedQubits;
+    }
+
     let result = first.compose(second);
-    Box::into_raw(Box::new(result))
+    unsafe { *out = Box::into_raw(Box::new(result)) };
+    ExitCode::Success
 }
 
 /// @ingroup QkObs
@@ -773,7 +808,8 @@ pub unsafe extern "C" fn qk_obs_compose(
 /// ```c
 ///     QkObs *first = qk_obs_zero(100);
 ///     QkObs *second = qk_obs_identity(100);
-///     QkObs *result = qk_obs_compose(first, second);
+///     uint32_t qargs[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+///     QkExitCode exit = qk_obs_compose_map(first, second, qargs, &result);
 /// ```
 ///
 /// # Safety
@@ -781,6 +817,7 @@ pub unsafe extern "C" fn qk_obs_compose(
 /// To call this function safely
 ///
 ///   * ``first`` and ``second`` must be valid, non-null pointers to ``QkObs``\ s
+///   * ``out`` must be a valid, non-null pointer to a ``QkObs*``
 ///   * ``qargs`` must point to an array of ``uint32_t``, readable for ``qk_obs_num_qubits(second)``
 ///     elements (meaning the number of qubits in ``second``)
 #[unsafe(no_mangle)]
@@ -788,7 +825,8 @@ pub unsafe extern "C" fn qk_obs_compose_map(
     first: *const SparseObservable,
     second: *const SparseObservable,
     qargs: *const u32,
-) -> *mut SparseObservable {
+    out: *mut *mut SparseObservable,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let first = unsafe { const_ptr_as_ref(first) };
     let second = unsafe { const_ptr_as_ref(second) };
@@ -798,7 +836,8 @@ pub unsafe extern "C" fn qk_obs_compose_map(
     let qargs_map = |index: u32| qargs[index as usize];
 
     let result = first.compose_map(second, qargs_map);
-    Box::into_raw(Box::new(result))
+    unsafe { *out = Box::into_raw(Box::new(result)) };
+    ExitCode::Success
 }
 
 /// @ingroup QkObs

--- a/releasenotes/notes/fix-c-api-sparse-observable-arithmetic-errors-15608.yaml
+++ b/releasenotes/notes/fix-c-api-sparse-observable-arithmetic-errors-15608.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    The ``sparse_observable`` C API functions (``qk_obs_add``, ``qk_obs_scaled_add``,
+    ``qk_obs_multiply``, ``qk_obs_compose``, ``qk_obs_compose_map``) now
+    return :c:type:`QkExitCode` instead of raw pointers, and accept an ``out``
+    parameter to store the result. In-place functions (``qk_obs_add_inplace``,
+    ``qk_obs_scaled_add_inplace``, ``qk_obs_multiply_inplace``) now also return
+    :c:type:`QkExitCode` instead of ``void``. All arithmetic functions properly
+    handle qubit count mismatches, returning
+    :c:macro:`QkExitCode_MismatchedQubits` instead of panicking.
+    Fixed `#15608 <https://github.com/Qiskit/qiskit/issues/15608>`__.

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -63,7 +63,8 @@ static int test_copy(void) {
 static int test_add(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
-    QkObs *obs = qk_obs_add(left, right);
+    QkObs *obs = NULL;
+    QkExitCode exit = qk_obs_add(left, right, &obs);
 
     size_t num_terms = qk_obs_num_terms(obs);
 
@@ -71,7 +72,7 @@ static int test_add(void) {
     qk_obs_free(right);
     qk_obs_free(obs);
 
-    return (num_terms != 2) ? EqualityError : Ok;
+    return (exit != QkExitCode_Success || num_terms != 2) ? EqualityError : Ok;
 }
 
 /**
@@ -80,14 +81,14 @@ static int test_add(void) {
 static int test_add_inplace(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
-    qk_obs_add_inplace(left, right);
+    QkExitCode exit = qk_obs_add_inplace(left, right);
 
     size_t num_terms = qk_obs_num_terms(left);
 
     qk_obs_free(left);
     qk_obs_free(right);
 
-    return (num_terms != 2) ? EqualityError : Ok;
+    return (exit != QkExitCode_Success || num_terms != 2) ? EqualityError : Ok;
 }
 
 /**
@@ -97,7 +98,8 @@ static int test_scaled_add(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
     QkComplex64 factor = {2.0, 2.0};
-    QkObs *result = qk_obs_scaled_add(left, right, &factor);
+    QkObs *result = NULL;
+    QkExitCode exit = qk_obs_scaled_add(left, right, &factor, &result);
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
@@ -114,7 +116,7 @@ static int test_scaled_add(void) {
     qk_obs_free(result);
     qk_obs_free(expected);
 
-    return is_equal ? Ok : EqualityError;
+    return (exit != QkExitCode_Success || !is_equal) ? EqualityError : Ok;
 }
 
 /**
@@ -124,7 +126,7 @@ static int test_scaled_add_inplace(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
     QkComplex64 factor = {2.0, 2.0};
-    qk_obs_scaled_add_inplace(left, right, &factor);
+    QkExitCode exit = qk_obs_scaled_add_inplace(left, right, &factor);
 
     // construct the expected observable: coeff * Id
     QkObs *expected = qk_obs_identity(100);
@@ -140,7 +142,7 @@ static int test_scaled_add_inplace(void) {
     qk_obs_free(right);
     qk_obs_free(expected);
 
-    return is_equal ? Ok : EqualityError;
+    return (exit != QkExitCode_Success || !is_equal) ? EqualityError : Ok;
 }
 
 /**
@@ -163,7 +165,8 @@ static int test_compose(void) {
     QkObsTerm term2 = {coeff2, 3, op2_bits, op2_indices, num_qubits};
     qk_obs_add_term(op2, &term2);
 
-    QkObs *result = qk_obs_compose(op1, op2);
+    QkObs *result = NULL;
+    QkExitCode exit = qk_obs_compose(op1, op2, &result);
 
     QkObs *expected = qk_obs_zero(num_qubits);
     QkComplex64 expected_coeff = {0.0, 2.0};
@@ -179,7 +182,7 @@ static int test_compose(void) {
     qk_obs_free(result);
     qk_obs_free(expected);
 
-    if (!is_equal) {
+    if (exit != QkExitCode_Success || !is_equal) {
         return EqualityError;
     }
     return Ok;
@@ -207,7 +210,8 @@ static int test_compose_map(void) {
 
     uint32_t qargs[2] = {98, 97}; // compose op2 onto these indices in op1
 
-    QkObs *result = qk_obs_compose_map(op1, op2, qargs);
+    QkObs *result = NULL;
+    QkExitCode exit = qk_obs_compose_map(op1, op2, qargs, &result);
 
     QkObs *expected = qk_obs_zero(num_qubits);
     QkBitTerm expected_bits[2] = {QkBitTerm_Right, QkBitTerm_Z};
@@ -222,7 +226,7 @@ static int test_compose_map(void) {
     qk_obs_free(result);
     qk_obs_free(expected);
 
-    if (!is_equal) {
+    if (exit != QkExitCode_Success || !is_equal) {
         return EqualityError;
     }
     return Ok;
@@ -243,12 +247,15 @@ static int test_compose_scalar(void) {
 
     QkObs *scalar = qk_obs_identity(0);
     QkComplex64 factor = {2.0, 0.0};
-    QkObs *mult = qk_obs_multiply(scalar, &factor);
+    QkObs *mult = NULL;
+    QkExitCode mult_exit = qk_obs_multiply(scalar, &factor, &mult);
     uint32_t *qargs = NULL; // no value will be read (also MSVC doesn't allow qargs[0], so use this)
 
-    QkObs *result = qk_obs_compose_map(op, mult, qargs);
+    QkObs *result = NULL;
+    QkExitCode cmp_exit = qk_obs_compose_map(op, mult, qargs, &result);
 
-    QkObs *expected = qk_obs_multiply(op, &factor);
+    QkObs *expected = NULL;
+    QkExitCode expected_exit = qk_obs_multiply(op, &factor, &expected);
 
     bool is_equal = qk_obs_equal(expected, result);
 
@@ -258,7 +265,8 @@ static int test_compose_scalar(void) {
     qk_obs_free(result);
     qk_obs_free(expected);
 
-    if (!is_equal) {
+    if (mult_exit != QkExitCode_Success || cmp_exit != QkExitCode_Success
+        || expected_exit != QkExitCode_Success || !is_equal) {
         return EqualityError;
     }
     return Ok;
@@ -273,7 +281,8 @@ static int test_mult(void) {
     for (int i = 0; i < 3; i++) {
         QkObs *obs = qk_obs_identity(100);
 
-        QkObs *result = qk_obs_multiply(obs, &coeffs[i]);
+        QkObs *result = NULL;
+        QkExitCode exit = qk_obs_multiply(obs, &coeffs[i], &result);
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
@@ -290,7 +299,7 @@ static int test_mult(void) {
         qk_obs_free(result);
         qk_obs_free(expected);
 
-        if (!is_equal) {
+        if (exit != QkExitCode_Success || !is_equal) {
             return EqualityError;
         }
     }
@@ -307,7 +316,7 @@ static int test_mult_inplace(void) {
     for (int i = 0; i < 3; i++) {
         QkObs *obs = qk_obs_identity(100);
 
-        qk_obs_multiply_inplace(obs, &coeffs[i]);
+        QkExitCode exit = qk_obs_multiply_inplace(obs, &coeffs[i]);
 
         // construct the expected observable: coeff * Id
         QkObs *expected = qk_obs_zero(100);
@@ -323,7 +332,7 @@ static int test_mult_inplace(void) {
         qk_obs_free(obs);
         qk_obs_free(expected);
 
-        if (!is_equal) {
+        if (exit != QkExitCode_Success || !is_equal) {
             return EqualityError;
         }
     }
@@ -337,7 +346,8 @@ static int test_mult_inplace(void) {
 static int test_canonicalize(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
-    QkObs *obs = qk_obs_add(left, right);
+    QkObs *obs = NULL;
+    QkExitCode add_exit = qk_obs_add(left, right, &obs);
 
     double tol = 1e-5;
     QkObs *simplified = qk_obs_canonicalize(obs, tol);
@@ -358,7 +368,7 @@ static int test_canonicalize(void) {
     qk_obs_free(simplified);
     qk_obs_free(expected);
 
-    return is_equal ? Ok : EqualityError;
+    return (add_exit != QkExitCode_Success || !is_equal) ? EqualityError : Ok;
 }
 
 /**


### PR DESCRIPTION
### Summary

All `qk_obs_*` arithmetic functions in the C API now return `QkExitCode` and accept an `out` parameter instead of returning raw pointers. In-place functions return `QkExitCode` instead of `void`. Arithmetic functions with mismatched qubits now return `QkExitCode_MismatchedQubits` instead of panicking.

### Changes

**crates/cext/src/sparse_observable.rs:**
- `qk_obs_add`, `qk_obs_scaled_add`, `qk_obs_multiply`, `qk_obs_compose`, `qk_obs_compose_map`: Added `out: *mut *mut SparseObservable`, return `ExitCode` instead of `*mut SparseObservable`
- `qk_obs_add_inplace`, `qk_obs_scaled_add_inplace`, `qk_obs_multiply_inplace`: Return `ExitCode` instead of `void`
- All arithmetic functions that operate on two observables now check for qubit count mismatch and return `ExitCode::MismatchedQubits`

**test/c/test_sparse_observable.c:** Updated all test functions to use new signatures and check exit codes.

**Fixes:** #15608