### PR TITLE
Constrain `z3-solver` in macOS CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,3 +3,7 @@
 # usage, but our test suite uses an exact reference file that uses the
 # pydot 4 output, so we need to enforce that during tests.
 pydot>=4.0.0
+
+# z3-solver 5.0 fails to install/load in CI on macOS 15 / Python 3.10 jobs.  See
+# https://github.com/Qiskit/qiskit/issues/16601 for the current state.
+z3-solver<5.0; sys_platform == "darwin"


### PR DESCRIPTION
The 5.0.0.0 release of `z3-solver` emits a "not supported on this platform" error in the CI macos-15 ARM runners, even though it apparently installs.  See gh-16601 for more detail.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
