### PR TITLE
Fix `CircuitDataError` into `PyErr` mapping for the `RegisterAlreadyExists` variant.

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -125,9 +125,7 @@ impl From<CircuitDataError> for PyErr {
             CircuitDataError::AddObjectRegistry(e) => e.into(),
             CircuitDataError::ErrorFromPython(e) => e,
             CircuitDataError::ParameterTableError(e) => e.into(),
-            CircuitDataError::RegisterNameExists(name) => {
-                CircuitError::new_err(format!("register name {name} already exists"))
-            }
+            CircuitDataError::RegisterNameExists(e) => e.into(),
             CircuitDataError::BitExceedsCapacity(bit_type, bit_index) => CircuitError::new_err(
                 format!("{bit_type} at index {bit_index} exceds circuit capacity."),
             ),


### PR DESCRIPTION
`impl From<CircuitDataError> for PyErr` incorrectly uses the wrapped `RegisterAlreadyExists` error as if it were the register name. This leads to a strange looking error message:

```
qiskit.circuit.exceptions.CircuitError: 'register name register name "a" already exists already exists'
```

`PyErr` mapping now uses the `From` trait implemented for `RegisterNameExists`.

See this [comment](https://github.com/Qiskit/qiskit/pull/16678#issuecomment-5120616317) on PR #16678.

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code: