### PR TITLE
Reduce dependabot Rust updates to one group a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      cargo:
+        patterns: ['*']
     labels:
       - "Rust"
       - "dependencies"


### PR DESCRIPTION
Our most important Rust packages are no longer managed by Dependabot because they almost always require significant manual intervention.  The remaining ones are minor, but due to complexity in our cross-dependency use of `hashbrown` and `num-bigint` in particular, Dependabot always inadvertently introduces breakages that need to be fixed by hand.

This aims to drastically reduce the number of Dependabot PRs we have to deal with for the `cargo` ecosystem, without compromising on getting the updates in a mostly timely manner.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
