### PR TITLE
Fix CommutativeCancellation dropping negative X-rotation sums

### DIFF
--- a/crates/transpiler/src/passes/commutation_cancellation.rs
+++ b/crates/transpiler/src/passes/commutation_cancellation.rs
@@ -338,7 +338,11 @@ pub fn cancel_commutations(
                     } else if sx_supported && is_multiple_of_pi(total_angle, 0.5) {
                         let num_sx = (total_angle / FRAC_PI_2).round();
                         total_phase -= FRAC_PI_4 * num_sx;
-                        for _ in 0..(num_sx as i64) % 4 {
+                        // `num_sx` may be negative (e.g. two `sxdg`); `%` would return a
+                        // negative remainder and skip the loop entirely, incorrectly removing
+                        // the rotation.  `SX**4 == I` exactly, so the Euclidean remainder is
+                        // always a valid replacement.
+                        for _ in 0..(num_sx as i64).rem_euclid(4) {
                             dag.insert_1q_on_incoming_qubit((StandardGate::SX, &[]), cancel_set[0]);
                         }
                     } else {

--- a/releasenotes/notes/fix-commutative-cancellation-negative-sx-16594.yaml
+++ b/releasenotes/notes/fix-commutative-cancellation-negative-sx-16594.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.CommutativeCancellation` (run at ``optimization_level`` 2 and 3)
+    where a set of commuting X-axis rotations summing to a negative angle could be removed
+    entirely instead of being resynthesized as :class:`.SXGate` instructions, producing a
+    circuit that was not equivalent to the input.  For example, two ``sxdg`` gates separated
+    by a gate on another qubit were cancelled as if they formed the identity, when their
+    product is actually an :class:`.XGate`.
+    Fixed `#16594 <https://github.com/Qiskit/qiskit/issues/16594>`__.

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -958,6 +958,29 @@ measure q0[1] -> c0[1];
         # We don't cancel any gates with a custom rzz gate
         self.assertEqual(res.count_ops()["z"], 2)
 
+    def test_negative_sx_rotation_sum(self):
+        """Two ``sxdg`` separated by a commuting gate combine to X, not identity.
+
+        Reproduce from https://github.com/Qiskit/qiskit/issues/16594"""
+        qc = QuantumCircuit(2)
+        qc.sxdg(1)
+        qc.sx(0)
+        qc.sxdg(1)
+        res = PassManager([CommutativeCancellation()]).run(qc)
+        self.assertTrue(Operator(qc).equiv(Operator(res)))
+
+    def test_negative_x_rotation_sums(self):
+        """Combined X rotations with negative totals resynthesize correctly."""
+        for gates in [["sxdg"] * 2, ["sxdg"] * 3, ["sxdg"] * 4, ["sxdg", "x", "sxdg"]]:
+            with self.subTest(gates=gates):
+                qc = QuantumCircuit(2)
+                for i, name in enumerate(gates):
+                    getattr(qc, name)(1)
+                    if i == 0:
+                        qc.sx(0)
+                res = PassManager([CommutativeCancellation()]).run(qc)
+                self.assertTrue(Operator(qc).equiv(Operator(res)))
+
     def test_determinism(self):
         """Test that the pass produces structurally equivalent circuits."""
         # This is two CZ rings in a row.  If the cancellation order is non-deterministic and each


### PR DESCRIPTION
### Summary

Fixes #16594

`CommutativeCancellation` removed a commuting pair of `sxdg` gates as if they were the identity, even though `sxdg·sxdg = X` (up to global phase), producing wrong results at `optimization_level` ≥ 2.

### Details and comments

Root cause: in `crates/transpiler/src/passes/commutation_cancellation.rs`, the `sx` resynthesis branch computes the number of `SX` gates to insert as `(num_sx as i64) % 4`. Rust's `%` returns a negative remainder for negative inputs (e.g. two `sxdg` give a combined angle of −π → `num_sx = −2` → `-2 % 4 == -2`), so the insertion loop `0..-2` ran zero times and the rotation vanished.

Fix: use `rem_euclid(4)`. Since `SX⁴ == I` exactly (`RX(2π)·e^{iπ} = (−I)·(−1) = I`), inserting `num_sx.rem_euclid(4)` gates is algebraically identical to inserting `num_sx`, and the existing global-phase bookkeeping stays exact. The neighbouring `X` branch is safe for negative angles: a single `X` with phase `−π/2·num_x` is exact for every odd `num_x`, positive or negative.

Added a regression test with the issue reproducer plus a parametrized test over other negative-sum sequences (`sxdg×3`, `sxdg×4`, `sxdg·x·sxdg`), and a release note.

Test evidence: issue reproducer now folds to `sx×3` with `Operator.equiv == True`; full-transpile check equivalent at O1 and O3; `test_commutative_cancellation.py` 66 passed + 28 subtests; adjacent suites (`test_commutation_analysis`, `test_commutative_inverse_cancellation`, `test_optimize_1q_decomposition`) 191 passed; 300-circuit random fuzz over `x/sx/sxdg/rx` sequences with exact-π angles: 0 non-equivalent outputs.
