### PR TITLE
Refactoring `Clifford` struct in Rust

### DIFF
--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -180,7 +180,7 @@ impl PauliList {
         *lhs.last_mut().unwrap() ^= &rhs[self.num_qubits - 1];
     }
 
-    /// Modifies the pauli list in-place by conjugating each pauli with SXDG-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with SXdg-gate
     pub fn append_sxdg(&mut self, qubit: usize) {
         self.scratch.clone_from(&self.data[qubit]);
         self.scratch &= &self.data[qubit + self.num_qubits];
@@ -744,7 +744,7 @@ impl Clifford {
         self.tableau.append_sx(qubit);
     }
 
-    /// Modifies the tableau in-place by conjugating with SXDG-gate
+    /// Modifies the tableau in-place by conjugating with SXdg-gate
     #[inline]
     pub fn append_sxdg(&mut self, qubit: usize) {
         self.tableau.append_sxdg(qubit);
@@ -888,6 +888,7 @@ impl Clifford {
     /// Modifies the tableau in-place by appending PPR gate,
     /// with an angle that is an integer multiple of pi/2
     /// so PPR is necessarily a Clifford gate.
+    /// See [PauliList::append_ppr] for details.
     #[inline]
     pub fn append_ppr(
         &mut self,

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -451,24 +451,32 @@ impl PauliList {
         self._append_final_part_ppr(pauli_z, pauli_x, indices, &active_indices);
     }
 
-    pub fn get_pauli_support_size(&self, idx: usize) -> usize {
+    /// Computes the support size (number of non-I terms) of the Pauli given by `pauli_idx`.
+    pub fn get_pauli_support_size(&self, pauli_idx: usize) -> usize {
         (0..self.num_qubits)
-            .filter(|q| self.data[*q].contains(idx) | self.data[*q + self.num_qubits].contains(idx))
+            .filter(|q| {
+                self.data[*q].contains(pauli_idx)
+                    | self.data[*q + self.num_qubits].contains(pauli_idx)
+            })
             .count()
     }
 
-    pub fn get_pauli_support(&self, idx: usize) -> Vec<usize> {
+    /// Computes the support (non-I terms) of the Pauli given by `pauli_idx`.
+    pub fn get_pauli_support(&self, pauli_idx: usize) -> Vec<usize> {
         (0..self.num_qubits)
-            .filter(|q| self.data[*q].contains(idx) | self.data[*q + self.num_qubits].contains(idx))
+            .filter(|q| {
+                self.data[*q].contains(pauli_idx)
+                    | self.data[*q + self.num_qubits].contains(pauli_idx)
+            })
             .collect()
     }
 
-    /// Return true if pauli1 and pauli2 commute
-    pub fn commute(&self, idx1: usize, idx2: usize) -> bool {
+    /// Returns whether two Paulis given `pauli_idx1` and `pauli_idx2` commute.
+    pub fn commute(&self, pauli_idx1: usize, pauli_idx2: usize) -> bool {
         let mut parity = false;
         for i in 0..self.num_qubits {
-            parity ^= (self.get_pauli_z(idx1, i) & self.get_pauli_x(idx2, i))
-                ^ (self.get_pauli_x(idx1, i) & self.get_pauli_z(idx2, i));
+            parity ^= (self.get_pauli_z(pauli_idx1, i) & self.get_pauli_x(pauli_idx2, i))
+                ^ (self.get_pauli_x(pauli_idx1, i) & self.get_pauli_z(pauli_idx2, i));
         }
         !parity
     }
@@ -592,10 +600,24 @@ impl fmt::Display for PauliList {
     }
 }
 
-/// SIMD accelerated Clifford.
+/// A SIMD-accelerated Clifford representation.
 ///
-/// Currently this class offers a reduced functionality of the python-based
-/// Clifford class.
+/// Conceptually, a Clifford is represented by a tableau in which the rows
+/// recorrespond to destabilizers and stabilizers, and the columns correspond
+/// to the X, Z, and phase components:
+///
+/// ```text
+/// [ destab_x | destab_z | destab_phase ]
+/// [  stab_x  |  stab_z  |  stab_phase  ]
+/// ```
+///
+/// Internally, this is stored as a `PauliList`, with `data` represented as a vector
+/// of "columns", and each column corresponding to the X, Z, and phase component of the
+/// Clifford. This makes it efficient to conjugate a Clifford by Clifford gates, as all
+/// of the Paulis are conjugated in a SIMD-accelerated fashion.
+///
+/// This type currently provides a subset of the functionality of the Python-based
+/// `Clifford`` class.
 #[derive(Clone)]
 pub struct Clifford {
     /// The (2 * num qubits) x (2 * num qubits + 1) stabilizer tableau stored
@@ -662,6 +684,201 @@ impl Clifford {
             .indexed_iter()
             .for_each(|(index, v)| out.tableau.data[index.1].set(index.0, *v));
         out
+    }
+
+    /// Returns the number of qubits the Clifford acts upon
+    #[inline]
+    pub fn num_qubits(&self) -> usize {
+        self.tableau.num_qubits
+    }
+
+    /// Returns the value in the given row and the given columns of the tableau.
+    /// The rows correspond to stabilizers and destabilizers, and the columns correspond
+    /// x, z, and phase components.
+    #[inline]
+    pub fn get_entry(&self, row: usize, col: usize) -> bool {
+        self.tableau.data[col].contains(row)
+    }
+
+    /// Sets the value in the given row and the given column of the tableau.
+    /// The rows correspond to stabilizers and destabilizers, and the columns correspond
+    /// x, z, and phase components.
+    #[inline]
+    pub fn set_entry(&mut self, row: usize, col: usize, value: bool) {
+        self.tableau.data[col].set(row, value);
+    }
+
+    /// Modifies the tableau in-place by conjugating with S-gate
+    #[inline]
+    pub fn append_s(&mut self, qubit: usize) {
+        self.tableau.append_s(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with Sdg-gate
+    #[inline]
+    pub fn append_sdg(&mut self, qubit: usize) {
+        self.tableau.append_sdg(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with SX-gate
+    #[inline]
+    pub fn append_sx(&mut self, qubit: usize) {
+        self.tableau.append_sx(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with SXDG-gate
+    #[inline]
+    pub fn append_sxdg(&mut self, qubit: usize) {
+        self.tableau.append_sxdg(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with H-gate
+    #[inline]
+    pub fn append_h(&mut self, qubit: usize) {
+        self.tableau.append_h(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with SWAP-gate
+    #[inline]
+    pub fn append_swap(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_swap(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with CX-gate
+    #[inline]
+    pub fn append_cx(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_cx(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with CZ-gate
+    #[inline]
+    pub fn append_cz(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_cz(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with CY-gate
+    /// (todo: rewrite using native tableau manipulations)
+    #[inline]
+    pub fn append_cy(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_cy(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with X-gate
+    #[inline]
+    pub fn append_x(&mut self, qubit: usize) {
+        self.tableau.append_x(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with Z-gate
+    #[inline]
+    pub fn append_z(&mut self, qubit: usize) {
+        self.tableau.append_z(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with Y-gate
+    #[inline]
+    pub fn append_y(&mut self, qubit: usize) {
+        self.tableau.append_y(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with iSWAP-gate
+    #[inline]
+    pub fn append_iswap(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_iswap(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with ECR-gate
+    #[inline]
+    pub fn append_ecr(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_ecr(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with DCX-gate
+    #[inline]
+    pub fn append_dcx(&mut self, qubit0: usize, qubit1: usize) {
+        self.tableau.append_dcx(qubit0, qubit1);
+    }
+
+    /// Modifies the tableau in-place by conjugating with V-gate
+    #[inline]
+    pub fn append_v(&mut self, qubit: usize) {
+        self.tableau.append_v(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with W-gate
+    #[inline]
+    pub fn append_w(&mut self, qubit: usize) {
+        self.tableau.append_w(qubit);
+    }
+
+    /// Modifies the tableau in-place by conjugating with RZ-gate,
+    /// with an angle that is an integer multiple of pi/2
+    /// (so RZ is necessarily a Clifford gate)
+    #[inline]
+    pub fn append_rz(&mut self, qubit: usize, multiple: usize) {
+        self.tableau.append_rz(qubit, multiple);
+    }
+
+    /// Modifies the tableau in-place by conjugating with RX-gate,
+    /// with an angle that is an integer multiple of pi/2
+    /// (so RX is necessarily a Clifford gate)
+    #[inline]
+    pub fn append_rx(&mut self, qubit: usize, multiple: usize) {
+        self.tableau.append_rx(qubit, multiple);
+    }
+
+    /// Modifies the tableau in-place by conjugating with RY-gate,
+    /// with an angle that is an integer multiple of pi/2
+    /// (so RY is necessarily a Clifford gate)
+    #[inline]
+    pub fn append_ry(&mut self, qubit: usize, multiple: usize) {
+        self.tableau.append_ry(qubit, multiple);
+    }
+
+    /// Applies the initial basis transformation for a Pauli Product Rotation,
+    /// and modifies the tableau in-place.
+    ///
+    /// See [`PauliList::_append_initial_part_ppr`] for details.
+    #[inline]
+    fn _append_initial_part_ppr(
+        &mut self,
+        z: &[bool],
+        x: &[bool],
+        indices: &[u32],
+        active_indices: &[usize],
+    ) {
+        self.tableau
+            ._append_initial_part_ppr(z, x, indices, active_indices);
+    }
+
+    /// Applies the final basis transformation for a Pauli Product Rotation,
+    /// and modifies the tableau in-place.
+    ///
+    /// See [`PauliList::_append_final_part_ppr`] for details.
+    #[inline]
+    fn _append_final_part_ppr(
+        &mut self,
+        z: &[bool],
+        x: &[bool],
+        indices: &[u32],
+        active_indices: &[usize],
+    ) {
+        self.tableau
+            ._append_final_part_ppr(z, x, indices, active_indices);
+    }
+
+    /// Modifies the tableau in-place by appending PPR gate,
+    /// with an angle that is an integer multiple of pi/2
+    /// so PPR is necessarily a Clifford gate.
+    #[inline]
+    pub fn append_ppr(
+        &mut self,
+        pauli_z: &[bool],
+        pauli_x: &[bool],
+        indices: &[u32],
+        multiple: usize,
+    ) {
+        self.tableau.append_ppr(pauli_z, pauli_x, indices, multiple);
     }
 
     /// Evolving a (dense) Pauli gate by the Clifford.
@@ -806,14 +1023,14 @@ impl fmt::Debug for Clifford {
 
 #[cfg(test)]
 mod tests {
-    use crate::clifford::{PauliLabelOrder, PauliList};
+    use crate::clifford::{PauliLabelOrder, PauliList, PauliListError};
 
     #[test]
     fn test_from_labels_and_back_with_left_to_right() {
-        let pauli_labels = vec!["XIZ".to_string(), "-YYY".to_string()];
+        let pauli_labels = ["XIZ".to_string(), "-YYY".to_string()];
         let pauli_list =
             PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::LeftToRight)
-                .expect("Pauli List should be created");
+                .expect("PauliList should be created without problems (all labels are valid)");
 
         // XIZ
         assert!(pauli_list.get_pauli_x(0, 0));
@@ -839,10 +1056,10 @@ mod tests {
 
     #[test]
     fn test_from_labels_and_back_with_right_to_left() {
-        let pauli_labels = vec!["+XIZ".to_string(), "-YYY".to_string()];
+        let pauli_labels = ["+XIZ".to_string(), "-YYY".to_string()];
         let pauli_list =
             PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::RightToLeft)
-                .expect("Pauli List should be created");
+                .expect("PauliList should be created without problems (all labels are valid)");
 
         // ZIX (when ordered left-to-right)
         assert!(!pauli_list.get_pauli_x(0, 0));
@@ -863,5 +1080,32 @@ mod tests {
 
         let pauli_labels_roundtrip = pauli_list.to_pauli_labels(PauliLabelOrder::RightToLeft);
         assert_eq!(pauli_labels_roundtrip, pauli_labels);
+    }
+
+    #[test]
+    fn test_from_invalid_labels() {
+        let pauli_labels = ["+XIZ".to_string(), "1XY".to_string()];
+        let pauli_list =
+            PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::RightToLeft);
+        assert!(matches!(pauli_list, Err(PauliListError::InvalidLabel(_))));
+    }
+
+    #[test]
+    fn test_commutation() {
+        let pauli_labels = [
+            "+XIZ".to_string(),
+            "-YYY".to_string(),
+            "IIX".to_string(),
+            "III".to_string(),
+        ];
+        let pauli_list =
+            PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::LeftToRight)
+                .expect("PauliList should be created without problems (all labels are valid)");
+        assert!(pauli_list.commute(0, 1));
+        assert!(!pauli_list.commute(2, 0));
+        assert!(pauli_list.commute(3, 0));
+        assert!(!pauli_list.commute(1, 2));
+        assert!(pauli_list.commute(2, 2));
+        assert!(pauli_list.commute(2, 3));
     }
 }

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -27,7 +27,22 @@ pub enum Pauli1q {
 /// SIMD accelerated PauliList.
 ///
 /// Stores multiple Paulis with associated phases, but in a packed format
-/// optimized for vectorized conjugation by Clifford gates.
+/// optimized for vectorized conjugation by Clifford gates. The phases are
+/// only allowed to be false ("+") and true ("-"); the "i" and "-i" phases
+/// are not allowed.
+///
+/// Implementation-wise, each entry in `data` is a `FixedBitSet` corresponding
+/// to some X, some Z, or the phase component of every Pauli in the list.
+///
+/// One can conceptually visualized a `PauliList` as the following two-dimensional
+/// array, with a row in this array corresponding to an entry in `data`, and a column
+/// corresponding to a specific Pauli (represented using X, Z, and phase components).
+///
+/// ```text
+/// [ pauli_1_x pauli_2_x pauli_3_x pauli_4_x ]
+/// [ pauli_1_z pauli_2_z pauli_3_z pauli_4_z ]
+/// [ pauli_1_p pauli_2_p pauli_3_p pauli_4_p ]
+/// ```
 #[derive(Clone)]
 pub struct PauliList {
     /// Number of qubits.

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -34,14 +34,17 @@ pub enum Pauli1q {
 /// Implementation-wise, each entry in `data` is a `FixedBitSet` corresponding
 /// to some X, some Z, or the phase component of every Pauli in the list.
 ///
-/// One can conceptually visualized a `PauliList` as the following two-dimensional
-/// array, with a row in this array corresponding to an entry in `data`, and a column
+/// One can conceptually visualize a `PauliList` as the following two-dimensional
+/// array, with a column in this array corresponding to an entry in `data`, and a row
 /// corresponding to a specific Pauli (represented using X, Z, and phase components).
+/// In this visual representation there are (2 * num_qubits + 1) columns and
+/// `num_paulis` rows.
 ///
 /// ```text
-/// [ pauli_1_x pauli_2_x pauli_3_x pauli_4_x ]
-/// [ pauli_1_z pauli_2_z pauli_3_z pauli_4_z ]
-/// [ pauli_1_p pauli_2_p pauli_3_p pauli_4_p ]
+/// [ pauli_1_x pauli_1_z pauli_1_p ]
+/// [ pauli_2_x pauli_2_z pauli_2_p ]
+/// [ pauli_3_x pauli_3_z pauli_3_p ]
+/// [ pauli_4_x pauli_4_z pauli_4_p ]
 /// ```
 #[derive(Clone)]
 pub struct PauliList {
@@ -49,7 +52,7 @@ pub struct PauliList {
     pub num_qubits: usize,
     /// Number of Paulis.
     pub num_paulis: usize,
-    /// List of Paulis, stored as vector of (2 * num_qubits) + 1 columns,
+    /// List of Paulis, stored as vector of (2 * num_qubits + 1) columns,
     /// each of length num_paulis.
     pub data: Vec<FixedBitSet>,
     /// Scratch space for internal computations, of length num_paulis.
@@ -617,28 +620,28 @@ impl fmt::Display for PauliList {
 
 /// A SIMD-accelerated Clifford representation.
 ///
-/// Conceptually, a Clifford is represented by a tableau in which the rows
-/// recorrespond to destabilizers and stabilizers, and the columns correspond
-/// to the X, Z, and phase components:
+/// Conceptually, a Clifford is represented by a (2 * num qubits) x (2 * num qubits + 1)
+/// stabilizer tableau in which the rows recorrespond to destabilizers and stabilizers,
+/// and the columns correspond to the X, Z, and phase components:
 ///
 /// ```text
 /// [ destab_x | destab_z | destab_phase ]
 /// [  stab_x  |  stab_z  |  stab_phase  ]
 /// ```
 ///
-/// Internally, this is stored as a `PauliList`, with `data` represented as a vector
-/// of "columns", and each column corresponding to the X, Z, and phase component of the
-/// Clifford. This makes it efficient to conjugate a Clifford by Clifford gates, as all
+/// Internally, this is stored as a `PauliList`, with `tableau` represented as a vector
+/// of (2 * num_qubits + 1) "columns", corresponding to the `num_qubits` X, `num_qubits` Z
+/// and the phase component of the tableau. Each column is of length (2 * num_qubits) with
+/// entries corresponding to `num_qubits` destabilizers and `num_qubits` stabilizers.
+/// This representations makes it efficient to conjugate a Clifford by Clifford gates, as all
 /// of the Paulis are conjugated in a SIMD-accelerated fashion.
 ///
 /// This type currently provides a subset of the functionality of the Python-based
 /// `Clifford`` class.
 #[derive(Clone)]
 pub struct Clifford {
-    /// The (2 * num qubits) x (2 * num qubits + 1) stabilizer tableau stored
-    /// as a vector of (2 * num_qubits) + 1 columns,
-    /// each of length (2 * num_qubits). The element in row
-    /// i and column j can be access as tableau.paulis[j][i].
+    /// Stabilizer tableau. The element in row i and column j can be accessed using
+    /// ``get_entry(i, j)``.
     pub tableau: PauliList,
 }
 

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -14,6 +14,8 @@ use std::fmt;
 use fixedbitset::FixedBitSet;
 use ndarray::ArrayView2;
 
+use thiserror::Error;
+
 /// 1-qubit Paulis
 #[derive(Clone, Copy, PartialEq)]
 pub enum Pauli1q {
@@ -39,20 +41,93 @@ pub struct PauliList {
     scratch: FixedBitSet,
 }
 
+#[derive(Error, Debug)]
+pub enum PauliListError {
+    #[error("Invalid Pauli label: {0}")]
+    InvalidLabel(String),
+}
+
+/// Specifies the order in which Pauli labels are interpreted.
+/// The standard Qiskit convention inteprets labels right-to-left:
+/// for Pauli label "IXYZ", the label on the first qubit is "Z". However,
+/// in some cases it is more convenient to interpret labels left-to-right.
+#[derive(PartialEq)]
+pub enum PauliLabelOrder {
+    LeftToRight,
+    RightToLeft,
+}
+
 impl PauliList {
+    /// A reference to the given x-row of the PauliList.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
     #[inline]
-    pub fn get_phase(&self) -> &FixedBitSet {
-        self.data.get(2 * self.num_qubits).unwrap()
+    pub fn get_x(&self, qubit: usize) -> &FixedBitSet {
+        self.data.get(qubit).unwrap()
     }
 
+    /// A mutable reference to the given x-row of the PauliList.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
+    #[inline]
+    pub fn get_x_mut(&mut self, qubit: usize) -> &mut FixedBitSet {
+        self.data.get_mut(qubit).unwrap()
+    }
+
+    /// A reference to the given z-row of the PauliList.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
     #[inline]
     pub fn get_z(&self, qubit: usize) -> &FixedBitSet {
         self.data.get(self.num_qubits + qubit).unwrap()
     }
 
+    /// A mutable reference to the z-row of the PauliList.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
     #[inline]
     pub fn get_z_mut(&mut self, qubit: usize) -> &mut FixedBitSet {
         self.data.get_mut(self.num_qubits + qubit).unwrap()
+    }
+
+    /// A reference to the phase row of the PauliList.
+    #[inline]
+    pub fn get_phase(&self) -> &FixedBitSet {
+        self.data.get(2 * self.num_qubits).unwrap()
+    }
+
+    /// A mutable reference to the phase row of the PauliList.
+    #[inline]
+    pub fn get_phase_mut(&mut self) -> &mut FixedBitSet {
+        self.data.get_mut(2 * self.num_qubits).unwrap()
+    }
+
+    /// The entry in the given x-row corresponding to the Pauli ``pauli_idx``.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
+    #[inline]
+    pub fn get_pauli_x(&self, pauli_idx: usize, qubit: usize) -> bool {
+        self.data[qubit][pauli_idx]
+    }
+
+    /// The entry in the given z-row corresponding to the Pauli ``pauli_idx``.
+    ///
+    /// Note: this function assumes that the given row exists
+    /// and panics otherwise.
+    #[inline]
+    pub fn get_pauli_z(&self, pauli_idx: usize, qubit: usize) -> bool {
+        self.data[qubit + self.num_qubits][pauli_idx]
+    }
+
+    /// The entry in the phase-row corresponding to the Pauli ``pauli_idx``.
+    #[inline]
+    pub fn get_pauli_phase(&self, pauli_idx: usize) -> bool {
+        self.data[2 * self.num_qubits][pauli_idx]
     }
 
     /// Modifies the pauli list in-place by conjugating each pauli with S-gate
@@ -375,6 +450,146 @@ impl PauliList {
 
         self._append_final_part_ppr(pauli_z, pauli_x, indices, &active_indices);
     }
+
+    pub fn get_pauli_support_size(&self, idx: usize) -> usize {
+        (0..self.num_qubits)
+            .filter(|q| self.data[*q].contains(idx) | self.data[*q + self.num_qubits].contains(idx))
+            .count()
+    }
+
+    pub fn get_pauli_support(&self, idx: usize) -> Vec<usize> {
+        (0..self.num_qubits)
+            .filter(|q| self.data[*q].contains(idx) | self.data[*q + self.num_qubits].contains(idx))
+            .collect()
+    }
+
+    /// Return true if pauli1 and pauli2 commute
+    pub fn commute(&self, idx1: usize, idx2: usize) -> bool {
+        let mut parity = false;
+        for i in 0..self.num_qubits {
+            parity ^= (self.get_pauli_z(idx1, i) & self.get_pauli_x(idx2, i))
+                ^ (self.get_pauli_x(idx1, i) & self.get_pauli_z(idx2, i));
+        }
+        !parity
+    }
+
+    /// Construct a [PauliList] from Pauli labels.
+    ///
+    /// # Arguments:
+    ///
+    /// * `num_qubits`: The number of qubits each Pauli is defined on.
+    /// * `pauli_labels`: An array of Pauli labels, where each label consists
+    ///   of an optional plus or minus sign followed by a sequence of `'I'`, `'X'`, `'Y'`,
+    ///   or `'Z'` characters. The `'i'` factor is not allowed.
+    /// * `label_order`: specifies whether each label should be interpreted left-to-right,
+    ///   or right-to-left.
+    ///
+    /// # Errors:
+    ///
+    /// Returns [`PauliListError::InvalidLabel`] if the labels are invalid.
+    pub fn from_pauli_labels(
+        num_qubits: usize,
+        pauli_labels: &[String],
+        label_order: PauliLabelOrder,
+    ) -> Result<Self, PauliListError> {
+        let num_paulis = pauli_labels.len();
+
+        let scratch = FixedBitSet::with_capacity(num_paulis);
+        let mut data: Vec<FixedBitSet> = Vec::with_capacity(2 * num_qubits + 1);
+
+        for _ in 0..2 * num_qubits + 1 {
+            data.push(scratch.clone());
+        }
+
+        for (pauli_idx, pauli_label) in pauli_labels.iter().enumerate() {
+            let s = if let Some(rest) = pauli_label.strip_prefix('-') {
+                data[2 * num_qubits].set(pauli_idx, true);
+                rest
+            } else if let Some(rest) = pauli_label.strip_prefix('+') {
+                rest
+            } else {
+                pauli_label.as_str()
+            };
+
+            for (j, c) in s.chars().enumerate() {
+                let qubit = if label_order == PauliLabelOrder::LeftToRight {
+                    j
+                } else {
+                    num_qubits - j - 1
+                };
+                match c {
+                    'X' => {
+                        data[qubit].set(pauli_idx, true);
+                    }
+                    'Z' => {
+                        data[qubit + num_qubits].set(pauli_idx, true);
+                    }
+                    'Y' => {
+                        data[qubit].set(pauli_idx, true);
+                        data[qubit + num_qubits].set(pauli_idx, true);
+                    }
+                    'I' => {}
+                    _ => {
+                        return Err(PauliListError::InvalidLabel(pauli_label.clone()));
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            num_qubits,
+            num_paulis,
+            data,
+            scratch,
+        })
+    }
+
+    /// Return Pauli labels.
+    ///
+    /// # Arguments:
+    ///
+    /// * `label_order`: specifies whether each label should be interpreted left-to-right,
+    ///   or right-to-left.
+    pub fn to_pauli_labels(&self, label_order: PauliLabelOrder) -> Vec<String> {
+        let mut pauli_labels: Vec<String> = Vec::with_capacity(self.num_paulis);
+        for pauli_idx in 0..self.num_paulis {
+            let mut s: String = String::with_capacity(self.num_qubits + 1);
+            let c = match self.get_pauli_phase(pauli_idx) {
+                false => '+',
+                true => '-',
+            };
+            s.push(c);
+            for j in 0..self.num_qubits {
+                let qubit = if label_order == PauliLabelOrder::LeftToRight {
+                    j
+                } else {
+                    self.num_qubits - j - 1
+                };
+                let c = match (
+                    self.get_pauli_x(pauli_idx, qubit),
+                    self.get_pauli_z(pauli_idx, qubit),
+                ) {
+                    (false, false) => 'I',
+                    (false, true) => 'Z',
+                    (true, false) => 'X',
+                    (true, true) => 'Y',
+                };
+                s.push(c);
+            }
+            pauli_labels.push(s);
+        }
+        pauli_labels
+    }
+}
+
+impl fmt::Display for PauliList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:?}",
+            self.to_pauli_labels(PauliLabelOrder::LeftToRight)
+        )
+    }
 }
 
 /// SIMD accelerated Clifford.
@@ -586,5 +801,67 @@ impl fmt::Debug for Clifford {
         }
         writeln!(f)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::clifford::{PauliLabelOrder, PauliList};
+
+    #[test]
+    fn test_from_labels_and_back_with_left_to_right() {
+        let pauli_labels = vec!["XIZ".to_string(), "-YYY".to_string()];
+        let pauli_list =
+            PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::LeftToRight)
+                .expect("Pauli List should be created");
+
+        // XIZ
+        assert!(pauli_list.get_pauli_x(0, 0));
+        assert!(!pauli_list.get_pauli_z(0, 0));
+        assert!(!pauli_list.get_pauli_x(0, 1));
+        assert!(!pauli_list.get_pauli_z(0, 1));
+        assert!(!pauli_list.get_pauli_x(0, 2));
+        assert!(pauli_list.get_pauli_z(0, 2));
+        assert!(!pauli_list.get_pauli_phase(0));
+        // -YYY
+        assert!(pauli_list.get_pauli_x(1, 0));
+        assert!(pauli_list.get_pauli_z(1, 0));
+        assert!(pauli_list.get_pauli_x(1, 1));
+        assert!(pauli_list.get_pauli_z(1, 1));
+        assert!(pauli_list.get_pauli_x(1, 2));
+        assert!(pauli_list.get_pauli_z(1, 2));
+        assert!(pauli_list.get_pauli_phase(1));
+
+        let pauli_labels_roundtrip = pauli_list.to_pauli_labels(PauliLabelOrder::LeftToRight);
+        let expected_pauli_labels = vec!["+XIZ".to_string(), "-YYY".to_string()];
+        assert_eq!(pauli_labels_roundtrip, expected_pauli_labels);
+    }
+
+    #[test]
+    fn test_from_labels_and_back_with_right_to_left() {
+        let pauli_labels = vec!["+XIZ".to_string(), "-YYY".to_string()];
+        let pauli_list =
+            PauliList::from_pauli_labels(3, &pauli_labels, PauliLabelOrder::RightToLeft)
+                .expect("Pauli List should be created");
+
+        // ZIX (when ordered left-to-right)
+        assert!(!pauli_list.get_pauli_x(0, 0));
+        assert!(pauli_list.get_pauli_z(0, 0));
+        assert!(!pauli_list.get_pauli_x(0, 1));
+        assert!(!pauli_list.get_pauli_z(0, 1));
+        assert!(pauli_list.get_pauli_x(0, 2));
+        assert!(!pauli_list.get_pauli_z(0, 2));
+        assert!(!pauli_list.get_pauli_phase(0));
+        // -YYY
+        assert!(pauli_list.get_pauli_x(1, 0));
+        assert!(pauli_list.get_pauli_z(1, 0));
+        assert!(pauli_list.get_pauli_x(1, 1));
+        assert!(pauli_list.get_pauli_z(1, 1));
+        assert!(pauli_list.get_pauli_x(1, 2));
+        assert!(pauli_list.get_pauli_z(1, 2));
+        assert!(pauli_list.get_pauli_phase(1));
+
+        let pauli_labels_roundtrip = pauli_list.to_pauli_labels(PauliLabelOrder::RightToLeft);
+        assert_eq!(pauli_labels_roundtrip, pauli_labels);
     }
 }

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -12,7 +12,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use ndarray::{Array2, ArrayView2};
+use ndarray::ArrayView2;
 
 /// 1-qubit Paulis
 #[derive(Clone, Copy, PartialEq)]
@@ -22,206 +22,140 @@ pub enum Pauli1q {
     Z,
 }
 
-/// Symplectic matrix.
-pub struct SymplecticMatrix {
-    /// Number of qubits.
-    pub num_qubits: usize,
-    /// Matrix with dimensions (2 * num_qubits) x (2 * num_qubits).
-    pub smat: Array2<bool>,
-}
-
-/// SIMD accelerated Clifford.
+/// SIMD accelerated PauliList.
 ///
-/// Currently this class offers a reduced functionality of the python-based
-/// Clifford class.
+/// Stores multiple Paulis with associated phases, but in a packed format
+/// optimized for vectorized conjugation by Clifford gates.
 #[derive(Clone)]
-pub struct Clifford {
+pub struct PauliList {
     /// Number of qubits.
     pub num_qubits: usize,
-    /// The (2 * num qubits) x (2 * num qubits + 1) stabilizer tableau stored
-    /// as a vector of (2 * num_qubits) + 1 columns,
-    /// each of length (2 * num_qubits). The element in row
-    /// i and column j can be access as tableau[j][i].
-    pub tableau: Vec<FixedBitSet>,
+    /// Number of Paulis.
+    pub num_paulis: usize,
+    /// List of Paulis, stored as vector of (2 * num_qubits) + 1 columns,
+    /// each of length num_paulis.
+    pub data: Vec<FixedBitSet>,
+    /// Scratch space for internal computations, of length num_paulis.
     scratch: FixedBitSet,
 }
 
-impl Clifford {
-    /// Create a new clifford from a tableau. The size of the tableau must match the number of
-    /// qubits provided otherwise an invalid Clifford object will be created.
-    pub fn new(num_qubits: usize, tableau: Vec<FixedBitSet>) -> Self {
-        Clifford {
-            num_qubits,
-            tableau,
-            scratch: FixedBitSet::with_capacity(2 * num_qubits),
-        }
-    }
-
-    /// Creates the identity Clifford on num_qubits
-    pub fn identity(num_qubits: usize) -> Self {
-        Self {
-            num_qubits,
-            tableau: (0..2 * num_qubits + 1)
-                .map(|i| {
-                    let mut column = FixedBitSet::with_capacity(2 * num_qubits);
-                    if i < 2 * num_qubits {
-                        // SAFETY: We know column is large enough since it's larger than the range
-                        // i is from
-                        unsafe {
-                            column.insert_unchecked(i);
-                        }
-                    }
-                    column
-                })
-                .collect(),
-            scratch: FixedBitSet::with_capacity(2 * num_qubits),
-        }
-    }
-
-    /// Creates a new Clifford from a tableau array of bools
-    #[inline]
-    pub fn from_array(tableau_array: ArrayView2<bool>) -> Self {
-        let tableau_shape = tableau_array.shape();
-        let num_qubits = tableau_shape[0] / 2;
-        let mut out = Self {
-            num_qubits,
-            tableau: (0..2 * num_qubits + 1)
-                .map(|_| FixedBitSet::with_capacity(2 * num_qubits))
-                .collect(),
-            scratch: FixedBitSet::with_capacity(2 * num_qubits),
-        };
-        tableau_array
-            .indexed_iter()
-            .for_each(|(index, v)| out.tableau[index.1].set(index.0, *v));
-        out
-    }
-
+impl PauliList {
     #[inline]
     pub fn get_phase(&self) -> &FixedBitSet {
-        self.tableau.get(2 * self.num_qubits).unwrap()
+        self.data.get(2 * self.num_qubits).unwrap()
     }
 
     #[inline]
     pub fn get_z(&self, qubit: usize) -> &FixedBitSet {
-        self.tableau.get(self.num_qubits + qubit).unwrap()
+        self.data.get(self.num_qubits + qubit).unwrap()
     }
 
     #[inline]
     pub fn get_z_mut(&mut self, qubit: usize) -> &mut FixedBitSet {
-        self.tableau.get_mut(self.num_qubits + qubit).unwrap()
+        self.data.get_mut(self.num_qubits + qubit).unwrap()
     }
 
-    /// Modifies the tableau in-place by appending S-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with S-gate
     pub fn append_s(&mut self, qubit: usize) {
-        self.scratch.clone_from(&self.tableau[qubit]);
-        self.scratch &= &self.tableau[qubit + self.num_qubits];
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + 1);
+        self.scratch.clone_from(&self.data[qubit]);
+        self.scratch &= &self.data[qubit + self.num_qubits];
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        let (lhs, rhs) = self.data.split_at_mut(qubit + 1);
         rhs[self.num_qubits - 1] ^= lhs.last().unwrap();
     }
 
-    /// Modifies the tableau in-place by appending Sdg-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with Sdg-gate
     pub fn append_sdg(&mut self, qubit: usize) {
-        let x = &self.tableau[qubit];
-        self.scratch
-            .clone_from(&self.tableau[qubit + self.num_qubits]);
+        let x = &self.data[qubit];
+        self.scratch.clone_from(&self.data[qubit + self.num_qubits]);
         self.scratch.toggle_range(..);
         self.scratch &= x;
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + 1);
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        let (lhs, rhs) = self.data.split_at_mut(qubit + 1);
         rhs[self.num_qubits - 1] ^= lhs.last().unwrap();
     }
 
-    /// Modifies the tableau in-place by appending SX-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with SX-gate
     pub fn append_sx(&mut self, qubit: usize) {
-        let x = &self.tableau[qubit];
-        let z = &self.tableau[qubit + self.num_qubits];
+        let x = &self.data[qubit];
+        let z = &self.data[qubit + self.num_qubits];
         self.scratch.clone_from(x);
         self.scratch.toggle_range(..);
         self.scratch &= z;
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + 1);
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        let (lhs, rhs) = self.data.split_at_mut(qubit + 1);
         *lhs.last_mut().unwrap() ^= &rhs[self.num_qubits - 1];
     }
 
-    /// Modifies the tableau in-place by appending SXDG-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with SXDG-gate
     pub fn append_sxdg(&mut self, qubit: usize) {
-        self.scratch.clone_from(&self.tableau[qubit]);
-        self.scratch &= &self.tableau[qubit + self.num_qubits];
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + 1);
+        self.scratch.clone_from(&self.data[qubit]);
+        self.scratch &= &self.data[qubit + self.num_qubits];
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        let (lhs, rhs) = self.data.split_at_mut(qubit + 1);
         *lhs.last_mut().unwrap() ^= &rhs[self.num_qubits - 1];
     }
 
-    /// Modifies the tableau in-place by appending H-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with H-gate
     pub fn append_h(&mut self, qubit: usize) {
-        let x = &self.tableau[qubit];
-        let z = &self.tableau[qubit + self.num_qubits];
+        let x = &self.data[qubit];
+        let z = &self.data[qubit + self.num_qubits];
         self.scratch.clone_from(x);
         self.scratch &= z;
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        self.tableau.swap(qubit, self.num_qubits + qubit);
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        self.data.swap(qubit, self.num_qubits + qubit);
     }
 
-    /// Modifies the tableau in-place by appending SWAP-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with SWAP-gate
     pub fn append_swap(&mut self, qubit0: usize, qubit1: usize) {
-        self.tableau.swap(qubit0, qubit1);
-        self.tableau
+        self.data.swap(qubit0, qubit1);
+        self.data
             .swap(self.num_qubits + qubit0, self.num_qubits + qubit1);
     }
 
-    /// Modifies the tableau in-place by appending CX-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with CX-gate
     pub fn append_cx(&mut self, qubit0: usize, qubit1: usize) {
-        let x0 = &self.tableau[qubit0];
-        let z0 = &self.tableau[qubit0 + self.num_qubits];
-        let x1 = &self.tableau[qubit1];
-        let z1 = &self.tableau[qubit1 + self.num_qubits];
+        let x0 = &self.data[qubit0];
+        let z0 = &self.data[qubit0 + self.num_qubits];
+        let x1 = &self.data[qubit1];
+        let z1 = &self.data[qubit1 + self.num_qubits];
 
         self.scratch.clone_from(x1);
         self.scratch ^= z0;
         self.scratch.toggle_range(..);
         self.scratch &= z1;
         self.scratch &= x0;
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
-        self.scratch.clone_from(&self.tableau[qubit1]);
-        self.scratch ^= &self.tableau[qubit0];
-        std::mem::swap(&mut self.tableau[qubit1], &mut self.scratch);
+        self.data[2 * self.num_qubits] ^= &self.scratch;
+        self.scratch.clone_from(&self.data[qubit1]);
+        self.scratch ^= &self.data[qubit0];
+        std::mem::swap(&mut self.data[qubit1], &mut self.scratch);
         self.scratch
-            .clone_from(&self.tableau[qubit0 + self.num_qubits]);
-        self.scratch ^= &self.tableau[qubit1 + self.num_qubits];
-        std::mem::swap(
-            &mut self.tableau[qubit0 + self.num_qubits],
-            &mut self.scratch,
-        );
+            .clone_from(&self.data[qubit0 + self.num_qubits]);
+        self.scratch ^= &self.data[qubit1 + self.num_qubits];
+        std::mem::swap(&mut self.data[qubit0 + self.num_qubits], &mut self.scratch);
     }
 
-    /// Modifies the tableau in-place by appending CZ-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with CZ-gate
     pub fn append_cz(&mut self, qubit0: usize, qubit1: usize) {
-        let x0 = &self.tableau[qubit0];
-        let z0 = &self.tableau[qubit0 + self.num_qubits];
-        let x1 = &self.tableau[qubit1];
-        let z1 = &self.tableau[qubit1 + self.num_qubits];
+        let x0 = &self.data[qubit0];
+        let z0 = &self.data[qubit0 + self.num_qubits];
+        let x1 = &self.data[qubit1];
+        let z1 = &self.data[qubit1 + self.num_qubits];
         self.scratch.clone_from(z0);
         self.scratch ^= z1;
         self.scratch &= &(x0 & x1);
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
+        self.data[2 * self.num_qubits] ^= &self.scratch;
         self.scratch
-            .clone_from(&self.tableau[qubit1 + self.num_qubits]);
-        self.scratch ^= &self.tableau[qubit0];
-        std::mem::swap(
-            &mut self.tableau[qubit1 + self.num_qubits],
-            &mut self.scratch,
-        );
+            .clone_from(&self.data[qubit1 + self.num_qubits]);
+        self.scratch ^= &self.data[qubit0];
+        std::mem::swap(&mut self.data[qubit1 + self.num_qubits], &mut self.scratch);
         self.scratch
-            .clone_from(&self.tableau[qubit0 + self.num_qubits]);
-        self.scratch ^= &self.tableau[qubit1];
-        std::mem::swap(
-            &mut self.tableau[qubit0 + self.num_qubits],
-            &mut self.scratch,
-        );
+            .clone_from(&self.data[qubit0 + self.num_qubits]);
+        self.scratch ^= &self.data[qubit1];
+        std::mem::swap(&mut self.data[qubit0 + self.num_qubits], &mut self.scratch);
     }
 
-    /// Modifies the tableau in-place by appending CY-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with CY-gate
     /// (todo: rewrite using native tableau manipulations)
     pub fn append_cy(&mut self, qubit0: usize, qubit1: usize) {
         self.append_sdg(qubit1);
@@ -229,26 +163,26 @@ impl Clifford {
         self.append_s(qubit1);
     }
 
-    /// Modifies the tableau in-place by appending X-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with X-gate
     pub fn append_x(&mut self, qubit: usize) {
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + self.num_qubits + 1);
+        let (lhs, rhs) = self.data.split_at_mut(qubit + self.num_qubits + 1);
         *rhs.last_mut().unwrap() ^= lhs.last().unwrap();
     }
 
-    /// Modifies the tableau in-place by appending Z-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with Z-gate
     pub fn append_z(&mut self, qubit: usize) {
-        let (lhs, rhs) = self.tableau.split_at_mut(qubit + 1);
+        let (lhs, rhs) = self.data.split_at_mut(qubit + 1);
         *rhs.last_mut().unwrap() ^= lhs.last().unwrap();
     }
 
-    /// Modifies the tableau in-place by appending Y-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with Y-gate
     pub fn append_y(&mut self, qubit: usize) {
-        self.scratch.clone_from(&self.tableau[qubit]);
-        self.scratch ^= &self.tableau[qubit + self.num_qubits];
-        self.tableau[2 * self.num_qubits] ^= &self.scratch;
+        self.scratch.clone_from(&self.data[qubit]);
+        self.scratch ^= &self.data[qubit + self.num_qubits];
+        self.data[2 * self.num_qubits] ^= &self.scratch;
     }
 
-    /// Modifies the tableau in-place by appending iSWAP-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with iSWAP-gate
     /// (todo: rewrite using native tableau manipulations)
     pub fn append_iswap(&mut self, qubit0: usize, qubit1: usize) {
         self.append_s(qubit0);
@@ -259,7 +193,7 @@ impl Clifford {
         self.append_h(qubit1);
     }
 
-    /// Modifies the tableau in-place by appending ECR-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with ECR-gate
     /// (todo: rewrite using native tableau manipulations)
     pub fn append_ecr(&mut self, qubit0: usize, qubit1: usize) {
         self.append_s(qubit0);
@@ -268,36 +202,34 @@ impl Clifford {
         self.append_x(qubit0);
     }
 
-    /// Modifies the tableau in-place by appending DCX-gate
+    /// Modifies the pauli list in-place by conjugating each pauli with DCX-gate
     /// (todo: rewrite using native tableau manipulations)
     pub fn append_dcx(&mut self, qubit0: usize, qubit1: usize) {
         self.append_cx(qubit0, qubit1);
         self.append_cx(qubit1, qubit0);
     }
 
-    /// Modifies the tableau in-place by appending V-gate.
+    /// Modifies the pauli list in-place by conjugating each pauli with V-gate
     /// This is equivalent to an Sdg gate followed by an H gate.
     pub fn append_v(&mut self, qubit: usize) {
-        self.scratch.clone_from(&self.tableau[qubit]);
-        self.scratch ^= &self.tableau[qubit + self.num_qubits];
-        self.tableau.swap(qubit, self.num_qubits + qubit);
-        std::mem::swap(&mut self.tableau[qubit], &mut self.scratch);
+        self.scratch.clone_from(&self.data[qubit]);
+        self.scratch ^= &self.data[qubit + self.num_qubits];
+        self.data.swap(qubit, self.num_qubits + qubit);
+        std::mem::swap(&mut self.data[qubit], &mut self.scratch);
     }
 
-    /// Modifies the tableau in-place by appending W-gate.
+    /// Modifies the pauli list in-place by conjugating each pauli with W-gate
     /// This is equivalent to two V gates.
     pub fn append_w(&mut self, qubit: usize) {
-        self.scratch.clone_from(&self.tableau[qubit]);
-        self.scratch ^= &self.tableau[qubit + self.num_qubits];
-        self.tableau.swap(qubit, self.num_qubits + qubit);
-        std::mem::swap(
-            &mut self.tableau[qubit + self.num_qubits],
-            &mut self.scratch,
-        );
+        self.scratch.clone_from(&self.data[qubit]);
+        self.scratch ^= &self.data[qubit + self.num_qubits];
+        self.data.swap(qubit, self.num_qubits + qubit);
+        std::mem::swap(&mut self.data[qubit + self.num_qubits], &mut self.scratch);
     }
-    /// Modifies the tableau in-place by appending RZ-gate,
+
+    /// Modifies the pauli list in-place by conjugating each pauli with RZ-gate,
     /// with an angle that is an integer multiple of pi/2
-    /// so RZ is necessarily a Clifford gate
+    /// (so RZ is necessarily a Clifford gate)
     pub fn append_rz(&mut self, qubit: usize, multiple: usize) {
         let multiple = multiple.rem_euclid(4);
         match multiple {
@@ -308,9 +240,10 @@ impl Clifford {
             _ => unreachable!("Multiple should be an integer."),
         }
     }
-    /// Modifies the tableau in-place by appending RX-gate,
+
+    /// Modifies the pauli list in-place by conjugating each pauli with RX-gate,
     /// with an angle that is an integer multiple of pi/2
-    /// so RX is necessarily a Clifford gate
+    /// (so RX is necessarily a Clifford gate)
     pub fn append_rx(&mut self, qubit: usize, multiple: usize) {
         let multiple = multiple.rem_euclid(4);
         match multiple {
@@ -321,9 +254,10 @@ impl Clifford {
             _ => unreachable!("Multiple should be an integer."),
         }
     }
-    /// Modifies the tableau in-place by appending RY-gate,
+
+    /// Modifies the pauli list in-place by conjugating each pauli with RY-gate,
     /// with an angle that is an integer multiple of pi/2
-    /// so RY is necessarily a Clifford gate
+    /// (so RY is necessarily a Clifford gate)
     pub fn append_ry(&mut self, qubit: usize, multiple: usize) {
         let multiple = multiple.rem_euclid(4);
         match multiple {
@@ -340,6 +274,7 @@ impl Clifford {
             _ => unreachable!("Multiple should be an integer."),
         }
     }
+
     /// Applies the initial basis transformation for a Pauli Product Rotation,
     /// and modifies the tableau in-place.
     ///
@@ -440,6 +375,79 @@ impl Clifford {
 
         self._append_final_part_ppr(pauli_z, pauli_x, indices, &active_indices);
     }
+}
+
+/// SIMD accelerated Clifford.
+///
+/// Currently this class offers a reduced functionality of the python-based
+/// Clifford class.
+#[derive(Clone)]
+pub struct Clifford {
+    /// The (2 * num qubits) x (2 * num qubits + 1) stabilizer tableau stored
+    /// as a vector of (2 * num_qubits) + 1 columns,
+    /// each of length (2 * num_qubits). The element in row
+    /// i and column j can be access as tableau.paulis[j][i].
+    pub tableau: PauliList,
+}
+
+impl Clifford {
+    /// Create a new clifford from a tableau. The size of the tableau must match the number of
+    /// qubits provided otherwise an invalid Clifford object will be created.
+    pub fn new(num_qubits: usize, tableau: Vec<FixedBitSet>) -> Self {
+        Clifford {
+            tableau: PauliList {
+                num_qubits,
+                num_paulis: 2 * num_qubits,
+                data: tableau,
+                scratch: FixedBitSet::with_capacity(2 * num_qubits),
+            },
+        }
+    }
+
+    /// Creates the identity Clifford on num_qubits
+    pub fn identity(num_qubits: usize) -> Self {
+        Self {
+            tableau: PauliList {
+                num_qubits,
+                num_paulis: 2 * num_qubits,
+                data: (0..2 * num_qubits + 1)
+                    .map(|i| {
+                        let mut column = FixedBitSet::with_capacity(2 * num_qubits);
+                        if i < 2 * num_qubits {
+                            // SAFETY: We know column is large enough since it's larger than the range
+                            // i is from
+                            unsafe {
+                                column.insert_unchecked(i);
+                            }
+                        }
+                        column
+                    })
+                    .collect(),
+                scratch: FixedBitSet::with_capacity(2 * num_qubits),
+            },
+        }
+    }
+
+    /// Creates a new Clifford from a tableau array of bools
+    #[inline]
+    pub fn from_array(tableau_array: ArrayView2<bool>) -> Self {
+        let tableau_shape = tableau_array.shape();
+        let num_qubits = tableau_shape[0] / 2;
+        let mut out = Self {
+            tableau: PauliList {
+                num_qubits,
+                num_paulis: 2 * num_qubits,
+                data: (0..2 * num_qubits + 1)
+                    .map(|_| FixedBitSet::with_capacity(2 * num_qubits))
+                    .collect(),
+                scratch: FixedBitSet::with_capacity(2 * num_qubits),
+            },
+        };
+        tableau_array
+            .indexed_iter()
+            .for_each(|(index, v)| out.tableau.data[index.1].set(index.0, *v));
+        out
+    }
 
     /// Evolving a (dense) Pauli gate by the Clifford.
     /// This is done by appending PPR (PPM) initial and final gates to the Clifford tableau in-place,
@@ -461,13 +469,15 @@ impl Clifford {
             .collect();
 
         if let Some(&idx) = active_indices.first() {
-            self._append_initial_part_ppr(in_z, in_x, indices_in, &active_indices);
+            self.tableau
+                ._append_initial_part_ppr(in_z, in_x, indices_in, &active_indices);
 
             // Evolving RZ by the Clifford.
             let (sign, z, x, indices) =
                 self.evolve_single_qubit_pauli(Pauli1q::Z, indices_in[idx] as usize);
 
-            self._append_final_part_ppr(in_z, in_x, indices_in, &active_indices);
+            self.tableau
+                ._append_final_part_ppr(in_z, in_x, indices_in, &active_indices);
 
             return (sign, z, x, indices);
         }
@@ -482,26 +492,27 @@ impl Clifford {
         pauli: Pauli1q,
         qbit: usize,
     ) -> (bool, Vec<bool>, Vec<bool>, Vec<u32>) {
-        let mut z = Vec::with_capacity(self.num_qubits);
-        let mut x = Vec::with_capacity(self.num_qubits);
-        let mut indices = Vec::with_capacity(self.num_qubits);
-        let mut pauli_indices = Vec::<usize>::with_capacity(2 * self.num_qubits);
+        let num_qubits = self.tableau.num_qubits;
+        let mut z = Vec::with_capacity(num_qubits);
+        let mut x = Vec::with_capacity(num_qubits);
+        let mut indices = Vec::with_capacity(num_qubits);
+        let mut pauli_indices = Vec::<usize>::with_capacity(2 * num_qubits);
         // Compute the y-count to avoid recomputing it later
         let mut pauli_y_count: u32 = 0;
-        for i in 0..self.num_qubits {
+        for i in 0..num_qubits {
             let (z_bit, x_bit) = match pauli {
                 Pauli1q::Z => (
-                    self.tableau[qbit][i],
-                    self.tableau[qbit][i + self.num_qubits],
+                    self.tableau.data[qbit][i],
+                    self.tableau.data[qbit][i + num_qubits],
                 ),
                 Pauli1q::X => (
-                    self.tableau[qbit + self.num_qubits][i],
-                    self.tableau[qbit + self.num_qubits][i + self.num_qubits],
+                    self.tableau.data[qbit + num_qubits][i],
+                    self.tableau.data[qbit + num_qubits][i + num_qubits],
                 ),
                 Pauli1q::Y => (
-                    self.tableau[qbit + self.num_qubits][i] ^ self.tableau[qbit][i],
-                    self.tableau[qbit + self.num_qubits][i + self.num_qubits]
-                        ^ self.tableau[qbit][i + self.num_qubits],
+                    self.tableau.data[qbit + num_qubits][i] ^ self.tableau.data[qbit][i],
+                    self.tableau.data[qbit + num_qubits][i + num_qubits]
+                        ^ self.tableau.data[qbit][i + num_qubits],
                 ),
             };
             if z_bit || x_bit {
@@ -512,7 +523,7 @@ impl Clifford {
                     pauli_indices.push(i);
                 }
                 if z_bit {
-                    pauli_indices.push(i + self.num_qubits);
+                    pauli_indices.push(i + num_qubits);
                 }
                 pauli_y_count += (x_bit && z_bit) as u32;
             }
@@ -530,17 +541,17 @@ fn compute_phase_product_pauli(
     pauli_y_count: u32,
 ) -> bool {
     let phase = pauli_indices.iter().fold(false, |acc, &pauli_index| {
-        acc ^ (clifford.tableau[2 * clifford.num_qubits][pauli_index])
+        acc ^ (clifford.tableau.data[2 * clifford.tableau.num_qubits][pauli_index])
     });
 
     let mut ifact: u8 = pauli_y_count as u8 % 4;
 
-    for j in 0..clifford.num_qubits {
+    for j in 0..clifford.tableau.num_qubits {
         let mut x = false;
         let mut z = false;
         for &pauli_index in pauli_indices.iter() {
-            let x1: bool = clifford.tableau[j][pauli_index];
-            let z1: bool = clifford.tableau[j + clifford.num_qubits][pauli_index];
+            let x1: bool = clifford.tableau.data[j][pauli_index];
+            let z1: bool = clifford.tableau.data[j + clifford.tableau.num_qubits][pauli_index];
 
             match (x1, z1, x, z) {
                 (false, true, true, true)
@@ -567,9 +578,9 @@ impl fmt::Debug for Clifford {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(f, "Tableau:")?;
-        for i in 0..2 * self.num_qubits {
-            for j in 0..2 * self.num_qubits + 1 {
-                write!(f, "{} ", self.tableau[j][i] as u8)?;
+        for i in 0..2 * self.tableau.num_qubits {
+            for j in 0..2 * self.tableau.num_qubits + 1 {
+                write!(f, "{} ", self.tableau.data[j][i] as u8)?;
             }
             writeln!(f)?;
         }

--- a/crates/synthesis/src/clifford/bm_synthesis.rs
+++ b/crates/synthesis/src/clifford/bm_synthesis.rs
@@ -22,7 +22,7 @@ use smallvec::smallvec;
 /// Return the number of CX-gates required for Clifford decomposition,
 /// for either a 2-qubit or a 3-qubit Clifford.
 fn cx_cost(clifford: &Clifford) -> usize {
-    if clifford.num_qubits == 2 {
+    if clifford.tableau.num_qubits == 2 {
         cx_cost2(clifford)
     } else {
         cx_cost3(clifford)
@@ -33,16 +33,16 @@ fn cx_cost(clifford: &Clifford) -> usize {
 /// for a 2-qubit Clifford.
 fn cx_cost2(clifford: &Clifford) -> usize {
     let r00 = rank2(
-        clifford.tableau[0][0],
-        clifford.tableau[2][0],
-        clifford.tableau[0][2],
-        clifford.tableau[2][2],
+        clifford.tableau.data[0][0],
+        clifford.tableau.data[2][0],
+        clifford.tableau.data[0][2],
+        clifford.tableau.data[2][2],
     );
     let r01 = rank2(
-        clifford.tableau[1][0],
-        clifford.tableau[3][0],
-        clifford.tableau[1][2],
-        clifford.tableau[3][2],
+        clifford.tableau.data[1][0],
+        clifford.tableau.data[3][0],
+        clifford.tableau.data[1][2],
+        clifford.tableau.data[3][2],
     );
     if r00 == 2 { r01 } else { r01 + 1 - r00 }
 }
@@ -66,10 +66,10 @@ fn cx_cost3(clifford: &Clifford) -> usize {
     let mut r2 = arr2(&[[0, 0, 0], [0, 0, 0], [0, 0, 0]]);
     for (q1, q2) in iproduct!(0..3, 0..3) {
         r2[[q1, q2]] = rank2(
-            clifford.tableau[q2][q1],
-            clifford.tableau[q2 + 3][q1],
-            clifford.tableau[q2][q1 + 3],
-            clifford.tableau[q2 + 3][q1 + 3],
+            clifford.tableau.data[q2][q1],
+            clifford.tableau.data[q2 + 3][q1],
+            clifford.tableau.data[q2][q1 + 3],
+            clifford.tableau.data[q2 + 3][q1 + 3],
         );
         let mut mask = FixedBitSet::with_capacity(6);
         // SAFETY: These indices are always valid because q2 is 0..3 so these
@@ -82,12 +82,12 @@ fn cx_cost3(clifford: &Clifford) -> usize {
         let mut xs = FixedBitSet::with_capacity(6);
         let mut zs = FixedBitSet::with_capacity(6);
         (0..6)
-            .map(|x| clifford.tableau[x][q1])
+            .map(|x| clifford.tableau.data[x][q1])
             .enumerate()
             .filter(|(_, x)| *x)
             .for_each(|(i, _)| unsafe { xs.toggle_unchecked(i) });
         (0..6)
-            .map(|x| clifford.tableau[x][q1 + 3])
+            .map(|x| clifford.tableau.data[x][q1 + 3])
             .enumerate()
             .filter(|(_, x)| *x)
             .for_each(|(i, _)| unsafe { zs.toggle_unchecked(i) });
@@ -159,23 +159,23 @@ fn reduce_cost(
     gates: &mut CliffordGatesVec,
 ) -> Result<(Clifford, usize), String> {
     // All choices for a 2-qubit block
-    for qubit0 in 0..cliff.num_qubits {
-        for qubit1 in qubit0 + 1..cliff.num_qubits {
+    for qubit0 in 0..cliff.tableau.num_qubits {
+        for qubit1 in qubit0 + 1..cliff.tableau.num_qubits {
             for (n0, n1) in iproduct!(0..3, 0..3) {
                 let mut reduced_cliff = cliff.clone();
 
                 // Apply the 2-qubit block and compute the new cost
                 if n0 == 1 {
-                    reduced_cliff.append_v(qubit0);
+                    reduced_cliff.tableau.append_v(qubit0);
                 } else if n0 == 2 {
-                    reduced_cliff.append_w(qubit0);
+                    reduced_cliff.tableau.append_w(qubit0);
                 }
                 if n1 == 1 {
-                    reduced_cliff.append_v(qubit1);
+                    reduced_cliff.tableau.append_v(qubit1);
                 } else if n1 == 2 {
-                    reduced_cliff.append_w(qubit1);
+                    reduced_cliff.tableau.append_w(qubit1);
                 }
-                reduced_cliff.append_cx(qubit0, qubit1);
+                reduced_cliff.tableau.append_cx(qubit0, qubit1);
                 let new_cost = cx_cost(&reduced_cliff);
 
                 // If the cost is reduced, we are done.
@@ -223,8 +223,8 @@ fn reduce_cost(
 /// ``gates`` vector. The ``output_qubit`` specifies for which qubit (in a possibly
 /// larger circuit) the decomposition corresponds.
 fn decompose_clifford_1q(cliff: &Clifford, gates: &mut CliffordGatesVec, output_qubit: usize) {
-    let destab_phase = cliff.tableau[2][0];
-    let stab_phase = cliff.tableau[2][1];
+    let destab_phase = cliff.tableau.data[2][0];
+    let stab_phase = cliff.tableau.data[2][1];
 
     if destab_phase && !stab_phase {
         gates.push((
@@ -246,10 +246,10 @@ fn decompose_clifford_1q(cliff: &Clifford, gates: &mut CliffordGatesVec, output_
         ));
     }
 
-    let destab_x = cliff.tableau[0][0];
-    let destab_z = cliff.tableau[1][0];
-    let stab_x = cliff.tableau[0][1];
-    let stab_z = cliff.tableau[1][1];
+    let destab_x = cliff.tableau.data[0][0];
+    let destab_z = cliff.tableau.data[1][0];
+    let stab_x = cliff.tableau.data[0][1];
+    let stab_z = cliff.tableau.data[1][1];
 
     if stab_z && !stab_x {
         if destab_z {
@@ -344,12 +344,15 @@ pub fn synth_clifford_bm_inner(
             FixedBitSet::with_capacity(2),
             FixedBitSet::with_capacity(2),
         ];
-        tableau[0].set(0, clifford.tableau[qubit][qubit]);
-        tableau[1].set(0, clifford.tableau[qubit + num_qubits][qubit]);
-        tableau[2].set(0, clifford.tableau[2 * num_qubits][qubit]);
-        tableau[0].set(1, clifford.tableau[qubit][qubit + num_qubits]);
-        tableau[1].set(1, clifford.tableau[qubit + num_qubits][qubit + num_qubits]);
-        tableau[2].set(1, clifford.tableau[2 * num_qubits][qubit + num_qubits]);
+        tableau[0].set(0, clifford.tableau.data[qubit][qubit]);
+        tableau[1].set(0, clifford.tableau.data[qubit + num_qubits][qubit]);
+        tableau[2].set(0, clifford.tableau.data[2 * num_qubits][qubit]);
+        tableau[0].set(1, clifford.tableau.data[qubit][qubit + num_qubits]);
+        tableau[1].set(
+            1,
+            clifford.tableau.data[qubit + num_qubits][qubit + num_qubits],
+        );
+        tableau[2].set(1, clifford.tableau.data[2 * num_qubits][qubit + num_qubits]);
         let clifford1q = Clifford::new(1, tableau);
 
         decompose_clifford_1q(&clifford1q, &mut all_gates, qubit);

--- a/crates/synthesis/src/clifford/bm_synthesis.rs
+++ b/crates/synthesis/src/clifford/bm_synthesis.rs
@@ -22,7 +22,7 @@ use smallvec::smallvec;
 /// Return the number of CX-gates required for Clifford decomposition,
 /// for either a 2-qubit or a 3-qubit Clifford.
 fn cx_cost(clifford: &Clifford) -> usize {
-    if clifford.tableau.num_qubits == 2 {
+    if clifford.num_qubits() == 2 {
         cx_cost2(clifford)
     } else {
         cx_cost3(clifford)
@@ -33,16 +33,16 @@ fn cx_cost(clifford: &Clifford) -> usize {
 /// for a 2-qubit Clifford.
 fn cx_cost2(clifford: &Clifford) -> usize {
     let r00 = rank2(
-        clifford.tableau.data[0][0],
-        clifford.tableau.data[2][0],
-        clifford.tableau.data[0][2],
-        clifford.tableau.data[2][2],
+        clifford.get_entry(0, 0),
+        clifford.get_entry(0, 2),
+        clifford.get_entry(2, 0),
+        clifford.get_entry(2, 2),
     );
     let r01 = rank2(
-        clifford.tableau.data[1][0],
-        clifford.tableau.data[3][0],
-        clifford.tableau.data[1][2],
-        clifford.tableau.data[3][2],
+        clifford.get_entry(0, 1),
+        clifford.get_entry(0, 3),
+        clifford.get_entry(2, 1),
+        clifford.get_entry(2, 3),
     );
     if r00 == 2 { r01 } else { r01 + 1 - r00 }
 }
@@ -66,10 +66,10 @@ fn cx_cost3(clifford: &Clifford) -> usize {
     let mut r2 = arr2(&[[0, 0, 0], [0, 0, 0], [0, 0, 0]]);
     for (q1, q2) in iproduct!(0..3, 0..3) {
         r2[[q1, q2]] = rank2(
-            clifford.tableau.data[q2][q1],
-            clifford.tableau.data[q2 + 3][q1],
-            clifford.tableau.data[q2][q1 + 3],
-            clifford.tableau.data[q2 + 3][q1 + 3],
+            clifford.get_entry(q1, q2),
+            clifford.get_entry(q1, q2 + 3),
+            clifford.get_entry(q1 + 3, q2),
+            clifford.get_entry(q1 + 3, q2 + 3),
         );
         let mut mask = FixedBitSet::with_capacity(6);
         // SAFETY: These indices are always valid because q2 is 0..3 so these
@@ -82,12 +82,12 @@ fn cx_cost3(clifford: &Clifford) -> usize {
         let mut xs = FixedBitSet::with_capacity(6);
         let mut zs = FixedBitSet::with_capacity(6);
         (0..6)
-            .map(|x| clifford.tableau.data[x][q1])
+            .map(|x| clifford.get_entry(q1, x))
             .enumerate()
             .filter(|(_, x)| *x)
             .for_each(|(i, _)| unsafe { xs.toggle_unchecked(i) });
         (0..6)
-            .map(|x| clifford.tableau.data[x][q1 + 3])
+            .map(|x| clifford.get_entry(q1 + 3, x))
             .enumerate()
             .filter(|(_, x)| *x)
             .for_each(|(i, _)| unsafe { zs.toggle_unchecked(i) });
@@ -159,23 +159,23 @@ fn reduce_cost(
     gates: &mut CliffordGatesVec,
 ) -> Result<(Clifford, usize), String> {
     // All choices for a 2-qubit block
-    for qubit0 in 0..cliff.tableau.num_qubits {
-        for qubit1 in qubit0 + 1..cliff.tableau.num_qubits {
+    for qubit0 in 0..cliff.num_qubits() {
+        for qubit1 in qubit0 + 1..cliff.num_qubits() {
             for (n0, n1) in iproduct!(0..3, 0..3) {
                 let mut reduced_cliff = cliff.clone();
 
                 // Apply the 2-qubit block and compute the new cost
                 if n0 == 1 {
-                    reduced_cliff.tableau.append_v(qubit0);
+                    reduced_cliff.append_v(qubit0);
                 } else if n0 == 2 {
-                    reduced_cliff.tableau.append_w(qubit0);
+                    reduced_cliff.append_w(qubit0);
                 }
                 if n1 == 1 {
-                    reduced_cliff.tableau.append_v(qubit1);
+                    reduced_cliff.append_v(qubit1);
                 } else if n1 == 2 {
-                    reduced_cliff.tableau.append_w(qubit1);
+                    reduced_cliff.append_w(qubit1);
                 }
-                reduced_cliff.tableau.append_cx(qubit0, qubit1);
+                reduced_cliff.append_cx(qubit0, qubit1);
                 let new_cost = cx_cost(&reduced_cliff);
 
                 // If the cost is reduced, we are done.
@@ -223,8 +223,8 @@ fn reduce_cost(
 /// ``gates`` vector. The ``output_qubit`` specifies for which qubit (in a possibly
 /// larger circuit) the decomposition corresponds.
 fn decompose_clifford_1q(cliff: &Clifford, gates: &mut CliffordGatesVec, output_qubit: usize) {
-    let destab_phase = cliff.tableau.data[2][0];
-    let stab_phase = cliff.tableau.data[2][1];
+    let destab_phase = cliff.get_entry(0, 2);
+    let stab_phase = cliff.get_entry(1, 2);
 
     if destab_phase && !stab_phase {
         gates.push((
@@ -246,10 +246,10 @@ fn decompose_clifford_1q(cliff: &Clifford, gates: &mut CliffordGatesVec, output_
         ));
     }
 
-    let destab_x = cliff.tableau.data[0][0];
-    let destab_z = cliff.tableau.data[1][0];
-    let stab_x = cliff.tableau.data[0][1];
-    let stab_z = cliff.tableau.data[1][1];
+    let destab_x = cliff.get_entry(0, 0);
+    let destab_z = cliff.get_entry(0, 1);
+    let stab_x = cliff.get_entry(1, 0);
+    let stab_z = cliff.get_entry(1, 1);
 
     if stab_z && !stab_x {
         if destab_z {
@@ -344,15 +344,15 @@ pub fn synth_clifford_bm_inner(
             FixedBitSet::with_capacity(2),
             FixedBitSet::with_capacity(2),
         ];
-        tableau[0].set(0, clifford.tableau.data[qubit][qubit]);
-        tableau[1].set(0, clifford.tableau.data[qubit + num_qubits][qubit]);
-        tableau[2].set(0, clifford.tableau.data[2 * num_qubits][qubit]);
-        tableau[0].set(1, clifford.tableau.data[qubit][qubit + num_qubits]);
+        tableau[0].set(0, clifford.get_entry(qubit, qubit));
+        tableau[1].set(0, clifford.get_entry(qubit, qubit + num_qubits));
+        tableau[2].set(0, clifford.get_entry(qubit, 2 * num_qubits));
+        tableau[0].set(1, clifford.get_entry(qubit + num_qubits, qubit));
         tableau[1].set(
             1,
-            clifford.tableau.data[qubit + num_qubits][qubit + num_qubits],
+            clifford.get_entry(qubit + num_qubits, qubit + num_qubits),
         );
-        tableau[2].set(1, clifford.tableau.data[2 * num_qubits][qubit + num_qubits]);
+        tableau[2].set(1, clifford.get_entry(qubit + num_qubits, 2 * num_qubits));
         let clifford1q = Clifford::new(1, tableau);
 
         decompose_clifford_1q(&clifford1q, &mut all_gates, qubit);

--- a/crates/synthesis/src/clifford/greedy_synthesis.rs
+++ b/crates/synthesis/src/clifford/greedy_synthesis.rs
@@ -408,7 +408,7 @@ pub fn resynthesize_clifford_circuit(
 ) -> Result<CliffordGatesVec, String> {
     let sim_clifford = clifford_from_gate_sequence(gates, num_qubits)?;
     let tableau = Array2::from_shape_fn((2 * num_qubits, 2 * num_qubits + 1), |(i, j)| {
-        sim_clifford.tableau.data[j][i]
+        sim_clifford.get_entry(i, j)
     });
     let mut synthesis = GreedyCliffordSynthesis::new(tableau.view())?;
     let (_, new_gates) = synthesis.run()?;

--- a/crates/synthesis/src/clifford/greedy_synthesis.rs
+++ b/crates/synthesis/src/clifford/greedy_synthesis.rs
@@ -408,7 +408,7 @@ pub fn resynthesize_clifford_circuit(
 ) -> Result<CliffordGatesVec, String> {
     let sim_clifford = clifford_from_gate_sequence(gates, num_qubits)?;
     let tableau = Array2::from_shape_fn((2 * num_qubits, 2 * num_qubits + 1), |(i, j)| {
-        sim_clifford.tableau[j][i]
+        sim_clifford.tableau.data[j][i]
     });
     let mut synthesis = GreedyCliffordSynthesis::new(tableau.view())?;
     let (_, new_gates) = synthesis.run()?;

--- a/crates/synthesis/src/clifford/utils.rs
+++ b/crates/synthesis/src/clifford/utils.rs
@@ -17,7 +17,17 @@ use qiskit_circuit::operations::{Param, StandardGate};
 use qiskit_quantum_info::clifford::Clifford;
 use smallvec::{SmallVec, smallvec};
 
-/// Symplectic matrix.
+/// A symplectic matrix representation.
+///
+/// Conceptually, a symplectic matrix is represented by a tableau in which the rows
+/// recorrespond to destabilizers and stabilizers, and the columns correspond
+/// to the X and Z components:
+///
+/// ```text
+/// [ destab_x | destab_z ]
+/// [  stab_x  |  stab_z  ]
+/// ```
+///
 /// Currently this class is internal to the synthesis library.
 pub struct SymplecticMatrix {
     /// Number of qubits.
@@ -175,35 +185,31 @@ pub fn clifford_from_gate_sequence(
         .iter()
         .try_for_each(|(gate, _params, qubits)| match *gate {
             StandardGate::S => {
-                clifford.tableau.append_s(qubits[0].index());
+                clifford.append_s(qubits[0].index());
                 Ok(())
             }
             StandardGate::Sdg => {
-                clifford.tableau.append_sdg(qubits[0].0 as usize);
+                clifford.append_sdg(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::SX => {
-                clifford.tableau.append_sx(qubits[0].0 as usize);
+                clifford.append_sx(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::SXdg => {
-                clifford.tableau.append_sxdg(qubits[0].0 as usize);
+                clifford.append_sxdg(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::H => {
-                clifford.tableau.append_h(qubits[0].index());
+                clifford.append_h(qubits[0].index());
                 Ok(())
             }
             StandardGate::CX => {
-                clifford
-                    .tableau
-                    .append_cx(qubits[0].index(), qubits[1].index());
+                clifford.append_cx(qubits[0].index(), qubits[1].index());
                 Ok(())
             }
             StandardGate::Swap => {
-                clifford
-                    .tableau
-                    .append_swap(qubits[0].index(), qubits[1].index());
+                clifford.append_swap(qubits[0].index(), qubits[1].index());
                 Ok(())
             }
             _ => Err(format!("Unsupported gate {gate:?}")),

--- a/crates/synthesis/src/clifford/utils.rs
+++ b/crates/synthesis/src/clifford/utils.rs
@@ -129,7 +129,7 @@ pub fn adjust_final_pauli_gates(
 
     // compute the phase difference
     let target_phase = target_tableau.column(2 * num_qubits);
-    let sim_phase = simulated_clifford.get_phase();
+    let sim_phase = simulated_clifford.tableau.get_phase();
 
     let delta_phase: Vec<bool> = target_phase
         .iter()
@@ -175,31 +175,35 @@ pub fn clifford_from_gate_sequence(
         .iter()
         .try_for_each(|(gate, _params, qubits)| match *gate {
             StandardGate::S => {
-                clifford.append_s(qubits[0].index());
+                clifford.tableau.append_s(qubits[0].index());
                 Ok(())
             }
             StandardGate::Sdg => {
-                clifford.append_sdg(qubits[0].0 as usize);
+                clifford.tableau.append_sdg(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::SX => {
-                clifford.append_sx(qubits[0].0 as usize);
+                clifford.tableau.append_sx(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::SXdg => {
-                clifford.append_sxdg(qubits[0].0 as usize);
+                clifford.tableau.append_sxdg(qubits[0].0 as usize);
                 Ok(())
             }
             StandardGate::H => {
-                clifford.append_h(qubits[0].index());
+                clifford.tableau.append_h(qubits[0].index());
                 Ok(())
             }
             StandardGate::CX => {
-                clifford.append_cx(qubits[0].index(), qubits[1].index());
+                clifford
+                    .tableau
+                    .append_cx(qubits[0].index(), qubits[1].index());
                 Ok(())
             }
             StandardGate::Swap => {
-                clifford.append_swap(qubits[0].index(), qubits[1].index());
+                clifford
+                    .tableau
+                    .append_swap(qubits[0].index(), qubits[1].index());
                 Ok(())
             }
             _ => Err(format!("Unsupported gate {gate:?}")),

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -148,97 +148,81 @@ pub fn run_litinski_transformation(
             match inst.op.view() {
                 OperationRef::StandardGate(StandardGate::I) => is_clifford = true,
                 OperationRef::StandardGate(StandardGate::X) => {
-                    clifford
-                        .tableau
-                        .append_x(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_x(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Y) => {
-                    clifford
-                        .tableau
-                        .append_y(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_y(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Z) => {
-                    clifford
-                        .tableau
-                        .append_z(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_z(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::H) => {
-                    clifford
-                        .tableau
-                        .append_h(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_h(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::S) => {
-                    clifford
-                        .tableau
-                        .append_s(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_s(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Sdg) => {
-                    clifford
-                        .tableau
-                        .append_sdg(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_sdg(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::SX) => {
-                    clifford
-                        .tableau
-                        .append_sx(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_sx(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::SXdg) => {
-                    clifford
-                        .tableau
-                        .append_sxdg(dag.get_qargs(inst.qubits)[0].index());
+                    clifford.append_sxdg(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CX) => {
-                    clifford.tableau.append_cx(
+                    clifford.append_cx(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CZ) => {
-                    clifford.tableau.append_cz(
+                    clifford.append_cz(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CY) => {
-                    clifford.tableau.append_cy(
+                    clifford.append_cy(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Swap) => {
-                    clifford.tableau.append_swap(
+                    clifford.append_swap(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::ISwap) => {
-                    clifford.tableau.append_iswap(
+                    clifford.append_iswap(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::ECR) => {
-                    clifford.tableau.append_ecr(
+                    clifford.append_ecr(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::DCX) => {
-                    clifford.tableau.append_dcx(
+                    clifford.append_dcx(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
@@ -265,10 +249,10 @@ pub fn run_litinski_transformation(
                                 is_clifford = true;
                                 match gate {
                                     StandardGate::RZ | StandardGate::Phase | StandardGate::U1 => {
-                                        clifford.tableau.append_rz(qubit, multiple)
+                                        clifford.append_rz(qubit, multiple)
                                     }
-                                    StandardGate::RX => clifford.tableau.append_rx(qubit, multiple),
-                                    StandardGate::RY => clifford.tableau.append_ry(qubit, multiple),
+                                    StandardGate::RX => clifford.append_rx(qubit, multiple),
+                                    StandardGate::RY => clifford.append_ry(qubit, multiple),
                                     _ => unreachable!(
                                         "We cannot have gates other than RZ/RX/RY/P/U1 at this point."
                                     ),
@@ -392,9 +376,7 @@ pub fn run_litinski_transformation(
                             is_ppr_angle_close_to_multiple_of_pi2(in_z, in_x, *angle, tol)
                         {
                             is_clifford = true;
-                            clifford
-                                .tableau
-                                .append_ppr(in_z, in_x, &indices_in, multiple)
+                            clifford.append_ppr(in_z, in_x, &indices_in, multiple)
                         }
                     }
                     if !is_clifford {

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -148,81 +148,97 @@ pub fn run_litinski_transformation(
             match inst.op.view() {
                 OperationRef::StandardGate(StandardGate::I) => is_clifford = true,
                 OperationRef::StandardGate(StandardGate::X) => {
-                    clifford.append_x(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_x(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Y) => {
-                    clifford.append_y(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_y(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Z) => {
-                    clifford.append_z(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_z(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::H) => {
-                    clifford.append_h(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_h(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::S) => {
-                    clifford.append_s(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_s(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Sdg) => {
-                    clifford.append_sdg(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_sdg(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::SX) => {
-                    clifford.append_sx(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_sx(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::SXdg) => {
-                    clifford.append_sxdg(dag.get_qargs(inst.qubits)[0].index());
+                    clifford
+                        .tableau
+                        .append_sxdg(dag.get_qargs(inst.qubits)[0].index());
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CX) => {
-                    clifford.append_cx(
+                    clifford.tableau.append_cx(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CZ) => {
-                    clifford.append_cz(
+                    clifford.tableau.append_cz(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::CY) => {
-                    clifford.append_cy(
+                    clifford.tableau.append_cy(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::Swap) => {
-                    clifford.append_swap(
+                    clifford.tableau.append_swap(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::ISwap) => {
-                    clifford.append_iswap(
+                    clifford.tableau.append_iswap(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::ECR) => {
-                    clifford.append_ecr(
+                    clifford.tableau.append_ecr(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
                     is_clifford = true
                 }
                 OperationRef::StandardGate(StandardGate::DCX) => {
-                    clifford.append_dcx(
+                    clifford.tableau.append_dcx(
                         dag.get_qargs(inst.qubits)[0].index(),
                         dag.get_qargs(inst.qubits)[1].index(),
                     );
@@ -249,10 +265,10 @@ pub fn run_litinski_transformation(
                                 is_clifford = true;
                                 match gate {
                                     StandardGate::RZ | StandardGate::Phase | StandardGate::U1 => {
-                                        clifford.append_rz(qubit, multiple)
+                                        clifford.tableau.append_rz(qubit, multiple)
                                     }
-                                    StandardGate::RX => clifford.append_rx(qubit, multiple),
-                                    StandardGate::RY => clifford.append_ry(qubit, multiple),
+                                    StandardGate::RX => clifford.tableau.append_rx(qubit, multiple),
+                                    StandardGate::RY => clifford.tableau.append_ry(qubit, multiple),
                                     _ => unreachable!(
                                         "We cannot have gates other than RZ/RX/RY/P/U1 at this point."
                                     ),
@@ -376,7 +392,9 @@ pub fn run_litinski_transformation(
                             is_ppr_angle_close_to_multiple_of_pi2(in_z, in_x, *angle, tol)
                         {
                             is_clifford = true;
-                            clifford.append_ppr(in_z, in_x, &indices_in, multiple)
+                            clifford
+                                .tableau
+                                .append_ppr(in_z, in_x, &indices_in, multiple)
                         }
                     }
                     if !is_clifford {


### PR DESCRIPTION
### Summary

This PR refactors the Rust `Clifford` structure,  allowing to store an arbitrary number of Paulis (in SIMD-packed form), as well as adds some additional usability functions `get_pauli_x`, `from_pauli_labels`. Both of these are needed for the followup PR #16581.

For better of for worse, I have called this structure `PauliList`, which is slightly different from the`PauliList` class in Python. The new Rust data structure stores Paulis as `Vec<FixedBitSet>`, where the elements of the vector correspond to x-, z- and phase- components of the Paulis in the list. In particular, this combines multiple Paulis into a SIMD-packed format, optimized for Clifford conjugation of all Paulis at once. Note that this was already present in the `Clifford` class, the refactoring simply allows an arbitrary number of Paulis. If someone thinks that having the same name as the existing Python class is confusing, they are welcome to suggest a better name, and I will gladly rename. Note that after this refactoring, the `PauliList` class in rust is conceptually identical to the `PauliSet` structure in Rustiq. 

The Clifford class now looks as follows:
```rust

pub struct Clifford {
    pub tableau: PauliList,
}
```
 
One detail is how to re-expose the functionality from the `PauliList` back to `Clifford`. I have probably not chosen a good solution, and replaced `clifford.some_method` by `clifford.tableau.some_method` every place a `Clifford` was used. Alternatively I considered implementing a `Deref` trait, however (if I understand this correctly) this is not an ideal solution either as Clifford is not just a list of `Paulis` but has additional mathematical structure and Clifford-specific methods. Another alternative I considered was to define the same methods in Clifford as well, something like 

```rust

impl Clifford {

fn some_method(&self) {
   self.tableau.some_method();
}
```
but this leads to a large number of boiler-plate code. I am not sure what is the best approach.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
