### PR TITLE
Infer MSRV in `tools/install_rust_msrv.sh`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ resolver = "2"
 [workspace.package]
 version = "2.6.0-dev"
 edition = "2024"
-rust-version = "1.87"  # Keep in sync with README.md, rust-toolchain.toml, and tools/install_rust_msrv.sh
+# Keep `rust-version` in sync with `README.md` and `rust-toolchain.toml`.
+rust-version = "1.87"
 license = "Apache-2.0"
 
 # Shared dependencies that can be inherited.  This just helps a little with

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
+set -e
+
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.87
-    rustup component add llvm-tools
-    rustup uninstall stable
+    msrv="$(python3 <<EOF
+from pathlib import Path
+import tomllib
+
+cargo_toml_file = Path("$0").absolute().parents[1] / "Cargo.toml"
+manifest = tomllib.load(open(cargo_toml_file, 'rb'))
+print(manifest["workspace"]["package"]["rust-version"])
+EOF
+)"
+    sh rust-installer/rustup.sh -y --default-toolchain "$msrv" --component llvm-tools
 fi
 . "$HOME/.cargo/env"


### PR DESCRIPTION
Since this is an executable, and Python 3.11+ has `tomllib` in the standard library, this just makes one fewer place to update on MSRV bumps.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

---

This is just a proposal - there's also a cost in having more complex logic in scripts.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
