### PR TITLE
Use pygraphviz to render pass manager drawings (step 1 of #16544)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ qasm3-import = [
 visualization = [
     "matplotlib >= 3.3",
     "pydot",
+    "pygraphviz >= 2.0",
     "Pillow >= 4.2.1",
     "pylatexenc >= 1.4",
     "seaborn >= 0.9.0",
@@ -234,6 +235,7 @@ optionals-interactive = [
     "matplotlib>=3.3",
     "pillow>=4.2.1",
     "pydot",
+    "pygraphviz>=2.0",
     "pylatexenc>=1.4",
     "seaborn>=0.9.0",
 ]

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -131,6 +131,12 @@ External Python Libraries
     For some graph visualizations, Qiskit uses `pydot <https://github.com/pydot/pydot>`__ as an
     interface to GraphViz (see :data:`HAS_GRAPHVIZ`).
 
+.. py:data:: HAS_PYGRAPHVIZ
+
+    Qiskit uses `pygraphviz <https://pygraphviz.github.io/>`__ to render pass-manager
+    visualizations.  From version 2.0, pygraphviz ships with bundled Graphviz binaries, so no
+    separate Graphviz installation is required.
+
 .. py:data:: HAS_PYGMENTS
 
     Pygments is a code highlighter and formatter used by many environments that involve rich
@@ -306,6 +312,7 @@ HAS_NETWORKX = _LazyImportTester("networkx", install="pip install networkx")
 HAS_NLOPT = _LazyImportTester("nlopt", name="NLopt Optimizer", install="pip install nlopt")
 HAS_PIL = _LazyImportTester("PIL.Image", name="pillow", install="pip install pillow")
 HAS_PYDOT = _LazyImportTester("pydot", install="pip install pydot")
+HAS_PYGRAPHVIZ = _LazyImportTester("pygraphviz", install="pip install pygraphviz")
 HAS_PYGMENTS = _LazyImportTester("pygments", install="pip install pygments")
 HAS_PYLATEX = _LazyImportTester(
     {

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -14,6 +14,7 @@
 Visualization function for a pass manager. Passes are grouped based on their
 flow controller, and coloured based on the type of pass.
 """
+
 from __future__ import annotations
 
 import os
@@ -29,19 +30,21 @@ from .exceptions import VisualizationError
 DEFAULT_STYLE = {AnalysisPass: "red", TransformationPass: "blue"}
 
 
-@_optionals.HAS_GRAPHVIZ.require_in_call
+@_optionals.HAS_PYGRAPHVIZ.require_in_call
 @_optionals.HAS_PYDOT.require_in_call
 def pass_manager_drawer(pass_manager, filename=None, style=None, raw=False):
     """
     Draws the pass manager.
 
-    This function needs `pydot <https://github.com/pydot/pydot>`__, which in turn needs
-    `Graphviz <https://www.graphviz.org/>`__ to be installed.
+    This function needs `pydot <https://github.com/pydot/pydot>`__ and
+    `pygraphviz <https://pygraphviz.github.io/>`__ to be installed. pygraphviz 2.0 bundles the
+    Graphviz binaries, so no separate Graphviz installation is required.
 
     .. warning::
-        This function will call the system Graphviz tool on a file involving user-controllable
-        strings (such as pass names).  It is recommended to only call this function on trusted
-        input.
+
+        This function will call the Graphviz tooling (bundled with pygraphviz) on a file
+        involving user-controllable strings (such as pass names).  It is recommended to only
+        call this function on trusted input.
 
     Args:
         pass_manager (PassManager): the pass manager to be drawn
@@ -111,19 +114,21 @@ def _get_node_color(pss, style):
     return "black"
 
 
-@_optionals.HAS_GRAPHVIZ.require_in_call
+@_optionals.HAS_PYGRAPHVIZ.require_in_call
 @_optionals.HAS_PYDOT.require_in_call
 def staged_pass_manager_drawer(pass_manager, filename=None, style=None, raw=False):
     """
     Draws the staged pass manager.
 
-        This function needs `pydot <https://github.com/erocarrera/pydot>`__, which in turn needs
-    `Graphviz <https://www.graphviz.org/>`__ to be installed.
+        This function needs `pydot <https://github.com/pydot/pydot>`__ and
+    `pygraphviz <https://pygraphviz.github.io/>`__ to be installed. pygraphviz 2.0 bundles the
+    Graphviz binaries, so no separate Graphviz installation is required.
 
     .. warning::
-        This function will call the system Graphviz tool on a file involving user-controllable
-        strings (such as pass names).  It is recommended to only call this function on trusted
-        input.
+
+        This function will call the Graphviz tooling (bundled with pygraphviz) on a file
+        involving user-controllable strings (such as pass names).  It is recommended to only
+        call this function on trusted input.
 
     Args:
         pass_manager (StagedPassManager): the staged pass manager to be drawn
@@ -300,9 +305,13 @@ def make_output(graph, raw, filename):
         else:
             raise VisualizationError("if format=raw, then a filename is required.")
 
+    import pygraphviz
+
+    agraph = pygraphviz.AGraph(string=graph.to_string())
+    agraph.layout(prog="dot")
+
     if not _optionals.HAS_PIL and filename:
-        # pylint says this isn't a method - it is
-        graph.write_png(filename)
+        agraph.draw(filename, format="png")
         return None
 
     _optionals.HAS_PIL.require_now("pass manager drawer")
@@ -312,11 +321,10 @@ def make_output(graph, raw, filename):
 
         tmppath = os.path.join(tmpdirname, "pass_manager.png")
 
-        # pylint says this isn't a method - it is
-        graph.write_png(tmppath)
+        agraph.draw(tmppath, format="png")
+        with Image.open(tmppath) as temp_image:
+            image = temp_image.copy()
 
-        image = Image.open(tmppath)
-        os.remove(tmppath)
         if filename:
             image.save(filename, "PNG")
         return image

--- a/releasenotes/notes/pygraphviz-pass-manager-drawer-16544.yaml
+++ b/releasenotes/notes/pygraphviz-pass-manager-drawer-16544.yaml
@@ -1,0 +1,12 @@
+---
+features_visualization:
+  - |
+    :func:`.pass_manager_drawer` and :func:`.staged_pass_manager_drawer` now render
+    images using `pygraphviz <https://pygraphviz.github.io/>`__, which bundles the
+    Graphviz binaries as of version 2.0.  A separate manual installation of the
+    Graphviz software is no longer required to draw pass managers.
+fixes:
+  - |
+    Fixed a bug on Windows where :func:`.pass_manager_drawer` raised a
+    ``PermissionError`` during temporary-file cleanup, because the rendered image's
+    file handle was still held open while the file was being deleted.

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -36,7 +36,7 @@ from qiskit.circuit.library.standard_gates.equivalence_library import (
 from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
 
 
-@unittest.skipUnless(optionals.HAS_GRAPHVIZ, "Graphviz not installed.")
+@unittest.skipUnless(optionals.HAS_PYGRAPHVIZ, "pygraphviz not installed.")
 @unittest.skipUnless(optionals.HAS_PYDOT, "pydot not installed")
 @unittest.skipUnless(optionals.HAS_PIL, "Pillow not installed")
 class TestPassManagerDrawer(QiskitVisualizationTestCase):


### PR DESCRIPTION
### AI/LLM disclosure
- [x] I didn't use LLM tooling or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code: 
---

Implements step 1 of the plan @1ucian0 outlined in #16544: adds 'pygraphviz' as a new optional dependency and removes the requirement for a manually installed system Graphviz when drawing pass managers.

### Changes
- New 'HAS_PYGRAPHVIZ' lazy tester in 'qiskit.utils.optionals' (with docs entry).
- 'pass_manager_drawer' / 'staged_pass_manager_drawer' now require pygraphviz instead of system Graphviz. Graph construction still uses pydot (removing pydot is step 2, pending the rustworkx question); rendering now hands the DOT source to pygraphviz, whose 2.0+ wheels bundle the Graphviz binaries.
- Added 'pygraphviz>=2.0' to the 'visualization' extra and 'optionals-interactive' group (2.0 is the first release with bundled binaries).
- Updated test skip conditions and added a release note.

### Windows wheel confirmation
On Windows 11 / Python 3.11 with **no system Graphviz installed**, 'pip install pygraphviz' fetched the prebuilt 'pygraphviz-2.0.1-cp311-win_amd64' wheel, and 'pass_manager_drawer' rendered successfully end-to-end – which is the platform confirmation step 1 is meant to provide.

### Also fixes a latent Windows bug
Testing this path exposed a pre-existing issue: 'make_output' called 'os.remove' on the temporary PNG while 'PIL.Image.open's' lazy file handle was still open, raising 'PermissionError' on Windows. The image is now loaded via a context manager and copied in-memory. (This predates this PR but was unreachable in practice, since the drawer previously required a system Graphviz install that Windows users rarely had.)

'test_pass_manager_drawer.py' passes 2/2 locally on Windows — these tests were previously always skipped on this platform.

The rustworkx-based call sites ('dag_visualization.py', 'gate_map.py', etc.) still legitimately require 'HAS_GRAPHVIZ', so that tester is unchanged. If this goes beyond step 1, I'm happy to trim it back.

Part of #16544 (step 2 - moving off pydot/dot-calls to follow separately).