### PR TITLE
Fix `ControlledGate.to_matrix` fallback

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -281,14 +281,14 @@ class ControlledGate(Gate):
     def to_matrix(self):
         """Return a matrix representation of the controlled gate."""
         if hasattr(self, "__array__"):
-            return super().to_matrix()
-        if (
-            self.base_gate is None
-            or self.num_qubits != self.num_ctrl_qubits + self.base_gate.num_qubits
-        ):
-            return super().to_matrix()
+            return self.__array__(dtype=complex)
+        if self.base_gate is None:
+            raise CircuitError(f"to_matrix not defined for {type(self)}")
+        has_ancillas = self.num_qubits != self.num_ctrl_qubits + self.base_gate.num_qubits
+        if has_ancillas:
+            raise CircuitError(f"to_matrix not defined for {type(self)}")
         try:
             base_matrix = self.base_gate.to_matrix()
         except (AttributeError, CircuitError, TypeError, ValueError) as ex:
-            raise CircuitError(f"to_matrix not defined for this {type(self)}") from ex
+            raise CircuitError(f"to_matrix not defined for {type(self)}") from ex
         return _compute_control_matrix(base_matrix, self.num_ctrl_qubits, self.ctrl_state)

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -282,8 +282,6 @@ class ControlledGate(Gate):
         """Return a matrix representation of the controlled gate."""
         if hasattr(self, "__array__"):
             return self.__array__(dtype=complex)
-        if self.base_gate is None:
-            raise CircuitError(f"to_matrix not defined for {type(self)}")
         has_ancillas = self.num_qubits != self.num_ctrl_qubits + self.base_gate.num_qubits
         if has_ancillas:
             raise CircuitError(f"to_matrix not defined for {type(self)}")

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -21,7 +21,7 @@ from qiskit.circuit.exceptions import CircuitError
 from . import QuantumRegister
 from .quantumcircuit import QuantumCircuit
 from .gate import Gate
-from ._utils import _ctrl_state_to_int
+from ._utils import _compute_control_matrix, _ctrl_state_to_int
 
 
 if TYPE_CHECKING:
@@ -277,3 +277,18 @@ class ControlledGate(Gate):
         else:
             inverse_gate = super().inverse(annotated=annotated)
         return inverse_gate
+
+    def to_matrix(self):
+        """Return a matrix representation of the controlled gate."""
+        if hasattr(self, "__array__"):
+            return super().to_matrix()
+        if (
+            self.base_gate is None
+            or self.num_qubits != self.num_ctrl_qubits + self.base_gate.num_qubits
+        ):
+            return super().to_matrix()
+        try:
+            base_matrix = self.base_gate.to_matrix()
+        except (AttributeError, CircuitError, TypeError, ValueError) as ex:
+            raise CircuitError(f"to_matrix not defined for this {type(self)}") from ex
+        return _compute_control_matrix(base_matrix, self.num_ctrl_qubits, self.ctrl_state)

--- a/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
+++ b/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed :meth:`.ControlledGate.to_matrix` for controlled gates such as
-    :meth:`.CSXGate.inverse` whose base gate already defines a matrix.
+    :meth:`.CSXGate` whose base gate already defines a matrix.
     Fixed `#10396 <https://github.com/Qiskit/qiskit/issues/10396>`__.

--- a/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
+++ b/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed :meth:`.ControlledGate.to_matrix` for controlled gates such as
-    ``CSXGate().inverse()`` whose base gate already defines a matrix.
-    See `#10396 <https://github.com/Qiskit/qiskit/issues/10396>`__.
+    :meth:`.CSXGate.inverse` whose base gate already defines a matrix.
+    Fixed `#10396 <https://github.com/Qiskit/qiskit/issues/10396>`__.

--- a/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
+++ b/releasenotes/notes/fix-controlledgate-to-matrix-6e65f6f602f4e3d8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed :meth:`.ControlledGate.to_matrix` for controlled gates such as
+    ``CSXGate().inverse()`` whose base gate already defines a matrix.
+    See `#10396 <https://github.com/Qiskit/qiskit/issues/10396>`__.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -277,6 +277,13 @@ class TestControlledGate(QiskitTestCase):
                     # CX is treated like a primitive within Terra, and doesn't have a definition.
                     self.assertTrue(Operator(special_case_gate.definition).equiv(naive_operator))
 
+    def test_inverse_controlled_gate_to_matrix(self):
+        """Test to_matrix for a plain controlled gate returned from inverse()."""
+        gate = CSXGate().inverse()
+        expected = CSXGate().to_matrix().conj().T
+
+        np.testing.assert_allclose(gate.to_matrix(), expected)
+
     def test_global_phase_control(self):
         """Test creation of a GlobalPhaseGate."""
         base = GlobalPhaseGate(np.pi / 7)

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -284,6 +284,34 @@ class TestControlledGate(QiskitTestCase):
 
         np.testing.assert_allclose(gate.to_matrix(), expected)
 
+    def test_generic_controlled_gate_to_matrix(self):
+        """Test to_matrix for a plain ControlledGate with a matrix-defined base gate."""
+        gate = ControlledGate(
+            "csx",
+            2,
+            [],
+            num_ctrl_qubits=1,
+            ctrl_state=0,
+            base_gate=SXGate(),
+        )
+        expected = _compute_control_matrix(SXGate().to_matrix(), 1, ctrl_state=0)
+
+        np.testing.assert_allclose(gate.to_matrix(), expected)
+
+    def test_controlled_gate_to_matrix_without_base_matrix_raises(self):
+        """Test to_matrix fails if the base gate has no matrix."""
+        gate = ControlledGate("cgate", 2, [], num_ctrl_qubits=1, base_gate=Gate("gate", 1, []))
+
+        with self.assertRaisesRegex(CircuitError, "to_matrix not defined"):
+            gate.to_matrix()
+
+    def test_controlled_gate_to_matrix_with_ancillas_raises(self):
+        """Test to_matrix fails if the controlled gate uses ancilla qubits."""
+        gate = ControlledGate("cgate", 3, [], num_ctrl_qubits=1, base_gate=XGate())
+
+        with self.assertRaisesRegex(CircuitError, "to_matrix not defined"):
+            gate.to_matrix()
+
     def test_global_phase_control(self):
         """Test creation of a GlobalPhaseGate."""
         base = GlobalPhaseGate(np.pi / 7)


### PR DESCRIPTION
## Summary

Fix `ControlledGate.to_matrix()` for plain controlled gates whose base gate defines a matrix. Fix #10396.

## Details

`CSXGate().inverse()` returns a plain `ControlledGate` around the inverse base gate, which has no `__array__`, so the inherited `Gate.to_matrix()` raised `CircuitError` even though the operation has a well-defined matrix.

`ControlledGate.to_matrix()` now delegates to the existing path first for subclasses that define `__array__` (so standard gates like `CXGate` are unchanged). Otherwise, if the gate has no extra ancilla qubits and its base gate has a matrix, it builds the controlled matrix with the existing `_compute_control_matrix` helper. Controlled gates with ancillas or a base gate without a matrix still raise, as before.

## Tests

- `test_inverse_controlled_gate_to_matrix` checks `CSXGate().inverse().to_matrix()` equals `CSXGate().to_matrix().conj().T`.
- Existing `TestOpenControlledToMatrix` and `TestControlledStandardGates` still pass.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tools to understand this PR: Claude and ChatGPT
