### PR TITLE
Reword `qiskit.passmanager` docs

### DIFF
--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -20,57 +20,70 @@ Passmanager (:mod:`qiskit.passmanager`)
 Overview
 ========
 
-The Qiskit pass manager is somewhat inspired by the `LLVM compiler <https://llvm.org/>`_,
-but it is designed to take a Python object as an input instead of plain source code.
+The Qiskit pass manager is inspired by the `LLVM compiler <https://llvm.org/>`_.
+The compiler infrastructure separates responsibilities into three main components;
+tasks, flow controllers, and pass managers.
 
-The pass manager converts the input Python object into an intermediate representation (IR),
-and it can be optimized and get lowered with a variety of transformations over multiple passes.
-The pass manager framework may employ multiple IRs with interleaved conversion passes,
-depending on the context of the compilation. Finally, the IR is converted back to some Python object.
-Note that the input type and output type are not necessarily the same.
+A compilation pipeline executes a sequence of :class:`Task` objects, each of which
+takes an intermediate representation (IR) as input, performs work, and returns an output IR.
+Where :class:`Task` defines the interface, an atomic task is a *pass*, which subclasses
+:class:`GenericPass` and implements its abstract :meth:`~GenericPass.run` method.
+This is the class that should be used as base class when implementing a custom compiler pass.
 
-Compilation in the pass manager is a chain of :class:`~.passmanager.Task` executions that
-take an IR and output a new IR with some optimization or data analysis.
-An atomic task is a *pass* which is a subclass of :class:`.GenericPass` that implements
-a :meth:`.~GenericPass.run` method that performs some work on the received IR.
-A set of passes may form a *flow controller*, which is a subclass of
-:class:`.BaseController`, which can implement arbitrary compilation-state-dependent logic for
-deciding which pass will get run next.
-Passes share intermediate data via the :class:`.PropertySet` object which is
-a free-form dictionary. A pass can populate the property set dictionary during the task execution.
-A flow controller can also consume the property set to control the pass execution,
-but this access must be read-only.
+Flow controllers provide execution models for a set of tasks.
+The simplest flow controller is a :class:`FlowControllerLinear`, which simply executes
+a set of tasks in a linear sequence.
+More advanced flow controllers include loops or conditional execution.
+These are, for example, used in Qiskit's preset transpiler pipelines for higher optimization
+levels where optimizations are run until a convergence criterion is met.
+
+Pass managers are responsible for managing the tasks, including scheduling required analyses and
+enabling modification of the task sequence by the user.
+Qiskit provides two IR-generic pass managers in this module, and pass manager specialized
+to :class:`.DAGCircuit` as IR in :mod:`qiskit.transpiler`. The IR-generic ones are:
+
+* :class:`BasePassManager`: a pass manager with fixed IR. This pass manager allows modifying the
+  set of tasks to be run and supports parallel execution of multiple inputs by means
+  of :func:`.parallel_map`. This class has support for additional conversion of an input program
+  representation to the internal IR, and a conversion to an output program format.
+
+  The :class:`BasePassManager` is the base class for Qiskit's preset pass managers
+  for :class:`.DAGCircuit` transpilation, such as returned by :func:`.generate_preset_pass_manager`.
+  There, implicit conversions to and from :class:`.QuantumCircuit` as input and output program
+  format are used.
+
+* :class:`MultiStagePassManager`: a staged pass manager where each stage can preserve or lower the IR.
+  A stage is defined by a :class:`~.passmanager.Task` or an iterable thereof, which can
+  also be grouped inside a :class:`BasePassManager`.
+  The stages must be set up such that the output IR of the current stage matches the input IR
+  of the next stage, there are (currently) no automatic translations.
+
+Pass managers also provide infrastructure to pass a :class:`PropertySet` with context-information
+through every task and a callback function for introspection.
+The :class:`PropertySet` is a free-form dictionary, which can be populated and read by a pass during
+execution, or read by a flow-controller to control pass execution.
 The property set is portable and handed over from pass to pass at execution.
-In addition to the property set, tasks also receive a :class:`.WorkflowStatus` data structure.
+In addition to the property set, tasks also receive a :class:`WorkflowStatus` data structure.
 This object is initialized when the pass manager is run and handed over to underlying tasks.
 The status is updated after every pass is run, and contains information about the pipeline state
 (number of passes run, failure state, and so on) as opposed to the :class:`PropertySet`, which
 contains information about the IR being optimized.
 
-A :class:`BasePassManager` is a wrapper of the flow controller, with responsibilities of
+The callback is called by :class:`GenericPass` instances expecting the following signature:
 
-* Scheduling tasks,
-* Converting an input Python object to an internal IR,
-* Initializing a property set and workflow status,
-* Running scheduled tasks to apply a series of transformations to the IR,
-* Converting the IR back to an output Python object.
+.. code-block:: python
 
-This indicates that the flow controller itself is type-agnostic, and a developer must
-implement a subclass of the :class:`BasePassManager` to manage the data conversion steps.
-This *veil of ignorance* allows us to choose the most efficient data representation
-for a particular pass manager task, while we can reuse the flow control machinery
-for different input and output types.
+    def callback(
+        task: Task[IR_IN, IR_OUT],
+        passmanager_ir: IR_OUT,
+        property_set: PropertySet,
+        running_time: float,
+        count: int
+    ) -> None:
+        ...
 
-A single flow controller always takes a single IR object, and returns a single
-IR object. Parallelism for multiple input objects is supported by the
-:class:`BasePassManager` by broadcasting the flow controller via
-the :func:`.parallel_map` function.
-
-The :class:`MultiStagePassManager` allows constructing staged compiler workflows with
-multiple IRs. A stage is defined by a :class:`~.passmanager.Task` or an iterable thereof, which can
-also be grouped inside a :class:`BasePassManager`.
-The stages must be set up such that the output IR of the current stage matches the input IR
-of the next stage, there are (currently) no automatic translations.
+Note that this signature differs slightly for passes and pass managers defined in the
+:mod:`qiskit.transpiler` module.
 
 
 Examples
@@ -206,16 +219,14 @@ See details in the following class API documentation.
 Interface
 =========
 
-Base classes
-------------
+Passes
+------
 
 .. autosummary::
    :toctree: ../stubs/
 
-   BasePassManager
-   BaseController
    GenericPass
-
+   Task
 
 Pass managers
 -------------
@@ -223,6 +234,7 @@ Pass managers
 .. autosummary::
    :toctree: ../stubs/
 
+   BasePassManager
    MultiStagePassManager
 
 Flow controllers
@@ -231,6 +243,7 @@ Flow controllers
 .. autosummary::
    :toctree: ../stubs/
 
+   BaseController
    FlowControllerLinear
    ConditionalController
    DoWhileController
@@ -258,7 +271,7 @@ from .flow_controllers import (
     ConditionalController,
     DoWhileController,
 )
-from .base_tasks import GenericPass, BaseController
+from .base_tasks import GenericPass, BaseController, Task
 from .compilation_status import PropertySet, WorkflowStatus, PassManagerState
 from .exceptions import PassManagerError
 
@@ -273,5 +286,6 @@ __all__ = [
     "PassManagerError",
     "PassManagerState",
     "PropertySet",
+    "Task",
     "WorkflowStatus",
 ]

--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -21,7 +21,7 @@ Overview
 ========
 
 The Qiskit pass manager is inspired by the `LLVM compiler <https://llvm.org/>`_.
-The compiler infrastructure separates responsibilities into three main components;
+The compiler infrastructure separates responsibilities into three main components:
 tasks, flow controllers, and pass managers.
 
 A compilation pipeline executes a sequence of :class:`Task` objects, each of which
@@ -39,7 +39,7 @@ levels where optimizations are run until a convergence criterion is met.
 
 Pass managers are responsible for managing the tasks, including scheduling required analyses and
 enabling modification of the task sequence by the user.
-Qiskit provides two IR-generic pass managers in this module, and pass manager specialized
+Qiskit provides two IR-generic pass managers in this module, and a pass manager specialized
 to :class:`.DAGCircuit` as IR in :mod:`qiskit.transpiler`. The IR-generic ones are:
 
 * :class:`BasePassManager`: a pass manager with fixed IR. This pass manager allows modifying the
@@ -74,6 +74,7 @@ The callback is called by :class:`GenericPass` instances expecting the following
 .. code-block:: python
 
     def callback(
+        *,
         task: Task[IR_IN, IR_OUT],
         passmanager_ir: IR_OUT,
         property_set: PropertySet,

--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -25,9 +25,9 @@ The compiler infrastructure separates responsibilities into three main component
 tasks, flow controllers, and pass managers.
 
 A compilation pipeline executes a sequence of :class:`Task` objects, each of which
-takes an intermediate representation (IR) as input, performs work, and returns an output IR.
-Where :class:`Task` defines the interface, an atomic task is a *pass*, which subclasses
-:class:`GenericPass` and implements its abstract :meth:`~GenericPass.run` method.
+takes an intermediate representation (IR) as input, performs work, and returns a, possibly
+different, IR as output. Where :class:`Task` defines the interface, an atomic task is a *pass*,
+which subclasses :class:`GenericPass` and implements its abstract :meth:`~GenericPass.run` method.
 This is the class that should be used as base class when implementing a custom compiler pass.
 
 Flow controllers provide execution models for a set of tasks.

--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -31,7 +31,7 @@ IR_OUT = TypeVar("IR_OUT")
 class Task(ABC, Generic[IR, IR_OUT]):
     """An interface of the pass manager task.
 
-    The task takes an IR, and outputs a (possible different) IR after some operation on it.
+    The task takes an IR, and outputs a (possibly different) IR after some operation on it.
     A task can rely on the :class:`.PropertySet` to communicate intermediate data among tasks.
     """
 

--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -31,7 +31,7 @@ IR_OUT = TypeVar("IR_OUT")
 class Task(ABC, Generic[IR, IR_OUT]):
     """An interface of the pass manager task.
 
-    The task takes a Qiskit IR, and outputs new Qiskit IR after some operation on it.
+    The task takes an IR, and outputs a (possible different) IR after some operation on it.
     A task can rely on the :class:`.PropertySet` to communicate intermediate data among tasks.
     """
 


### PR DESCRIPTION
Reword the `qiskit.passmanager` docs page to clearly distinguish into tasks, flow controllers and pass managers as 3 components. This attempts to more clearly describe pass managers as scheduling and customizing task sequences and explain that the flow controllers are the actual execution engine. Also this phrases the input and output conversions as feature of `BasePassManager`, not as general behavior of pass managers.

We could expand the example to write a multi-IR pass manager. While it would be great to have a workflow using e.g. Qiskit Fermions, maybe the more permanent example would be based just on the numeric toy example below.

Closes #16297.
Closes #16150.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
