### PR TITLE
Add C API support for big unsigned integers

### DIFF
--- a/capi_slots.txt
+++ b/capi_slots.txt
@@ -1,7 +1,7 @@
 __version__ = "2.5.0-rc1"
 circuit = [
     "qk_api_version",
-    "",
+    "qk_biguint_clear",
     "",
     "",
     "",
@@ -94,9 +94,9 @@ circuit = [
     "qk_control_flow_switch_case_labels_bit_width",
     "qk_control_flow_switch_case_labels_uint",
     "qk_control_flow_switch_case_labels_clear",
-    "",
-    "",
-    "",
+    "qk_control_flow_condition_reg_cond_big_uint",
+    "qk_control_flow_switch_case_labels_big_uint",
+    "qk_control_flow_switch_case_labels_big_uint_clear",
     "",
     "",
     "",
@@ -321,7 +321,7 @@ circuit = [
     "qk_var_name",
     "qk_var_type_info",
     "qk_stretch_name",
-    "",
+    "qk_value_big_uint",
     "",
     "",
     "",
@@ -885,4 +885,3 @@ qi = [
     "",
     "",
 ]
-

--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -82,6 +82,7 @@ pub static QISKIT_PUBLIC_API_CRATES: &[&str] =
 
 pub static EXPORT_PREFIX: &str = "Qk";
 pub static EXPORT_RENAME: &[(&str, &str)] = &[
+    ("CBigUint", "BigUint"),
     ("CBlocksMode", "BlocksMode"),
     ("CDagNeighbors", "DagNeighbors"),
     ("CDagNodeType", "DagNodeType"),
@@ -120,6 +121,7 @@ pub static EXPORT_RENAME: &[(&str, &str)] = &[
     ("CConditionBitInfo", "ConditionBitInfo"),
     ("CBoxDurationKind", "BoxDurationKind"),
     ("CSwitchCaseLabels", "SwitchCaseLabels"),
+    ("CSwitchCaseBigUintLabels", "SwitchCaseBigUintLabels"),
     ("CSymbolType", "SymbolType"),
     ("CSymbolInfo", "SymbolInfo"),
     ("CLoopCollectionType", "LoopCollectionType"),

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -21,13 +21,17 @@ pub use crate::impl_::{ExportedFunction, ExportedFunctions};
 // =================================================================================================
 
 // We use a (small) number of different tables here so there's more breaks and places to expand.
-pub static FUNCTIONS_CIRCUIT: ExportedFunctions =
-    ExportedFunctions::leaves(5, || vec![impl_::export_fn!(qiskit_cext::qk_api_version)])
-        .add_child(5, &circuit::FUNCTIONS)
-        .add_child(105, &dag::FUNCTIONS)
-        .add_child(205, &param::FUNCTIONS)
-        .add_child(255, &circuit_library::FUNCTIONS)
-        .add_child(305, &classical_expr::FUNCTIONS);
+pub static FUNCTIONS_CIRCUIT: ExportedFunctions = ExportedFunctions::leaves(5, || {
+    vec![
+        impl_::export_fn!(qiskit_cext::qk_api_version),
+        impl_::export_fn!(qiskit_cext::big_uint::qk_biguint_clear),
+    ]
+})
+.add_child(5, &circuit::FUNCTIONS)
+.add_child(105, &dag::FUNCTIONS)
+.add_child(205, &param::FUNCTIONS)
+.add_child(255, &circuit_library::FUNCTIONS)
+.add_child(305, &classical_expr::FUNCTIONS);
 pub static FUNCTIONS_QI: ExportedFunctions =
     ExportedFunctions::empty().add_child(0, &sparse_observable::FUNCTIONS);
 pub use transpiler::FUNCTIONS as FUNCTIONS_TRANSPILE;
@@ -140,6 +144,9 @@ mod circuit {
             export_fn!(qk_control_flow_switch_case_labels_bit_width),
             export_fn!(qk_control_flow_switch_case_labels_uint),
             export_fn!(qk_control_flow_switch_case_labels_clear),
+            export_fn!(qk_control_flow_condition_reg_cond_big_uint),
+            export_fn!(qk_control_flow_switch_case_labels_big_uint),
+            export_fn!(qk_control_flow_switch_case_labels_big_uint_clear),
         ]
     });
 }
@@ -490,6 +497,7 @@ mod classical_expr {
             export_fn!(qk_var_name),
             export_fn!(qk_var_type_info),
             export_fn!(qk_stretch_name),
+            export_fn!(qk_value_big_uint),
         ]
     });
 }

--- a/crates/cext/src/big_uint.rs
+++ b/crates/cext/src/big_uint.rs
@@ -1,0 +1,82 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use std::ptr;
+
+use crate::pointers::mut_ptr_as_ref;
+use num_bigint::BigUint;
+
+/// An owned copy of an arbitrary-size unsigned integer.
+///
+/// The value is represented as little-endian bytes in `data`; that is, the least significant byte
+/// is first.  A zero value has `num_bytes == 0` and `data == NULL`.
+///
+/// The memory for `data` is allocated by functions that return `QkBigUint`, and must be freed by
+/// `qk_biguint_clear`.
+#[repr(C)]
+pub struct CBigUint {
+    /// The little-endian bytes of the integer.
+    pub(crate) data: *const u8,
+    /// The number of bytes pointed to by `data`.
+    pub(crate) num_bytes: usize,
+}
+
+pub(crate) fn biguint_to_c(value: &BigUint) -> CBigUint {
+    let bytes = value.to_bytes_le().into_boxed_slice();
+    CBigUint {
+        num_bytes: bytes.len(),
+        data: if bytes.is_empty() {
+            ptr::null()
+        } else {
+            Box::into_raw(bytes) as *const u8
+        },
+    }
+}
+
+pub(crate) unsafe fn clear_biguint(value: &mut CBigUint) {
+    if !value.data.is_null() && value.num_bytes > 0 {
+        drop(unsafe {
+            Box::from_raw(ptr::slice_from_raw_parts_mut(
+                value.data as *mut u8,
+                value.num_bytes,
+            ))
+        });
+    }
+    value.data = ptr::null();
+    value.num_bytes = 0;
+}
+
+/// @ingroup QkBigUint
+/// Clear a `QkBigUint` struct.
+///
+/// This function must be called to free the memory allocated by functions that
+/// return `QkBigUint`. After calling this function, the data pointer in the
+/// struct will be set to null and the byte count will be set to zero.
+///
+/// @param value A pointer to the `QkBigUint` struct to clear.
+///
+/// # Example
+/// ```c
+/// QkBigUint value = qk_value_big_uint(expr_value);
+/// // Use the bytes...
+/// qk_biguint_clear(&value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid pointer to a `QkBigUint`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_biguint_clear(value: *mut CBigUint) {
+    // SAFETY: Per documentation, value is a valid pointer to a CBigUint.
+    let value = unsafe { mut_ptr_as_ref(value) };
+    unsafe { clear_biguint(value) };
+}

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -12,6 +12,7 @@
 
 use std::ptr;
 
+use crate::big_uint::{CBigUint, biguint_to_c};
 use crate::pointers::const_ptr_as_ref;
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
@@ -811,6 +812,43 @@ pub unsafe extern "C" fn qk_value_uint(value: *const Value) -> u64 {
 
     raw.to_u64()
         .expect("Integer value too large to fit in uint64_t")
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract the unsigned integer value from a ``QkValue`` of type ``QkExprType_Uint``.
+///
+/// The returned value is an owned copy of the integer in little-endian byte order.  The caller
+/// must free the returned value using `qk_biguint_clear`.
+///
+/// @param value A pointer to a uint value.
+///
+/// @return The integer value as little-endian bytes.
+///
+/// Panics if ``value`` does not point to a ``QkExprType_Uint`` value.
+///
+/// # Example
+/// ```c
+/// QkBigUint raw = qk_value_big_uint(value);
+/// qk_biguint_clear(&raw);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_big_uint(value: *const Value) -> CBigUint {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Uint {
+        raw,
+        ty: Type::Uint(_),
+    } = value
+    else {
+        panic!("qk_value_big_uint called on non-uint value")
+    };
+
+    biguint_to_c(raw)
 }
 
 /// @ingroup QkClassicalExpressions

--- a/crates/cext/src/control_flow.rs
+++ b/crates/cext/src/control_flow.rs
@@ -27,6 +27,7 @@ use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::{Clbit, Qubit};
 use uuid::Uuid;
 
+use crate::big_uint::{CBigUint, biguint_to_c, clear_biguint};
 use crate::classical_expr::CDurationInfo;
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use num_traits::ToPrimitive;
@@ -212,6 +213,21 @@ impl From<Option<&BoxDuration>> for CBoxDurationKind {
 pub struct CSwitchCaseLabels {
     /// Pointer to an array of label values
     labels: *const u64,
+    /// Number of labels in the array
+    num_labels: usize,
+}
+
+/// Contains the arbitrary-size labels for a Switch case.
+///
+/// This struct holds an array of unsigned integer label values that a Switch case matches against.
+/// Each label is represented as little-endian bytes in a `QkBigUint`.
+/// The memory for the labels array is allocated by
+/// `qk_control_flow_switch_case_labels_big_uint` and must be freed using
+/// `qk_control_flow_switch_case_labels_big_uint_clear`.
+#[repr(C)]
+pub struct CSwitchCaseBigUintLabels {
+    /// Pointer to an array of label values
+    labels: *const CBigUint,
     /// Number of labels in the array
     num_labels: usize,
 }
@@ -714,6 +730,52 @@ pub unsafe extern "C" fn qk_control_flow_condition_reg_cond_uint(
 
     cond.to_u64()
         .unwrap_or_else(|| panic!("Condition value too large to fit in uint64_t"))
+}
+
+/// @ingroup QkControlFlow
+/// Get the condition value of the classical register condition for a control flow instruction.
+///
+/// Extracts the condition as an arbitrary-size unsigned integer from an IfElse or While
+/// instruction that has a classical register condition. The returned value is an owned copy in
+/// little-endian byte order, and must be freed using `qk_biguint_clear`.
+///
+/// @param cf_inst A valid pointer to a ``QkControlFlowInstruction`` that must represent
+///     an IfElse or While instruction with a classical register condition.
+///
+/// @return The condition value as little-endian bytes.
+///
+/// Panics if ``cf_inst`` is not an IfElse or While control flow instruction,
+/// or if the condition is not a register type.
+///
+/// # Example
+/// ```c
+/// // Assuming cf_inst is an IfElse or While instruction with a register condition
+/// QkBigUint expected_value = qk_control_flow_condition_reg_cond_big_uint(cf_inst);
+/// qk_biguint_clear(&expected_value);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``cf_inst`` is not a valid pointer to a ``QkControlFlowInstruction``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_control_flow_condition_reg_cond_big_uint(
+    cf_inst: *const CControlFlowInstruction,
+) -> CBigUint {
+    // SAFETY: Per documentation, cf_inst is a valid pointer to a CControlFlowInstruction.
+    let cf_inst = unsafe { const_ptr_as_ref(cf_inst) };
+
+    let condition = match &cf_inst.control_flow_inst().control_flow {
+        ControlFlow::IfElse { condition } | ControlFlow::While { condition } => condition,
+        _ => {
+            panic!("Expected either an IfElse or a While control flow instruction")
+        }
+    };
+
+    let Condition::Register(_, cond) = condition else {
+        panic!("Expected a register condition for the instruction")
+    };
+
+    biguint_to_c(cond)
 }
 
 /// @ingroup QkControlFlow
@@ -1584,6 +1646,73 @@ pub unsafe extern "C" fn qk_control_flow_switch_case_labels_uint(
 }
 
 /// @ingroup QkControlFlow
+/// Get the arbitrary-size labels for a specific case in a Switch statement.
+///
+/// Each case in a Switch statement can have one or more labels (e.g., ``case(1, 2, 3)``)
+/// has three labels: 1, 2, and 3). This function retrieves all unsigned integer labels for a
+/// given case. Note that the default case can also include labels, which can be retrieved by
+/// this function. When called on a default case without additional labels, the function sets
+/// ``num_labels = 0`` and ``labels = NULL`` in the returned `QkSwitchCaseBigUintLabels` struct.
+///
+/// The returned labels are owned copies in little-endian byte order. If ``num_labels > 0``,
+/// call `qk_control_flow_switch_case_labels_big_uint_clear` to free the memory allocated by
+/// this function.
+///
+/// @param cf_inst A pointer to the control flow instruction.
+///     The control flow instruction must be of a Switch kind.
+/// @param case_idx The index of the case whose labels to retrieve. Must be less than
+///     the value returned by `qk_control_flow_switch_num_cases`.
+///
+/// @return A `QkSwitchCaseBigUintLabels` struct with the label information for the given case.
+///
+/// Panics if ``cf_inst`` is not a Switch control flow instruction.
+///
+/// # Example
+/// ```c
+/// // Assuming cf_inst is a Switch control flow instruction
+/// QkSwitchCaseBigUintLabels case_labels =
+///     qk_control_flow_switch_case_labels_big_uint(cf_inst, 0);
+/// qk_control_flow_switch_case_labels_big_uint_clear(&case_labels);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``cf_inst`` is not a valid pointer to a ``QkControlFlowInstruction``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_control_flow_switch_case_labels_big_uint(
+    cf_inst: *const CControlFlowInstruction,
+    case_idx: usize,
+) -> CSwitchCaseBigUintLabels {
+    // SAFETY: Per documentation, cf_inst is a valid pointer to a CControlFlowInstruction.
+    let cf_inst = unsafe { const_ptr_as_ref(cf_inst) };
+
+    let ControlFlow::Switch { label_spec, .. } = &cf_inst.control_flow_inst().control_flow else {
+        panic!("Expected a Switch control flow instruction")
+    };
+
+    let labels = label_spec[case_idx]
+        .iter()
+        .filter_map(|l| {
+            if let CaseSpecifier::Uint(label) = l {
+                Some(biguint_to_c(label))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<CBigUint>>()
+        .into_boxed_slice();
+
+    CSwitchCaseBigUintLabels {
+        num_labels: labels.len(),
+        labels: if labels.is_empty() {
+            ptr::null() // occurs for a default case without additional labels
+        } else {
+            Box::into_raw(labels) as *const CBigUint
+        },
+    }
+}
+
+/// @ingroup QkControlFlow
 /// Clear a `QkSwitchCaseLabels` struct.
 ///
 /// This function must be called to free the memory allocated by
@@ -1623,6 +1752,55 @@ pub unsafe extern "C" fn qk_control_flow_switch_case_labels_clear(labels: *mut C
         labels.labels = std::ptr::null();
         labels.num_labels = 0;
     }
+}
+
+/// @ingroup QkControlFlow
+/// Clear a `QkSwitchCaseBigUintLabels` struct.
+///
+/// This function must be called to free the memory allocated by
+/// `qk_control_flow_switch_case_labels_big_uint`. After calling this function,
+/// the labels pointer in the struct will be set to null and the count will be set to zero.
+///
+/// @param labels A pointer to the `QkSwitchCaseBigUintLabels` struct to clear.
+///     The struct must have been previously populated by
+///     `qk_control_flow_switch_case_labels_big_uint`.
+///
+/// # Example
+/// ```c
+/// // Assuming cf_inst is a Switch control flow instruction
+/// QkSwitchCaseBigUintLabels case_labels =
+///     qk_control_flow_switch_case_labels_big_uint(cf_inst, 0);
+/// // Use the labels...
+/// qk_control_flow_switch_case_labels_big_uint_clear(&case_labels);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``labels`` is not a valid pointer to a
+/// `QkSwitchCaseBigUintLabels`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_control_flow_switch_case_labels_big_uint_clear(
+    labels: *mut CSwitchCaseBigUintLabels,
+) {
+    // SAFETY: Per documentation, labels is a valid pointer to a CSwitchCaseBigUintLabels.
+    let labels = unsafe { mut_ptr_as_ref(labels) };
+
+    if !labels.labels.is_null() && labels.num_labels > 0 {
+        let labels_slice = unsafe {
+            std::slice::from_raw_parts_mut(labels.labels as *mut CBigUint, labels.num_labels)
+        };
+        for label in labels_slice {
+            unsafe { clear_biguint(label) };
+        }
+        drop(unsafe {
+            Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                labels.labels as *mut CBigUint,
+                labels.num_labels,
+            ))
+        });
+    }
+    labels.labels = std::ptr::null();
+    labels.num_labels = 0;
 }
 
 //////////////////////////////////////////////////////////////////

--- a/crates/cext/src/lib.rs
+++ b/crates/cext/src/lib.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+pub mod big_uint;
 mod extras;
 mod pointers;
 #[cfg(feature = "python_binding")]

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -4,6 +4,7 @@
 
 /**
  * @defgroup QkBitTerm QkBitTerm
+ * @defgroup QkBigUint QkBigUint
  * @defgroup QkCircuit QkCircuit
  * @defgroup QkCircuitLibrary QkCircuitLibrary
  * @defgroup QkClassicalRegister QkClassicalRegister

--- a/releasenotes/notes/c-api-big-uint-16666.yaml
+++ b/releasenotes/notes/c-api-big-uint-16666.yaml
@@ -1,0 +1,7 @@
+---
+features_c:
+  - |
+    Added :c:struct:`QkBigUint` and C API accessors for arbitrary-size
+    unsigned integers in classical-expression values, control-flow register
+    conditions, and switch-case labels. Returned values use little-endian bytes
+    and should be freed with :c:func:`qk_biguint_clear`.

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -24,8 +24,7 @@
 static bool biguint_matches_bytes(const QkBigUint *value, const uint8_t *expected,
                                   size_t expected_len, const char *context) {
     if (value->num_bytes != expected_len) {
-        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len,
-               value->num_bytes);
+        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len, value->num_bytes);
         return false;
     }
     if (expected_len > 0 && value->data == NULL) {

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -21,6 +21,27 @@
 #include <stdio.h>
 #include <string.h>
 
+static bool biguint_matches_bytes(const QkBigUint *value, const uint8_t *expected,
+                                  size_t expected_len, const char *context) {
+    if (value->num_bytes != expected_len) {
+        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len,
+               value->num_bytes);
+        return false;
+    }
+    if (expected_len > 0 && value->data == NULL) {
+        printf("Expected %s to have non-null data\n", context);
+        return false;
+    }
+    for (size_t i = 0; i < expected_len; i++) {
+        if (value->data[i] != expected[i]) {
+            printf("Expected %s byte %zu to be %u, got %u\n", context, i, (unsigned)expected[i],
+                   (unsigned)value->data[i]);
+            return false;
+        }
+    }
+    return true;
+}
+
 // TODO: remove these forward declarations
 // These are used for generating classical expressions for testing. They are non-public C API
 // functions which should be removed once we have C API for generating classical expressions.
@@ -437,6 +458,7 @@ static int test_expr_value(void) {
     int result = Ok;
     QkDurationInfo duration_info = {QkDurationType_Dt, {.dt = 12345}};
     QkExprNode *expr = NULL;
+    QkBigUint big_uint = {NULL, 0};
 
     for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
         expr = inner_test_value((QkExprType)ty, true, duration_info, 3.14, 12345);
@@ -525,6 +547,15 @@ static int test_expr_value(void) {
                 result = EqualityError;
                 goto cleanup;
             }
+
+            big_uint = qk_value_big_uint(value);
+            uint8_t expected_bytes[] = {0x39, 0x30};
+            if (!biguint_matches_bytes(&big_uint, expected_bytes, sizeof(expected_bytes),
+                                       "uint value")) {
+                result = EqualityError;
+                goto cleanup;
+            }
+            qk_biguint_clear(&big_uint);
         }
 
         inner_expr_free(expr);
@@ -533,6 +564,9 @@ static int test_expr_value(void) {
     expr = NULL;
 
 cleanup:
+    if (big_uint.data != NULL) {
+        qk_biguint_clear(&big_uint);
+    }
     if (expr)
         inner_expr_free(expr);
 

--- a/test/c/test_control_flow.c
+++ b/test/c/test_control_flow.c
@@ -24,8 +24,7 @@
 static bool biguint_matches_repeated_byte(const QkBigUint *value, uint8_t expected_byte,
                                           size_t expected_len, const char *context) {
     if (value->num_bytes != expected_len) {
-        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len,
-               value->num_bytes);
+        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len, value->num_bytes);
         return false;
     }
     if (expected_len > 0 && value->data == NULL) {
@@ -34,8 +33,8 @@ static bool biguint_matches_repeated_byte(const QkBigUint *value, uint8_t expect
     }
     for (size_t i = 0; i < expected_len; i++) {
         if (value->data[i] != expected_byte) {
-            printf("Expected %s byte %zu to be %u, got %u\n", context, i,
-                   (unsigned)expected_byte, (unsigned)value->data[i]);
+            printf("Expected %s byte %zu to be %u, got %u\n", context, i, (unsigned)expected_byte,
+                   (unsigned)value->data[i]);
             return false;
         }
     }
@@ -432,8 +431,7 @@ static int test_switch_case_on_register(void) {
 
     big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 0);
     if (big_case_labels.num_labels != 1) {
-        printf("Expected one big integer label for case 0, got %zu\n",
-               big_case_labels.num_labels);
+        printf("Expected one big integer label for case 0, got %zu\n", big_case_labels.num_labels);
         result = EqualityError;
         goto cleanup;
     }
@@ -463,8 +461,7 @@ static int test_switch_case_on_register(void) {
 
     big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 1);
     if (big_case_labels.num_labels != 3) {
-        printf("Expected 3 big integer labels for case 1, got %zu\n",
-               big_case_labels.num_labels);
+        printf("Expected 3 big integer labels for case 1, got %zu\n", big_case_labels.num_labels);
         result = EqualityError;
         goto cleanup;
     }
@@ -493,8 +490,7 @@ static int test_switch_case_on_register(void) {
 
     big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 2);
     if (big_case_labels.num_labels != 1) {
-        printf("Expected one big integer label for case 2, got %zu\n",
-               big_case_labels.num_labels);
+        printf("Expected one big integer label for case 2, got %zu\n", big_case_labels.num_labels);
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_control_flow.c
+++ b/test/c/test_control_flow.c
@@ -21,6 +21,31 @@
 #include <stdio.h>
 #include <string.h>
 
+static bool biguint_matches_repeated_byte(const QkBigUint *value, uint8_t expected_byte,
+                                          size_t expected_len, const char *context) {
+    if (value->num_bytes != expected_len) {
+        printf("Expected %s to have %zu bytes, got %zu\n", context, expected_len,
+               value->num_bytes);
+        return false;
+    }
+    if (expected_len > 0 && value->data == NULL) {
+        printf("Expected %s to have non-null data\n", context);
+        return false;
+    }
+    for (size_t i = 0; i < expected_len; i++) {
+        if (value->data[i] != expected_byte) {
+            printf("Expected %s byte %zu to be %u, got %u\n", context, i,
+                   (unsigned)expected_byte, (unsigned)value->data[i]);
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool biguint_matches_u8(const QkBigUint *value, uint8_t expected, const char *context) {
+    return biguint_matches_repeated_byte(value, expected, 1, context);
+}
+
 // TODO: remove this forward declaration
 // This is used to generate a circuit with control flow instructions. This a non-public C API
 // function which should be removed once we have C API for adding control flow operations.
@@ -359,6 +384,8 @@ static int test_switch_case_on_register(void) {
     int result = Ok;
     QkCircuit *circuit = inner_test_control_flow_circuit();
     QkControlFlowInstruction *cf_inst = NULL;
+    QkSwitchCaseLabels case_labels = {NULL, 0};
+    QkSwitchCaseBigUintLabels big_case_labels = {NULL, 0};
 
     cf_inst = qk_circuit_get_control_flow_instruction(circuit, 2, NULL);
     if (cf_inst == NULL) {
@@ -403,11 +430,23 @@ static int test_switch_case_on_register(void) {
         goto cleanup;
     }
 
+    big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 0);
+    if (big_case_labels.num_labels != 1) {
+        printf("Expected one big integer label for case 0, got %zu\n",
+               big_case_labels.num_labels);
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (!biguint_matches_repeated_byte(&big_case_labels.labels[0], 0xff, 10, "case 0 label")) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    qk_control_flow_switch_case_labels_big_uint_clear(&big_case_labels);
+
     // Test case 1: multiple labels (1, 2, 3)
-    QkSwitchCaseLabels case_labels = qk_control_flow_switch_case_labels_uint(cf_inst, 1);
+    case_labels = qk_control_flow_switch_case_labels_uint(cf_inst, 1);
     if (case_labels.num_labels != 3) {
         printf("Expected 3 labels for case 1, got %zu\n", case_labels.num_labels);
-        qk_control_flow_switch_case_labels_clear(&case_labels);
         result = EqualityError;
         goto cleanup;
     }
@@ -416,21 +455,54 @@ static int test_switch_case_on_register(void) {
         if (case_labels.labels[l] != l + 1) {
             printf("Expected label %zu for case 1, got %" PRIu64 "\n", l + 1,
                    case_labels.labels[l]);
-            qk_control_flow_switch_case_labels_clear(&case_labels);
             result = EqualityError;
             goto cleanup;
         }
     }
     qk_control_flow_switch_case_labels_clear(&case_labels);
 
+    big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 1);
+    if (big_case_labels.num_labels != 3) {
+        printf("Expected 3 big integer labels for case 1, got %zu\n",
+               big_case_labels.num_labels);
+        result = EqualityError;
+        goto cleanup;
+    }
+    for (size_t l = 0; l < 3; l++) {
+        if (!biguint_matches_u8(&big_case_labels.labels[l], (uint8_t)(l + 1), "case 1 label")) {
+            result = EqualityError;
+            goto cleanup;
+        }
+    }
+    qk_control_flow_switch_case_labels_big_uint_clear(&big_case_labels);
+
     // Test case 2: A label and DEFAULT ((1<<64)-1, DEFAULT)
     case_labels = qk_control_flow_switch_case_labels_uint(cf_inst, 2);
     if (case_labels.num_labels != 1) {
         printf("Expected one label for case 2, got %zu\n", case_labels.num_labels);
-        qk_control_flow_switch_case_labels_clear(&case_labels);
         result = EqualityError;
         goto cleanup;
     }
+    if (case_labels.labels[0] != UINT64_MAX) {
+        printf("Expected label for case 2 to be UINT64_MAX, got %" PRIu64 "\n",
+               case_labels.labels[0]);
+        result = EqualityError;
+        goto cleanup;
+    }
+    qk_control_flow_switch_case_labels_clear(&case_labels);
+
+    big_case_labels = qk_control_flow_switch_case_labels_big_uint(cf_inst, 2);
+    if (big_case_labels.num_labels != 1) {
+        printf("Expected one big integer label for case 2, got %zu\n",
+               big_case_labels.num_labels);
+        result = EqualityError;
+        goto cleanup;
+    }
+    if (!biguint_matches_repeated_byte(&big_case_labels.labels[0], 0xff, 8, "case 2 label")) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    qk_control_flow_switch_case_labels_big_uint_clear(&big_case_labels);
 
     bool is_default = qk_control_flow_switch_is_case_default(cf_inst, 1);
     if (is_default) {
@@ -447,6 +519,12 @@ static int test_switch_case_on_register(void) {
     }
 
 cleanup:
+    if (case_labels.labels != NULL) {
+        qk_control_flow_switch_case_labels_clear(&case_labels);
+    }
+    if (big_case_labels.labels != NULL) {
+        qk_control_flow_switch_case_labels_big_uint_clear(&big_case_labels);
+    }
     if (cf_inst != NULL) {
         qk_control_flow_instruction_free(cf_inst);
     }
@@ -752,6 +830,7 @@ static int test_while_on_register_large_condition(void) {
     int result = Ok;
     QkCircuit *circuit = inner_test_control_flow_circuit();
     QkControlFlowInstruction *cf_inst = qk_circuit_get_control_flow_instruction(circuit, 9, NULL);
+    QkBigUint cond = {NULL, 0};
 
     uint64_t cond_bit_width = qk_control_flow_condition_reg_cond_bit_width(cf_inst);
     if (cond_bit_width <= 64) {
@@ -761,7 +840,22 @@ static int test_while_on_register_large_condition(void) {
         goto cleanup;
     }
 
+    cond = qk_control_flow_condition_reg_cond_big_uint(cf_inst);
+    if (!biguint_matches_repeated_byte(&cond, 0xff, 10, "large register condition")) {
+        result = EqualityError;
+        goto cleanup;
+    }
+    qk_biguint_clear(&cond);
+    if (cond.data != NULL || cond.num_bytes != 0) {
+        printf("Expected qk_biguint_clear to reset the large register condition\n");
+        result = EqualityError;
+        goto cleanup;
+    }
+
 cleanup:
+    if (cond.data != NULL) {
+        qk_biguint_clear(&cond);
+    }
     qk_control_flow_instruction_free(cf_inst);
     qk_circuit_free(circuit);
     return result;


### PR DESCRIPTION
Fixes #16666.

### Summary

- add `QkBigUint` as an owned little-endian byte representation for arbitrary-size unsigned integers
- expose C API accessors for uint expression values, control-flow register conditions, and switch-case labels without narrowing to `uint64_t`
- register the new exports in the C API ABI slot table and vtable
- add C tests for 80-bit labels/conditions and byte-level value extraction

### Verification

- `cargo check -p qiskit-cext`
- `make ctest`
- `cargo run --quiet -p qiskit-bindgen-cli -- check-abi capi_slots.txt`
- `cargo check -p qiskit-cext-vtable --features addr`
- `cargo fmt --check --package qiskit-cext --package qiskit-bindgen --package qiskit-cext-vtable`
- `git diff --check`

`bash tools/run_clang_format.sh` could not run locally because `clang-format` is not installed in this environment.
