### PR TITLE
Improve InverseCancellation error for adjacent inverse-pair gates

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -13,6 +13,7 @@
 """
 A generic InverseCancellation pass for any set of gate-inverse pairs.
 """
+
 from __future__ import annotations
 
 
@@ -90,9 +91,22 @@ class InverseCancellation(TransformationPass):
             self._use_standard_gates = True
         else:
             self._use_standard_gates = False
-            for gates in gates_to_cancel:
+            for idx, gates in enumerate(gates_to_cancel):
                 if isinstance(gates, Gate):
-                    if gates != gates.inverse():
+                    gate_inverse = gates.inverse()
+                    if gates != gate_inverse:
+                        next_gate = (
+                            gates_to_cancel[idx + 1] if idx + 1 < len(gates_to_cancel) else None
+                        )
+                        if isinstance(next_gate, Gate) and gate_inverse == next_gate:
+                            raise TranspilerError(
+                                f"Gate {gates.name} is not self-inverse, but the "
+                                f"following gate '{next_gate.name}' is its inverse. "
+                                "To cancel this pair, group them together as a tuple "
+                                "instead of listing them separately, e.g. "
+                                "InverseCancellation("
+                                f"[({type(gates).__name__}(), {type(next_gate).__name__}())])."
+                            )
                         raise TranspilerError(f"Gate {gates.name} is not self-inverse")
                 elif isinstance(gates, tuple):
                     if len(gates) != 2:

--- a/releasenotes/notes/fix-inverse-cancellation-tuple-hint-e347e2e8c495f1a8.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-tuple-hint-e347e2e8c495f1a8.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed :class:`.InverseCancellation` to raise a more informative
+    :class:`.TranspilerError` when a gate that is not self-inverse is
+    given as a flat list entry and the very next entry in the list is
+    its inverse. The error now names the partner gate and points to the
+    tuple-pair syntax, e.g. ``InverseCancellation([(SGate(), SdgGate())])``,
+    instead of only reporting that the first gate is not self-inverse.
+    Fixed `#7413 <https://github.com/Qiskit/qiskit/issues/7413>`__.

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -546,6 +546,42 @@ class TestInverseCancellation(QiskitTestCase):
             self.assertIn("h", gates_after)
             self.assertNotIn("p", gates_after)
 
+    def test_flat_gate_pair_error_hints_tuple_syntax(self):
+        """A flat list with a gate immediately followed by its own inverse
+        should raise a TranspilerError that names the partner gate and
+        points at the tuple-pair syntax, instead of the bare
+        "is not self-inverse" message.
+
+        See: https://github.com/Qiskit/qiskit/issues/7413
+        """
+        from qiskit.circuit.library import SGate, SdgGate
+        from qiskit.transpiler.exceptions import TranspilerError
+        from qiskit.transpiler.passes import InverseCancellation
+
+        with self.assertRaises(TranspilerError) as ctx:
+            InverseCancellation([SGate(), SdgGate()])
+
+        message = str(ctx.exception).lower()
+        self.assertIn("sdg", message)
+        self.assertIn("tuple", message)
+
+    def test_lone_non_self_inverse_gate_raises_cleanly(self):
+        """A non-self-inverse gate with no following item to pair with
+        must still raise a plain TranspilerError, not crash (e.g. with an
+        IndexError from peeking past the end of the list).
+
+        See: https://github.com/Qiskit/qiskit/issues/7413
+        """
+        from qiskit.circuit.library import SGate
+        from qiskit.transpiler.exceptions import TranspilerError
+        from qiskit.transpiler.passes import InverseCancellation
+
+        with self.assertRaises(TranspilerError) as ctx:
+            InverseCancellation([SGate()])
+
+        message = str(ctx.exception).lower()
+        self.assertIn("not self-inverse", message)
+
 
 @ddt.ddt
 class TestCXCancellation(QiskitTestCase):


### PR DESCRIPTION
[paste the description block above here]
