### PR TITLE
Refactor remaining needless_collect cases

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5996,21 +5996,15 @@ impl DAGCircuit {
             .collect();
 
         for terminus in termini {
-            let last_edges: Vec<_> = self
+            let mut last_edges = self
                 .dag
-                .edges_directed(terminus, dir.opposite())
-                .map(|e| {
-                    (
-                        match dir {
-                            Direction::Outgoing => e.source(),
-                            Direction::Incoming => e.target(),
-                        },
-                        e.id(),
-                        *e.weight(),
-                    )
-                })
-                .collect();
-            for (op_node, old_edge, weight) in last_edges.into_iter() {
+                .neighbors_directed(terminus, dir.opposite())
+                .detach();
+            while let Some((old_edge, op_node)) = last_edges.next(&self.dag) {
+                let weight = *self
+                    .dag
+                    .edge_weight(old_edge)
+                    .expect("edge index from a graph walker should still be valid");
                 match dir {
                     Direction::Outgoing => {
                         self.dag.add_edge(op_node, new_node, weight);

--- a/crates/synthesis/src/linear/lnn.rs
+++ b/crates/synthesis/src/linear/lnn.rs
@@ -69,10 +69,11 @@ fn _get_lower_triangular<'a>(
         });
 
         // Use row operations directed upwards to zero out all "1"s above the remaining "1" in row i
-        let rows_to_update: Vec<usize> = (0..i).rev().filter(|k| mat[[*k, *first_j]]).collect();
-        rows_to_update.into_iter().for_each(|k| {
-            _row_op_update_instructions(&mut cx_instructions_rows, mat.view_mut(), i, k);
-        });
+        for k in (0..i).rev() {
+            if mat[[k, *first_j]] {
+                _row_op_update_instructions(&mut cx_instructions_rows, mat.view_mut(), i, k);
+            }
+        }
     }
     // Apply only U instructions to get the permuted L
     for (ctrl, trgt) in cx_instructions_rows {


### PR DESCRIPTION
Fixes #16634

Follow-up to #16651. After re-running the issue command, the remaining clippy::needless_collect warnings were in dag_circuit.rs and linear/lnn.rs.

### Summary
- use a detached DAG neighbor walker while rewiring terminal edges, avoiding the temporary edge vector
- replace the LNN row-update collection with a descending loop that checks each row before mutating

### Tests
- cargo clippy -- -W clippy::needless_collect
- cargo test -p qiskit-circuit test_push --lib
- cargo test -p qiskit-synthesis --lib
- cargo fmt --check --package qiskit-circuit --package qiskit-synthesis
- git diff --check