### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn qk_transpile_stage_routing(
 ///   If the transpiler fails a pointer to the string with the error description will be written
 ///   to this pointer. That pointer needs to be freed with ``qk_str_free``. This can be a null
 ///   pointer in which case the error will not be written out.
-/// @param state A pointer to a ``QkTranspilerStageState`` object contiaining the layout. Typically you will need
+/// @param state A pointer to a ``QkTranspilerStageState`` object containing the layout. Typically you will need
 ///   to run the `qk_transpile_stage_layout` prior to this function and that will provide a
 ///   `QkTranspileLayout` object with the initial layout set you want to take that output layout from
 ///   that function and use this as the input for this. If you don't have a layout object (e.g. you ran

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -614,7 +614,7 @@ defining the condition and its type.  The high bit of the byte is now a flag, in
 ``INSTRUCTION`` struct.
 
 A complete instruction payload appears in the data stream, including trailing objects and without
-any padding bytes inbetween elements, as:
+any padding bytes between elements, as:
 
 .. code-block:: text
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -338,7 +338,7 @@ class QuantumChannel(LinearOp):
         if hasattr(data, "to_channel"):
             # TODO: this 'to_channel' method is the same case as the above
             # but is used by current version of Aer. It should be removed
-            # once Aer is nupdated to use `to_quantumchannel`
+            # once Aer is updated to use `to_quantumchannel`
             # instead of `to_channel`,
             return data.to_channel()
         # Finally if the input is not a QuantumChannel and doesn't have a


### PR DESCRIPTION
- Corrects "contiaining" -> "containing", "inbetween" -> "between", and "nupdated" -> "updated".

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

