### PR TITLE
Fix deadlock in Optimize1qGatesDecomposition

### DIFF
--- a/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
+++ b/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
@@ -367,6 +367,11 @@ impl Optimize1qGatesDecompositionState {
     }
 }
 
+struct AnalysisResults {
+    runs: Vec<Vec<NodeIndex>>,
+    sequences: Vec<Option<OneQubitGateSequence>>,
+}
+
 fn process_run(
     raw_run: &[NodeIndex],
     dag: &DAGCircuit,
@@ -471,10 +476,10 @@ pub fn py_run_optimize_1q_gates_decomposition(
     global_decomposers: Option<Vec<String>>,
 ) -> PyResult<()> {
     if getenv_use_multiple_threads() {
-        let (runs, sequences) = py.detach(|| {
+        let results = py.detach(|| {
             parallel_analyze_runs(dag, state, target, basis_gates, global_decomposers)
         })?;
-        apply_sequences(dag, runs, sequences)?;
+        apply_sequences(dag, results.runs, results.sequences)?;
     } else {
         let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
         for raw_run in runs {
@@ -504,7 +509,7 @@ fn parallel_analyze_runs(
     target: Option<&Target>,
     basis_gates: Option<HashSet<String>>,
     global_decomposers: Option<Vec<String>>,
-) -> PyResult<(Vec<Vec<NodeIndex>>, Vec<Option<OneQubitGateSequence>>)> {
+) -> PyResult<AnalysisResults> {
     let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
     let sequences = runs
         .par_iter()
@@ -519,7 +524,7 @@ fn parallel_analyze_runs(
             )
         })
         .collect::<PyResult<Vec<_>>>()?;
-    Ok((runs, sequences))
+    Ok(AnalysisResults { runs, sequences })
 }
 
 fn apply_sequences(
@@ -548,9 +553,8 @@ pub fn run_optimize_1q_gates_decomposition(
     global_decomposers: Option<Vec<String>>,
 ) -> PyResult<()> {
     if getenv_use_multiple_threads() {
-        let (runs, sequences) =
-            parallel_analyze_runs(dag, state, target, basis_gates, global_decomposers)?;
-        apply_sequences(dag, runs, sequences)?;
+        let results = parallel_analyze_runs(dag, state, target, basis_gates, global_decomposers)?;
+        apply_sequences(dag, results.runs, results.sequences)?;
     } else {
         let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
         for raw_run in runs {

--- a/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
+++ b/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
@@ -462,6 +462,84 @@ fn process_run(
 
 #[pyfunction]
 #[pyo3(name = "optimize_1q_gates_decomposition", signature = (dag, state, *, target=None, basis_gates=None, global_decomposers=None))]
+pub fn py_run_optimize_1q_gates_decomposition(
+    py: Python,
+    dag: &mut DAGCircuit,
+    state: &Optimize1qGatesDecompositionState,
+    target: Option<&Target>,
+    basis_gates: Option<HashSet<String>>,
+    global_decomposers: Option<Vec<String>>,
+) -> PyResult<()> {
+    if getenv_use_multiple_threads() {
+        let (runs, sequences) = py.detach(|| {
+            parallel_analyze_runs(dag, state, target, basis_gates, global_decomposers)
+        })?;
+        apply_sequences(dag, runs, sequences)?;
+    } else {
+        let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
+        for raw_run in runs {
+            let sequence = process_run(
+                &raw_run,
+                dag,
+                state,
+                target,
+                basis_gates.as_ref(),
+                global_decomposers.as_ref(),
+            )?;
+            if let Some(sequence) = sequence {
+                for gate in sequence.gates {
+                    dag.insert_1q_on_incoming_qubit((gate.0, &gate.1), raw_run[0]);
+                }
+                dag.add_global_phase(&Param::Float(sequence.global_phase))?;
+                dag.remove_1q_sequence(&raw_run);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parallel_analyze_runs(
+    dag: &mut DAGCircuit,
+    state: &Optimize1qGatesDecompositionState,
+    target: Option<&Target>,
+    basis_gates: Option<HashSet<String>>,
+    global_decomposers: Option<Vec<String>>,
+) -> PyResult<(Vec<Vec<NodeIndex>>, Vec<Option<OneQubitGateSequence>>)> {
+    let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
+    let sequences = runs
+        .par_iter()
+        .map(|raw_run| {
+            process_run(
+                raw_run,
+                dag,
+                state,
+                target,
+                basis_gates.as_ref(),
+                global_decomposers.as_ref(),
+            )
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok((runs, sequences))
+}
+
+fn apply_sequences(
+    dag: &mut DAGCircuit,
+    runs: Vec<Vec<NodeIndex>>,
+    sequences: Vec<Option<OneQubitGateSequence>>,
+) -> PyResult<()> {
+    runs.into_iter()
+        .zip(sequences)
+        .filter_map(|(raw_run, sequence)| sequence.map(|x| (raw_run, x)))
+        .try_for_each(|(raw_run, sequence)| -> PyResult<()> {
+            for gate in sequence.gates {
+                dag.insert_1q_on_incoming_qubit((gate.0, &gate.1), raw_run[0]);
+            }
+            dag.add_global_phase(&Param::Float(sequence.global_phase))?;
+            dag.remove_1q_sequence(&raw_run);
+            Ok(())
+        })
+}
+
 pub fn run_optimize_1q_gates_decomposition(
     dag: &mut DAGCircuit,
     state: &Optimize1qGatesDecompositionState,
@@ -469,33 +547,12 @@ pub fn run_optimize_1q_gates_decomposition(
     basis_gates: Option<HashSet<String>>,
     global_decomposers: Option<Vec<String>>,
 ) -> PyResult<()> {
-    let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
     if getenv_use_multiple_threads() {
-        let sequences = runs
-            .par_iter()
-            .map(|raw_run| {
-                process_run(
-                    raw_run,
-                    dag,
-                    state,
-                    target,
-                    basis_gates.as_ref(),
-                    global_decomposers.as_ref(),
-                )
-            })
-            .collect::<PyResult<Vec<_>>>()?;
-        runs.into_iter()
-            .zip(sequences)
-            .filter_map(|(raw_run, sequence)| sequence.map(|x| (raw_run, x)))
-            .try_for_each(|(raw_run, sequence)| -> PyResult<()> {
-                for gate in sequence.gates {
-                    dag.insert_1q_on_incoming_qubit((gate.0, &gate.1), raw_run[0]);
-                }
-                dag.add_global_phase(&Param::Float(sequence.global_phase))?;
-                dag.remove_1q_sequence(&raw_run);
-                Ok(())
-            })?;
+        let (runs, sequences) =
+            parallel_analyze_runs(dag, state, target, basis_gates, global_decomposers)?;
+        apply_sequences(dag, runs, sequences)?;
     } else {
+        let runs: Vec<Vec<NodeIndex>> = dag.collect_1q_runs().unwrap().collect();
         for raw_run in runs {
             let sequence = process_run(
                 &raw_run,
@@ -547,7 +604,7 @@ pub fn matmul_1q_with_slice(operator: &mut [[Complex64; 2]; 2], other: &[[Comple
 }
 
 pub fn optimize_1q_gates_decomposition_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_optimize_1q_gates_decomposition))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_optimize_1q_gates_decomposition))?;
     m.add_class::<Optimize1qGatesDecompositionState>()?;
     Ok(())
 }

--- a/releasenotes/notes/fix-deadlock-o1qgd-dcc90e816a66e6c0.yaml
+++ b/releasenotes/notes/fix-deadlock-o1qgd-dcc90e816a66e6c0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a potential deadlock in the :class:`.Optimize1qGatesDecomposition`
+    transpiler pass when run with custom defined single qubit gates in
+    a :class:`.QuantumCircuit` or :class:`.Target`.
+    Fixed `#16591 <https://github.com/Qiskit/qiskit/issues/16591>`__.

--- a/test/python/transpiler/test_optimize_1q_decomposition.py
+++ b/test/python/transpiler/test_optimize_1q_decomposition.py
@@ -17,7 +17,14 @@ import unittest
 import ddt
 import numpy as np
 
-from qiskit.circuit import QuantumRegister, QuantumCircuit, ClassicalRegister, Parameter, Gate
+from qiskit.circuit import (
+    QuantumRegister,
+    QuantumCircuit,
+    ClassicalRegister,
+    Parameter,
+    Gate,
+    Measure,
+)
 from qiskit.circuit.library.generalized_gates import UnitaryGate
 from qiskit.circuit.library.standard_gates import (
     UGate,
@@ -815,6 +822,34 @@ class TestOptimize1qGatesDecomposition(QiskitTestCase):
         expected = QuantumCircuit(1)
         expected.u(0, 0, 0.5, [0])
 
+        self.assertEqual(result, expected)
+
+    def test_custom_gate_in_target(self):
+        """Test reproduce of deadlock from: #16591."""
+
+        class CustomGate(Gate):
+            """Custom u1 gate."""
+
+            def __init__(self, lam):
+                super().__init__("custom_u1", 1, [lam])
+
+            def __array__(self, dtype=None, _copy=None):
+                return U1Gate(*self.params).__array__(dtype=dtype)
+
+        target = Target(num_qubits=2)
+        target.add_instruction(CustomGate(Parameter("lam")))
+        target.add_instruction(Measure())
+
+        qc = QuantumCircuit(2)
+        qc.append(CustomGate(0.5), [0])
+        qc.append(CustomGate(0.5), [1])
+        qc.measure_all()
+
+        result = Optimize1qGatesDecomposition(target)(qc)
+        expected = QuantumCircuit(2)
+        expected.append(CustomGate(0.5), [0])
+        expected.append(CustomGate(0.5), [1])
+        expected.measure_all()
         self.assertEqual(result, expected)
 
     def test_unitary_gate_row_major(self):


### PR DESCRIPTION
This commit fixes an oversight in the new multithreaded Optimize1qGatesDecomposition pass introduced in #15667 that could cause a deadlock with the Python GIL when using custom 1q gates. If there are custom gates defined in Python then we need Python to get the matrix of that custom gate. However, when running in a multithreaded context Python only allows one thread to interact with the interpreter at a time via the GIL. When operating in parallel the pass was not releasing the GIL from the parent thread running the pass. This meant that the children threads would wait to acquire the GIL to call Python but never be able to get the lock because the parent thread that spawned it never released the GIL.

This commit fixes that issue by adding a dedicate entrypoint for calling the pass via Python and having that entrypoint release the GIL prior to launching an parallel threads. It then reacquires the GIL before modifying the output DAG which might need Python for working with the custom gates. This mirrors the pattern used in the other parallel passes that work in a similar way such as `UnitarySynthesis` and `TwoQubitPeepholeOptimization`.

Fixes #16591

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
