### PR TITLE
Preserve StatePreparation width in inverse

### DIFF
--- a/qiskit/circuit/library/data_preparation/state_preparation.py
+++ b/qiskit/circuit/library/data_preparation/state_preparation.py
@@ -207,7 +207,11 @@ class StatePreparation(Gate):
             None if self._label in ("State Preparation", "State Preparation Dg") else self._label
         )
 
-        return StatePreparation(self._params_arg, inverse=not self._inverse, label=label)
+        # Integer states can have an explicit width that cannot be inferred from the value.
+        num_qubits = self.num_qubits if self._from_int else None
+        return StatePreparation(
+            self._params_arg, num_qubits=num_qubits, inverse=not self._inverse, label=label
+        )
 
     def broadcast_arguments(self, qargs, cargs):
         flat_qargs = [qarg for sublist in qargs for qarg in sublist]

--- a/releasenotes/notes/fix-stateprep-inverse-width-16430.yaml
+++ b/releasenotes/notes/fix-stateprep-inverse-width-16430.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed :meth:`.StatePreparation.inverse` so integer-bitmap inputs preserve an explicit
+    ``num_qubits`` value when constructing the inverse gate.
+    See `#16430 <https://github.com/Qiskit/qiskit/issues/16430>`__.

--- a/test/python/circuit/library/test_state_preparation.py
+++ b/test/python/circuit/library/test_state_preparation.py
@@ -90,6 +90,14 @@ class TestStatePreparation(QiskitTestCase):
         actual_sv = Statevector(qc)
         self.assertTrue(desired_sv == actual_sv)
 
+    def test_inverse_preserves_integer_state_width(self):
+        """Test inverse preserves explicit qubit count for integer states."""
+        qc = QuantumCircuit(2)
+        stateprep = StatePreparation(1, num_qubits=2)
+        qc.append(stateprep, [0, 1])
+        qc.append(stateprep.inverse(), [0, 1])
+        self.assertTrue(np.allclose(Operator(qc).data, np.identity(2**qc.num_qubits)))
+
     def test_incompatible_state_and_qubit_args(self):
         """Test error raised if number of qubits not compatible with state arg"""
         qc = QuantumCircuit(3)


### PR DESCRIPTION
## Summary

Fix #16430.

`StatePreparation.inverse()` rebuilt the inverse gate from the stored integer
value alone, so an explicit `num_qubits` given at construction was lost. For
integer inputs the constructor then re-inferred the minimal width from the
value, e.g. `StatePreparation(1, num_qubits=2).inverse()` collapsed to a
1-qubit gate.

The fix forwards the original width when rebuilding the inverse, but only for
integer-backed instances — `num_qubits` is invalid for label and vector inputs,
so those paths are unchanged.

## Tests

Added a regression that appends `StatePreparation(1, num_qubits=2)` and its
inverse on the same 2-qubit circuit and checks the result is the identity.

```
python -m unittest test.python.circuit.library.test_state_preparation -v
```

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to understand this PR: Claude and ChatGPT
