### PR TITLE
Fix failure reporting on Windows CI runners

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -72,8 +72,6 @@ jobs:
           stestr run --slowest --abbreviate
         shell: bash
         env:
-          LANG: "C.UTF-8"
-          PYTHONIOENCODING: "utf-8:backslashreplace"
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE
           RUST_BACKTRACE: 1

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -50,38 +50,37 @@ jobs:
         run: 'echo "QISKIT_BUILD_WITH_MIMALLOC=1" >> $GITHUB_ENV'
       - name: Install dependencies
         run: |
+          set -e
           python -m venv test-job
-          .\test-job\Scripts\activate
+          source ./test-job/Scripts/activate
           python -m pip install -U pip
-          python -m pip install -U `
-            -c constraints.txt `
-            --group test `
+          python -m pip install -U \
+            -c constraints.txt \
+            --group test \
+            ${EXTRA_GROUPS} \
             -e .
-          pip check
-      - name: Install Optional packages
-        run: |
-          .\test-job\Scripts\activate
-          pip install -c constraints.txt --group optionals-all
-          pip check
-        if: ${{ inputs.install-optionals }}
+        shell: bash
+        env:
+          EXTRA_GROUPS: ${{ inputs.install-optionals && '--group optionals-all' || '' }}
       - name: Run Tests
         run: |
-          chcp.com 65001
-          .\test-job\Scripts\activate
+          set -e
+          source ./test-job/Scripts/activate
           python tools/report_numpy_state.py
-          $Env:PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
+          export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
           stestr run --slowest --abbreviate
-      - name: Filter stestr history
-        run: |
-          .\test-job\Scripts\activate
-          stestr history remove all
+        shell: bash
         env:
           LANG: "C.UTF-8"
           PYTHONIOENCODING: "utf-8:backslashreplace"
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE
           RUST_BACKTRACE: 1
+      - name: Filter stestr history
+        run: |
+          .\test-job\Scripts\activate
+          stestr history remove all
       - name: Copy and Publish images
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}


### PR DESCRIPTION
The Windows unit test runs were somewhat misconfigured. The were previously failing to propagate failures in the set-up jobs up to the exit status of the shell, which manifested as errors around locating an `stestr` executable while trying to run the test suite when the actual error was in a `pip install` command in a prior step.  This was masked because `cmd.exe` doesn't have an easy equivalent to `set -e` (or at least, not one I know / found out about), and the last command in the installation step was a `pip check`.

Separately, the environment configuration for the test-runner step had got lost, and was being applied only to the `stestr history` pruning.

The easiest fix for this is just to centralise everything on `bash` and use its `set -e`.  Inserting an extra `--group optionals` by variable expansion allows us to install all the packages in a single step, obviating the need for a `pip check` anyway.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
