### PR TITLE
Fix non-determinism in `DAGCircuit::remove_qubits`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5398,7 +5398,7 @@ impl DAGCircuit {
         &mut self,
         qubits: T,
     ) -> Result<(), DAGError> {
-        let qubits: HashSet<Qubit> = qubits.into_iter().collect();
+        let qubits: IndexSet<Qubit> = qubits.into_iter().collect();
 
         let mut busy_bits = Vec::new();
         for bit in qubits.iter() {
@@ -5532,7 +5532,7 @@ impl DAGCircuit {
         &mut self,
         clbits: T,
     ) -> Result<(), DAGError> {
-        let clbits: HashSet<Clbit> = clbits.into_iter().collect();
+        let clbits: IndexSet<Clbit> = clbits.into_iter().collect();
         let mut busy_bits = Vec::new();
         for bit in clbits.iter() {
             if !self.is_wire_idle(Wire::Clbit(*bit)) {

--- a/releasenotes/notes/fix-remove-qubits-determinism-411c539483747ed5.yaml
+++ b/releasenotes/notes/fix-remove-qubits-determinism-411c539483747ed5.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a non-determinism of the edge-removal order in :meth:`.DAGCircuit.remove_qubits` and
+    :meth:`~.DAGCircuit.remove_clbits`.  This caused later edge additions to have non-deterministic 
+    identifiers, affecting some traversal algorithms.  See `#16655
+    <https://github.com/Qiskit/qiskit/issues/16655>`__.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -402,6 +402,50 @@ class TestDagRegisters(DAGTest):
         with self.assertRaises(DAGCircuitError):
             dag.find_bit(new_bit)
 
+    def test_remove_qubits_determinism(self):
+        """Regression test of gh-16655."""
+
+        def build() -> DAGCircuit:
+            in_reg = QuantumRegister(4, "f")
+            in_dag = DAGCircuit()
+            in_dag.add_qreg(in_reg)
+
+            out_reg = QuantumRegister(4, "q")
+            out_dag = in_dag.copy_empty_like()
+            out_dag.add_qreg(out_reg)
+            out_dag.remove_qregs(in_reg)
+            out_dag.remove_qubits(*in_reg)
+            out_dag.apply_operation_back(XGate(), (out_dag.qubits[0],), ())
+            out_dag.apply_operation_back(XGate(), (out_dag.qubits[1],), ())
+            return out_dag
+
+        base = build()
+        dags = [build() for _ in range(10)]
+        self.assertEqual([base.structurally_equal(dag) for dag in dags], [True] * len(dags))
+
+    def test_remove_clbits_determinism(self):
+        """Regression test of gh-16655."""
+
+        def build() -> DAGCircuit:
+            qr = QuantumRegister(4, "q")
+            in_reg = ClassicalRegister(4, "f")
+            in_dag = DAGCircuit()
+            in_dag.add_qreg(qr)
+            in_dag.add_creg(in_reg)
+
+            out_reg = ClassicalRegister(4, "c")
+            out_dag = in_dag.copy_empty_like()
+            out_dag.add_creg(out_reg)
+            out_dag.remove_cregs(in_reg)
+            out_dag.remove_clbits(*in_reg)
+            out_dag.apply_operation_back(Measure(), (out_dag.qubits[0],), (out_dag.clbits[0],))
+            out_dag.apply_operation_back(Measure(), (out_dag.qubits[1],), (out_dag.clbits[1],))
+            return out_dag
+
+        base = build()
+        dags = [build() for _ in range(10)]
+        self.assertEqual([base.structurally_equal(dag) for dag in dags], [True] * len(dags))
+
 
 class TestDagWireRemoval(DAGTest):
     """Test removal of registers and idle wires."""


### PR DESCRIPTION
A classical hash-map iteration, but subtle because all the same removals were made, so the effect was a re-ordering of the free list and thus required later additions to become observable.

Fix #16655
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
