### PR TITLE
cext: fix UB writing to uninitialized buffers in transpile_layout C API

### DIFF
--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -107,12 +107,9 @@ pub unsafe extern "C" fn qk_transpile_layout_initial_layout(
         // SAFETY: Per the documentation initial_layout must be a valid pointer with a sufficient
         // allocation for the output array
         unsafe {
-            let out_slice =
-                std::slice::from_raw_parts_mut(initial_layout, out_initial_layout.len());
-            out_slice
-                .iter_mut()
-                .zip(out_initial_layout.iter())
-                .for_each(|(dest, src)| *dest = src.0);
+            for (i, src) in out_initial_layout.iter().enumerate() {
+                initial_layout.add(i).write(src.0);
+            }
         };
         true
     } else {
@@ -160,11 +157,9 @@ pub unsafe extern "C" fn qk_transpile_layout_output_permutation(
         // SAFETY: Per the documentation output_permutation must be a valid pointer with a sufficient
         // allocation for the output array
         unsafe {
-            let out_slice = std::slice::from_raw_parts_mut(output_permutation, permutation.len());
-            out_slice
-                .iter_mut()
-                .zip(permutation.iter())
-                .for_each(|(dest, src)| *dest = src.0);
+            for (i, src) in permutation.iter().enumerate() {
+                output_permutation.add(i).write(src.0);
+            }
         };
         true
     } else {
@@ -213,11 +208,9 @@ pub unsafe extern "C" fn qk_transpile_layout_final_layout(
     // SAFETY: Per the documentation final_layout must be a valid pointer with a sufficient
     // allocation for the output array
     unsafe {
-        let out_slice = std::slice::from_raw_parts_mut(final_layout, result.len());
-        out_slice
-            .iter_mut()
-            .zip(result.iter())
-            .for_each(|(dest, src)| *dest = src.0);
+        for (i, src) in result.iter().enumerate() {
+            final_layout.add(i).write(src.0);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #15370.

As identified by @jakelishman in https://github.com/Qiskit/qiskit/pull/15297#discussion_r2556111303, the three layout query functions in `crates/cext/src/transpiler/transpile_layout.rs` create a `&mut [u32]` slice over caller-provided uninitialized memory, which violates Rust's validity invariants even for write-only access.

**Functions fixed:**
- `qk_transpile_layout_initial_layout`
- `qk_transpile_layout_output_permutation`
- `qk_transpile_layout_final_layout`

## Change

Replace `std::slice::from_raw_parts_mut` + iterator pattern with direct raw pointer writes using `ptr.add(i).write(value)`:

```rust
// Before (UB — slice over uninitialized memory)
let out_slice = std::slice::from_raw_parts_mut(ptr, len);
out_slice.iter_mut().zip(data.iter()).for_each(|(dest, src)| *dest = src.0);

// After (safe — raw pointer write, no reference to uninitialized memory)
for (i, src) in data.iter().enumerate() {
    ptr.add(i).write(src.0);
}
```

The bug is only caught by Miri with `-Zmiri-recursive-validation`, which explains why existing tests pass.

## Test

Built cleanly with `cargo build -p qiskit-cext`. Existing tests unchanged.