### PR TITLE
Add term_to_pauli_product_rotation helper for SparseObservable

### DIFF
--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -15,6 +15,7 @@ use std::ffi::{CString, c_char};
 use crate::exit_codes::{CInputError, ExitCode};
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref, slice_from_ptr, try_slice_from_ptr};
 use num_complex::Complex64;
+use qiskit_circuit::operations::{Param, PauliProductRotation};
 
 use qiskit_quantum_info::sparse_observable::{
     BitTerm, CoherenceError, SparseObservable, SparseTermView,
@@ -528,6 +529,43 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
     let obs = unsafe { mut_ptr_as_ref(obs) };
 
     obs.bit_terms_mut().as_mut_ptr()
+}
+
+/// Convert a single SparseObservable term to a PauliProductRotation gate + global phase.
+///
+/// This takes a slice of `BitTerm` values and a coefficient, and produces:
+/// - A `PauliProductRotation` gate representing the Pauli rotation
+/// - A global phase correction from projector terms
+fn term_to_pauli_product_rotation(
+    bit_terms: &[BitTerm],
+    coeff: f64,
+) -> (PauliProductRotation, f64) {
+    let n = bit_terms.len();
+    let mut z = Vec::with_capacity(n);
+    let mut x = Vec::with_capacity(n);
+    let mut global_phase = 0.0;
+
+    for bit in bit_terms {
+        match bit {
+            BitTerm::X => { z.push(false); x.push(true); }
+            BitTerm::Y => { z.push(true); x.push(true); }
+            BitTerm::Z => { z.push(true); x.push(false); }
+            // Projectors |ψ⟩⟨ψ| = (I ± P)/2 contribute the Pauli P and an identity
+            // term I/2 → global phase of -theta/2 in exp(-i*theta*|ψ⟩⟨ψ|).
+            BitTerm::Zero | BitTerm::One => { z.push(true); x.push(false); global_phase -= 0.5; }
+            BitTerm::Plus | BitTerm::Minus => { z.push(false); x.push(true); global_phase -= 0.5; }
+            BitTerm::Right | BitTerm::Left => { z.push(true); x.push(true); global_phase -= 0.5; }
+        }
+    }
+
+    (
+        PauliProductRotation {
+            z,
+            x,
+            angle: Param::Float(coeff * 2.0),
+        },
+        global_phase,
+    )
 }
 
 /// @ingroup QkObs

--- a/releasenotes/notes/feat-sparse-obs-to-pauli-rotation-15969.yaml
+++ b/releasenotes/notes/feat-sparse-obs-to-pauli-rotation-15969.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added :func:`term_to_pauli_product_rotation` helper that converts a single
+    SparseObservable term (``BitTerm`` array + coefficient) to a
+    :class:`~qiskit.circuit.library.PauliProductRotation` gate and a global
+    phase contribution. Projector bit terms (Plus, Minus, Zero, One, Right,
+    Left) are correctly expanded into Pauli operators with the appropriate
+    global phase. This enables quantum chemistry workflows from
+    :class:`SparseObservable` to :class:`PauliProductRotation` gates.
+    Part of `#15969 <https://github.com/Qiskit/qiskit/issues/15969>`__.


### PR DESCRIPTION
### Summary

Adds a helper function to convert a single SparseObservable term (BitTerm array + coefficient) to a PauliProductRotation gate + global phase. Projector bit terms (Plus, Minus, Zero, One, Right, Left) are correctly expanded into their underlying Pauli operators with the identity-part contribution to global phase.

### Changes

- **cext/sparse_observable.rs**: Added internal  function
- **Release note** added

### Usage

For a SparseObservable term with Pauli string XY and coefficient θ:
- BitTerms [X, Y] → PauliProductRotation(z=[1,0], x=[1,1], angle=2θ)
- BitTerms with projectors also compute the global phase: e.g., Zero → Z + -0.5 phase per qubit

### Related

Refs #15969 (partially addresses — C API exposure tracked in #15971)