### PR TITLE
Remove obsolete QPY per-circuit Rust bindings

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -27,7 +27,7 @@ use numpy::IntoPyArray;
 use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyAny, PyBytes, PyDict, PyList, PyString, PyTuple, PyType};
+use pyo3::types::{IntoPyDict, PyAny, PyDict, PyList, PyString, PyTuple, PyType};
 use qiskit_circuit::bit::{
     ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
@@ -1620,40 +1620,6 @@ pub(crate) fn unpack_circuit(
         circuit.setattr("_layout", layout)?;
     }
     Ok(circuit.unbind().as_any().clone())
-}
-
-#[pyfunction]
-#[pyo3(name = "read_circuit")]
-#[pyo3(signature = (file_obj, version, metadata_deserializer, use_symengine, annotation_factories))]
-pub(crate) fn py_read_circuit(
-    py: Python,
-    file_obj: &Bound<PyAny>,
-    version: u8,
-    metadata_deserializer: &Bound<PyAny>,
-    use_symengine: bool,
-    annotation_factories: &Bound<PyDict>,
-) -> Result<Py<PyAny>, QpyError> {
-    let pos = file_obj.call_method0("tell")?.extract::<usize>()?;
-    let bytes = file_obj.call_method0("read")?;
-    let serialized_circuit: &[u8] = bytes
-        .cast::<PyBytes>()
-        .map_err(|_| QpyError::InvalidPythonType {
-            python_type: "PyBytes".to_string(),
-            name: "serialized_circuit".to_string(),
-        })?
-        .as_bytes();
-    let (packed_circuit, bytes_read) =
-        deserialize_with_args::<formats::QPYCircuit, (u8,)>(serialized_circuit, (version,))?;
-    let unpacked_circuit = unpack_circuit(
-        py,
-        &packed_circuit,
-        version,
-        Some(metadata_deserializer),
-        use_symengine,
-        annotation_factories,
-    )?;
-    file_obj.call_method1("seek", (pos + bytes_read,))?;
-    Ok(unpacked_circuit)
 }
 
 // handling for non control flow gates with conditionals, for backwards compatability

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -1249,30 +1249,3 @@ pub(crate) fn pack_circuit(
         layout,
     })
 }
-
-#[pyfunction]
-#[pyo3(name = "write_circuit")]
-#[pyo3(signature = (file_obj, circuit, metadata_serializer, use_symengine, version, annotation_factories))]
-pub(crate) fn py_write_circuit(
-    py: Python,
-    file_obj: &Bound<PyAny>,
-    circuit: &Bound<PyAny>,
-    metadata_serializer: &Bound<PyAny>,
-    use_symengine: bool,
-    version: u8,
-    annotation_factories: &Bound<PyDict>,
-) -> PyResult<usize> {
-    let packed_circuit = pack_circuit(
-        &mut circuit.extract()?,
-        Some(metadata_serializer),
-        use_symengine,
-        version,
-        annotation_factories,
-    )?;
-    let serialized_circuit = serialize(&packed_circuit)?;
-    file_obj.call_method1(
-        "write",
-        (pyo3::types::PyBytes::new(py, &serialized_circuit),),
-    )?;
-    Ok(serialized_circuit.len())
-}

--- a/crates/qpy/src/lib.rs
+++ b/crates/qpy/src/lib.rs
@@ -35,8 +35,6 @@ mod value;
 /// Internal module supplying the QPY capabilities.  The entries in it should largely
 /// be re-exposed directly to public Python space.
 pub fn qpy(module: &Bound<PyModule>) -> PyResult<()> {
-    module.add_function(wrap_pyfunction!(circuit_writer::py_write_circuit, module)?)?;
-    module.add_function(wrap_pyfunction!(circuit_reader::py_read_circuit, module)?)?;
     module.add_function(wrap_pyfunction!(interface::py_dump_qpy, module)?)?;
     module.add_function(wrap_pyfunction!(interface::py_load_qpy, module)?)?;
     Ok(())

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -53,7 +53,6 @@ from qiskit.quantum_info import SparseObservable
 from qiskit.circuit.library import PauliProductMeasurement
 from qiskit.synthesis import evolution as evo_synth
 from qiskit.transpiler.layout import Layout, TranspileLayout
-from qiskit._accelerate import qpy as _qpy
 
 if typing.TYPE_CHECKING:
     from qiskit.circuit.annotation import QPYSerializer, Annotation
@@ -297,7 +296,6 @@ def _loads_instruction_parameter(
             read_circuit,
             version=version,
             annotation_factories=annotation_factories,
-            use_rust=False,
         )
     elif type_key == type_keys.Value.MODIFIER:
         param = common.data_from_binary(data_bytes, _read_modifier)
@@ -835,7 +833,6 @@ def _read_custom_operations(file_obj, version, vectors, annotation_state):
                         read_circuit,
                         version=version,
                         annotation_factories=annotation_state.factories,
-                        use_rust=False,
                     )
                 elif name.startswith(r"###PauliEvolutionGate_"):
                     definition_circuit = common.data_from_binary(
@@ -901,7 +898,6 @@ def _dumps_instruction_parameter(
             write_circuit,
             version=version,
             annotation_factories=annotation_factories,
-            use_rust=False,
         )
     elif isinstance(param, Modifier):
         type_key = type_keys.Value.MODIFIER
@@ -1263,7 +1259,6 @@ def _write_custom_operation(
             write_circuit,
             version=version,
             annotation_factories=annotation_state.factories,
-            use_rust=False,
         )
         size = len(data)
         num_ctrl_qubits = operation.num_ctrl_qubits
@@ -1279,7 +1274,6 @@ def _write_custom_operation(
             write_circuit,
             version=version,
             annotation_factories=annotation_state.factories,
-            use_rust=False,
         )
         size = len(data)
     if base_gate is None:
@@ -1510,7 +1504,6 @@ def write_circuit(
     use_symengine=False,
     version=common.QPY_VERSION,
     annotation_factories=None,
-    use_rust=True,
 ):
     """Write a single QuantumCircuit object in the file like object.
 
@@ -1528,20 +1521,7 @@ def write_circuit(
         version (int): The QPY format version to use for serializing this circuit
         annotation_factories (dict): a mapping of namespaces to zero-argument factory functions that
             produce instances of :class:`.annotation.QPYSerializer`.
-        use_rust (bool): whether to use the rust based serialization engine. On by default.
     """
-    if use_rust:
-        if annotation_factories is None:
-            annotation_factories = {}
-        _qpy.write_circuit(
-            file_obj,
-            circuit,
-            metadata_serializer,
-            use_symengine,
-            version,
-            annotation_factories=annotation_factories,
-        )
-        return
     annotation_state = _AnnotationSerializationState(annotation_factories or {})
     metadata_raw = json.dumps(
         circuit.metadata, separators=(",", ":"), cls=metadata_serializer
@@ -1655,7 +1635,6 @@ def read_circuit(
     metadata_deserializer=None,
     use_symengine=False,
     annotation_factories=None,
-    use_rust=True,
 ):
     """Read a single QuantumCircuit object from the file like object.
 
@@ -1676,20 +1655,12 @@ def read_circuit(
             deserialize the payload.
         annotation_factories (dict): mapping of namespaces to factory functions for custom
             annotation deserializer objects.
-        use_rust (bool): whether to use the rust based deserialization engine. On by default.
     Returns:
         QuantumCircuit: The circuit object from the file.
 
     Raises:
         QpyError: Invalid register.
     """
-
-    if use_rust:
-        if annotation_factories is None:
-            annotation_factories = {}
-        return _qpy.read_circuit(
-            file_obj, version, metadata_deserializer, use_symengine, annotation_factories
-        )
 
     vectors = {}
     if version < 2:

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -233,7 +233,6 @@ def dump(
             use_symengine=bool(use_symengine),
             version=version,
             annotation_factories=annotation_factories,
-            use_rust=use_rust,
         )
 
     if version >= 16:
@@ -450,7 +449,6 @@ def load(
                 metadata_deserializer=metadata_deserializer,
                 use_symengine=bool(use_symengine),
                 annotation_factories=annotation_factories,
-                use_rust=use_rust,
             )
         )
     return programs

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -119,7 +119,7 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.cx(0, 1)
         if version < 14:
             with io.BytesIO() as fptr, self.assertRaises(UnsupportedFeatureForVersion):
-                write_circuit(fptr, qc, version=version, use_rust=write_with == "Rust")
+                write_circuit(fptr, qc, version=version)
         else:
             self.assert_roundtrip_equal(
                 qc, version=version, read_with=read_with, write_with=write_with


### PR DESCRIPTION
Fixes #16641.

### Summary

This removes the old Python-facing Rust QPY per-circuit helpers now that the Rust QPY path handles complete QPY files through `dump` and `load`.

The change:

- stops exposing `_qpy.write_circuit` and `_qpy.read_circuit` from the Rust QPY module
- removes the `use_rust` option from Python's internal `qiskit.qpy.binary_io.circuits.write_circuit` and `read_circuit` helpers
- keeps the high-level `qiskit.qpy.dump` and `qiskit.qpy.load` Rust routing intact for compatible QPY versions
- updates the affected QPY roundtrip test call site

No release note added because these are internal QPY helper paths rather than public user-facing API.

### Tests

- `cargo check -p qiskit-qpy`
- `cargo fmt --check --package qiskit-qpy`
- `python -m unittest test.python.qpy.test_roundtrip`
- `python -m py_compile qiskit/qpy/interface.py qiskit/qpy/binary_io/circuits.py test/python/qpy/test_roundtrip.py`
- `git diff --check`

AI/LLM disclosure: Codex was used to inspect the issue, edit the patch, and run verification The final changes were reviewed before submission.
