### PR TITLE
Fix transpiler error message with routing_pass when layout_trials or swap_trials is set

### DIFF
--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -171,7 +171,7 @@ class SabreLayout(TransformationPass):
             if self._coupling_map is not None:
                 self._coupling_map.make_symmetric()
         if routing_pass is not None and (swap_trials is not None or layout_trials is not None):
-            raise TranspilerError("Both routing_pass and swap_trials can't be set at the same time")
+            raise TranspilerError("The 'routing_pass' argument cannot be set alongside 'swap_trials' or 'layout_trials'.")
         self.routing_pass = routing_pass
         self.seed = seed
         self.max_iterations = max_iterations

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -171,7 +171,9 @@ class SabreLayout(TransformationPass):
             if self._coupling_map is not None:
                 self._coupling_map.make_symmetric()
         if routing_pass is not None and (swap_trials is not None or layout_trials is not None):
-            raise TranspilerError("The 'routing_pass' argument cannot be set alongside 'swap_trials' or 'layout_trials'.")
+            raise TranspilerError(
+                "The 'routing_pass' argument cannot be set alongside 'swap_trials' or 'layout_trials'."
+            )
         self.routing_pass = routing_pass
         self.seed = seed
         self.max_iterations = max_iterations

--- a/releasenotes/notes/fix-sabre-layout-error-message-829bf2b51cdc3374.yaml
+++ b/releasenotes/notes/fix-sabre-layout-error-message-829bf2b51cdc3374.yaml
@@ -1,0 +1,9 @@
+fixes:
+  - |
+    Fixes a misleading ``TranspilerError`` message when attempting to specify a custom
+    ``routing_pass`` alongside built-in optimization trials. The error string now correctly
+    identifies that ``routing_pass`` is mutually exclusive with both ``swap_trials`` and
+    ``layout_trials``.
+
+    Fix `#16632 <https://github.com/Qiskit/qiskit/issues/16632>`__.
+

--- a/releasenotes/notes/fix-sabre-layout-error-message-829bf2b51cdc3374.yaml
+++ b/releasenotes/notes/fix-sabre-layout-error-message-829bf2b51cdc3374.yaml
@@ -1,9 +1,6 @@
 fixes:
   - |
-    Fixes a misleading ``TranspilerError`` message when attempting to specify a custom
-    ``routing_pass`` alongside built-in optimization trials. The error string now correctly
-    identifies that ``routing_pass`` is mutually exclusive with both ``swap_trials`` and
-    ``layout_trials``.
-
-    Fix `#16632 <https://github.com/Qiskit/qiskit/issues/16632>`__.
+    The error message from :class:`.SabreLayout` when setting incompatible
+    arguments now correctly states the limitations. See `#16632
+    <https://github.com/Qiskit/qiskit/issues/16632>`__.
 


### PR DESCRIPTION
This PR improves the clarity of the TranspilerError message when SabreLayout is called with `routing_pass` argument and `layout_trials` at the same time. 


Fix issue #16632 

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Gemini Pro 3.1 (just for the release notes english correction)

