### PR TITLE
QPY annotation rewrite

### DIFF
--- a/crates/qpy/src/annotations.rs
+++ b/crates/qpy/src/annotations.rs
@@ -9,156 +9,148 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
+
 use crate::bytes::Bytes;
 use crate::error::QpyError;
-use hashbrown::HashMap;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyIterator, PyNotImplemented};
-/// The purpose of AnnotationHandler is to keep track of all the annotation serializers/deserializers at once.
-/// Each namespace has one potential serializer/deserializer corresponding to it, given in the factories list.
-/// When serializing the first time a namespace is encountered, the serializer is generated from the factory,
-/// but it remains inside `potential_serializers` as long as it did not manage to serialize any annotation.
-/// The way to determine whether a serialization attempt succeeded is to check whether the result of `dump_annotation`
-/// was `NotImplemented`.
+use pyo3::types::{PyAny, PyDict};
 
+/// Handles QPY annotations at the boundary appropriate to the caller.
+///
+/// Python QPY entry points delegate annotation handling to the existing Python state objects.
+/// Native callers do not initialize any Python annotation machinery and fail only if the payload
+/// actually requires annotation handling.
 #[derive(Debug)]
-pub struct AnnotationHandler<'a> {
-    pub annotation_factories: &'a Bound<'a, PyDict>,
-    factories: HashMap<String, Py<PyAny>>,
-    pub serializers: HashMap<String, (usize, Py<PyAny>)>,
-    potential_serializers: HashMap<String, Py<PyAny>>,
-    pub deserializers: Vec<Py<PyAny>>,
+pub enum AnnotationHandler {
+    Python {
+        factories: Py<PyDict>,
+        serialization_state: Py<PyAny>,
+        deserialization_state: Py<PyAny>,
+    },
+    Native,
 }
 
-impl<'a> AnnotationHandler<'a> {
-    pub fn new(annotation_factories: &'a Bound<'a, PyDict>) -> Self {
-        let mut factories = HashMap::with_capacity(annotation_factories.len());
-        for (key, value) in annotation_factories.iter() {
-            if let Ok(key_string) = key.extract() {
-                // we ignore non-string keys since they will not be invoked during serialization
-                // where we choose serializer according to the namespace string
-                factories.insert(key_string, value.clone().unbind());
-            }
-        }
-
-        let serializers = HashMap::new();
-        let potential_serializers = HashMap::new();
-        // deserializers are created on demand based on the QPY annotation headers
-        let deserializers = Vec::new();
-        AnnotationHandler {
-            annotation_factories,
-            factories,
-            serializers,
-            potential_serializers,
-            deserializers,
-        }
-    }
-    pub fn serialize(&mut self, annotation: &Py<PyAny>) -> Result<(u32, Bytes), QpyError> {
+impl AnnotationHandler {
+    pub fn python(factories: &Py<PyDict>) -> Result<Self, QpyError> {
         Python::attach(|py| {
-            let annotation_namespace: String = annotation.getattr(py, "namespace")?.extract(py)?;
-            let annotation_module = py.import("qiskit.circuit.annotation")?;
-            let namespace_iter_func = annotation_module.getattr("iter_namespaces")?;
-            let namespace_iter =
-                PyIterator::from_object(&namespace_iter_func.call1((&annotation_namespace,))?)?;
-            for namespace_res in namespace_iter {
-                let namespace = namespace_res?;
-                let namespace_string: String = namespace.clone().extract()?;
-                // first check for an active serializer
-                if let Some((index, serializer)) = self.serializers.get(&namespace_string) {
-                    let result = serializer.call_method1(
-                        py,
-                        "dump_annotation",
-                        (namespace.clone(), annotation),
-                    )?;
-                    if !result.is(PyNotImplemented::get(py)) {
-                        let result_bytes: Bytes = result.extract(py)?;
-                        return Ok((*index as u32, result_bytes));
-                    }
-                } else if let Some(serializer) = self.potential_serializers.get(&namespace_string) {
-                    let result = serializer.call_method1(
-                        py,
-                        "dump_annotation",
-                        (namespace.clone(), annotation),
-                    )?;
-                    if !result.is(PyNotImplemented::get(py)) {
-                        let index = self.serializers.len();
-                        let result_bytes: Bytes = result.extract(py)?;
-                        self.serializers
-                            .insert(namespace_string.clone(), (index, serializer.clone()));
-                        return Ok((index as u32, result_bytes));
-                    }
-                }
-                // no serializer, let's try to create one from the corresponding factory
-                else if let Some(factory) = self.factories.get(&namespace_string) {
-                    let serializer = factory.call0(py)?;
-                    let result = serializer.call_method1(
-                        py,
-                        "dump_annotation",
-                        (namespace.clone(), annotation),
-                    )?;
-                    if !result.is(PyNotImplemented::get(py)) {
-                        let index = self.serializers.len();
-                        let result_bytes: Bytes = result.extract(py)?;
-                        self.serializers
-                            .insert(namespace_string.clone(), (index, serializer));
-                        return Ok((index as u32, result_bytes));
-                    } else {
-                        // This time the serializer failed, but we might want to try it again without
-                        // having to reconstruct it from the factory
-                        self.potential_serializers
-                            .insert(namespace_string.clone(), serializer);
-                    }
-                }
-            }
-            Err(QpyError::AnnotationError(format!(
-                "No configured annotation serializer could handle {}",
-                annotation.bind(py).repr()?,
-            )))
+            let module = py.import("qiskit.qpy.binary_io.circuits")?;
+            let serialization_state = module
+                .getattr("_AnnotationSerializationState")?
+                .call1((factories.bind(py),))?
+                .unbind();
+            let deserialization_state = module
+                .getattr("_AnnotationDeserializationState")?
+                .call1((factories.bind(py),))?
+                .unbind();
+            Ok(Self::Python {
+                factories: factories.clone_ref(py),
+                serialization_state,
+                deserialization_state,
+            })
         })
     }
 
+    /// Create independent annotation state for a nested circuit while preserving the caller mode.
+    pub fn child(&self) -> Result<Self, QpyError> {
+        match self {
+            Self::Python { factories, .. } => Self::python(factories),
+            Self::Native => Ok(Self::Native),
+        }
+    }
+
+    pub fn serialize(&mut self, annotation: &Py<PyAny>) -> Result<(u32, Bytes), QpyError> {
+        match self {
+            Self::Python {
+                serialization_state,
+                ..
+            } => Python::attach(|py| {
+                Ok(serialization_state
+                    .call_method1(py, "serialize", (annotation,))?
+                    .extract(py)?)
+            }),
+            Self::Native => Err(Self::native_error("serialize")),
+        }
+    }
+
     pub fn load(&self, index: u32, payload: Bytes) -> Result<Py<PyAny>, QpyError> {
-        if let Some(deserializer) = self.deserializers.get(index as usize) {
-            Python::attach(|py| -> Result<Py<PyAny>, QpyError> {
-                Ok(deserializer.call_method1(py, "load_annotation", (payload,))?)
-            })
-        } else {
-            Err(QpyError::ConversionError(format!(
-                "Annotation deserializer index {:?} out of range (0...{:?}), is too large and would overflow",
-                index,
-                self.deserializers.len()
-            )))
+        match self {
+            Self::Python {
+                deserialization_state,
+                ..
+            } => Python::attach(|py| {
+                Ok(deserialization_state.call_method1(py, "load", (index, payload))?)
+            }),
+            Self::Native => Err(Self::native_error("deserialize")),
         }
     }
 
     pub fn dump_serializers(&self) -> Result<Vec<(String, Bytes)>, QpyError> {
-        // we need to be a little careful to keep the result sorted by index order
-        let mut result: Vec<Option<(String, Bytes)>> = vec![None; self.serializers.len()];
-        Python::attach(|py| -> Result<(), QpyError> {
-            for (namespace, (index, serializer)) in &self.serializers {
-                let state: Bytes = serializer.call_method0(py, "dump_state")?.extract(py)?;
-                result[*index] = Some((namespace.clone(), state));
-            }
-            Ok(())
-        })?;
-        Ok(result.into_iter().flatten().collect())
+        match self {
+            Self::Python {
+                serialization_state,
+                ..
+            } => Python::attach(|py| {
+                Ok(serialization_state
+                    .call_method0(py, "dump_states")?
+                    .extract(py)?)
+            }),
+            Self::Native => Ok(Vec::new()),
+        }
     }
 
     pub fn load_deserializers(&mut self, data: Vec<(String, Bytes)>) -> Result<(), QpyError> {
-        Python::attach(|py| -> Result<(), QpyError> {
-            for (namespace, state) in data {
-                if let Some(factory) = self.factories.get(&namespace) {
-                    let serializer = factory.call0(py)?;
-                    serializer.call_method1(
-                        py,
-                        "load_state",
-                        (namespace.clone(), state.clone()),
-                    )?;
-                    self.deserializers.push(serializer);
-                };
-            }
-            Ok(())
-        })?;
-        Ok(())
+        if data.is_empty() {
+            return Ok(());
+        }
+        match self {
+            Self::Python {
+                deserialization_state,
+                ..
+            } => Python::attach(|py| {
+                for (namespace, state) in data {
+                    deserialization_state.call_method1(py, "initialize", (namespace, state))?;
+                }
+                Ok(())
+            }),
+            Self::Native => Err(Self::native_error("deserialize")),
+        }
+    }
+
+    fn native_error(action: &str) -> QpyError {
+        QpyError::AnnotationError(format!(
+            "native QPY cannot {action} circuits containing annotations"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_handler_is_inert_without_annotations() {
+        assert!(
+            AnnotationHandler::native()
+                .dump_serializers()
+                .is_ok_and(|states| states.is_empty())
+        );
+        assert!(
+            AnnotationHandler::native()
+                .load_deserializers(Vec::new())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn native_handler_rejects_annotations() {
+        let mut handler = AnnotationHandler::native();
+        assert!(matches!(
+            handler.load(0, Bytes::new()),
+            Err(QpyError::AnnotationError(_))
+        ));
+        assert!(matches!(
+            handler.load_deserializers(vec![("namespace".to_owned(), Bytes::new())]),
+            Err(QpyError::AnnotationError(_))
+        ));
     }
 }

--- a/crates/qpy/src/annotations.rs
+++ b/crates/qpy/src/annotations.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn native_handler_rejects_annotations() {
-        let mut handler = AnnotationHandler::native();
+        let handler = AnnotationHandler::native();
         assert!(matches!(
             handler.load(0, Bytes::new()),
             Err(QpyError::AnnotationError(_))

--- a/crates/qpy/src/annotations.rs
+++ b/crates/qpy/src/annotations.rs
@@ -50,6 +50,12 @@ impl AnnotationHandler {
         })
     }
 
+    // we will use this as part of the python-independance path
+    #[allow(dead_code)]
+    pub fn native() -> Self {
+        Self::Native
+    }
+
     /// Create independent annotation state for a nested circuit while preserving the caller mode.
     pub fn child(&self) -> Result<Self, QpyError> {
         match self {

--- a/crates/qpy/src/annotations.rs
+++ b/crates/qpy/src/annotations.rs
@@ -64,7 +64,7 @@ impl AnnotationHandler {
         }
     }
 
-    pub fn serialize(&mut self, annotation: &Py<PyAny>) -> Result<(u32, Bytes), QpyError> {
+    pub fn serialize(&self, annotation: &Py<PyAny>) -> Result<(u32, Bytes), QpyError> {
         match self {
             Self::Python {
                 serialization_state,
@@ -104,7 +104,7 @@ impl AnnotationHandler {
         }
     }
 
-    pub fn load_deserializers(&mut self, data: Vec<(String, Bytes)>) -> Result<(), QpyError> {
+    pub fn load_deserializers(&self, data: Vec<(String, Bytes)>) -> Result<(), QpyError> {
         if data.is_empty() {
             return Ok(());
         }

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1363,7 +1363,7 @@ fn read_custom_instructions(
                     qpy_data.version,
                     None,
                     qpy_data.use_symengine,
-                    qpy_data.annotation_handler.annotation_factories,
+                    qpy_data.annotation_handler.child()?,
                 )?)
             }
         } else {
@@ -1566,7 +1566,7 @@ pub(crate) fn unpack_circuit(
     version: u8,
     metadata_deserializer: Option<&Bound<PyAny>>,
     use_symengine: bool,
-    annotation_factories: &Bound<PyDict>,
+    annotation_handler: AnnotationHandler,
 ) -> Result<Py<PyAny>, QpyError> {
     let instruction_capacity = packed_circuit.instructions.len();
     // create an empty circuit; we'll fill data as we go along
@@ -1579,7 +1579,7 @@ pub(crate) fn unpack_circuit(
         standalone_vars: HashMap::new(),
         standalone_stretches: HashMap::new(),
         vectors: HashMap::new(),
-        annotation_handler: AnnotationHandler::new(annotation_factories),
+        annotation_handler,
     };
     if let Some(annotation_headers) = &packed_circuit.annotation_headers {
         let annotation_deserializers_data: Vec<(String, Bytes)> = annotation_headers
@@ -1644,13 +1644,14 @@ pub(crate) fn py_read_circuit(
         .as_bytes();
     let (packed_circuit, bytes_read) =
         deserialize_with_args::<formats::QPYCircuit, (u8,)>(serialized_circuit, (version,))?;
+    let annotation_handler = AnnotationHandler::python(&annotation_factories.clone().unbind())?;
     let unpacked_circuit = unpack_circuit(
         py,
         &packed_circuit,
         version,
         Some(metadata_deserializer),
         use_symengine,
-        annotation_factories,
+        annotation_handler,
     )?;
     file_obj.call_method1("seek", (pos + bytes_read,))?;
     Ok(unpacked_circuit)

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -1041,7 +1041,7 @@ fn pack_custom_instruction(
                 Some(py.None().bind(py)),
                 false,
                 qpy_data.version,
-                qpy_data.annotation_handler.annotation_factories,
+                qpy_data.annotation_handler.child()?,
             )?)?)
         }
         CircuitInstructionType::AnnotatedOperation => {
@@ -1056,7 +1056,7 @@ fn pack_custom_instruction(
                     Some(py.None().bind(py)),
                     false,
                     qpy_data.version,
-                    qpy_data.annotation_handler.annotation_factories,
+                    qpy_data.annotation_handler.child()?,
                 )
                 .and_then(|fmt| serialize(&fmt))
             })
@@ -1207,9 +1207,8 @@ pub(crate) fn pack_circuit(
     metadata_serializer: Option<&Bound<PyAny>>,
     _use_symengine: bool,
     version: u8,
-    annotation_factories: &Bound<PyDict>,
+    annotation_handler: AnnotationHandler,
 ) -> Result<formats::QPYCircuit, QpyError> {
-    let annotation_handler = AnnotationHandler::new(annotation_factories);
     let mut qpy_data = QPYWriteData {
         circuit_data: &mut circuit.data,
         version,
@@ -1262,12 +1261,13 @@ pub(crate) fn py_write_circuit(
     version: u8,
     annotation_factories: &Bound<PyDict>,
 ) -> PyResult<usize> {
+    let annotation_handler = AnnotationHandler::python(&annotation_factories.clone().unbind())?;
     let packed_circuit = pack_circuit(
         &mut circuit.extract()?,
         Some(metadata_serializer),
         use_symengine,
         version,
-        annotation_factories,
+        annotation_handler,
     )?;
     let serialized_circuit = serialize(&packed_circuit)?;
     file_obj.call_method1(

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -22,6 +22,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 use qiskit_circuit::converters::QuantumCircuitData;
 
+use crate::annotations::AnnotationHandler;
 use crate::bytes::Bytes;
 use crate::circuit_reader::unpack_circuit;
 use crate::circuit_writer::pack_circuit;
@@ -62,7 +63,7 @@ pub fn dump_qpy(
     metadata_serializer: Option<Bound<PyAny>>,
     use_symengine: bool,
     qpy_version: u8,
-    annotation_factories: Bound<PyDict>,
+    annotation_handler: AnnotationHandler,
 ) -> Result<Bytes, QpyError> {
     if qpy_version < QPY_WRITE_MIN_VERSION {
         Err(QpyError::UnsupportedFeatureForVersion {
@@ -79,7 +80,7 @@ pub fn dump_qpy(
                 metadata_serializer.as_ref(),
                 use_symengine,
                 qpy_version,
-                &annotation_factories,
+                annotation_handler.child()?,
             )?)
         })
         .collect::<Result<Vec<Bytes>, QpyError>>()?;
@@ -135,12 +136,13 @@ pub fn py_dump_qpy(
     annotation_factories: Option<Bound<PyDict>>,
 ) -> PyResult<()> {
     let annotation_factories = annotation_factories.unwrap_or(PyDict::new(py));
+    let annotation_handler = AnnotationHandler::python(&annotation_factories.clone().unbind())?;
     let serialized_qpy = dump_qpy(
         programs.extract()?,
         metadata_serializer,
         use_symengine.unwrap_or(false),
         version,
-        annotation_factories,
+        annotation_handler,
     )?;
     file_obj.call_method1("write", (pyo3::types::PyBytes::new(py, &serialized_qpy),))?;
     Ok(())
@@ -192,7 +194,7 @@ pub fn load_qpy(
     data: &Bytes,
     qpy_version: u8,
     metadata_deserializer: Option<&Bound<PyAny>>,
-    annotation_factories: &Bound<PyDict>,
+    annotation_handler: AnnotationHandler,
 ) -> Result<Vec<Py<PyAny>>, QpyError> {
     if qpy_version < QPY_READ_MIN_VERSION {
         Err(QpyError::UnsupportedFeatureForVersion {
@@ -235,7 +237,7 @@ pub fn load_qpy(
                 qpy_file_header.qpy_version,
                 metadata_deserializer,
                 use_symengine,
-                annotation_factories,
+                annotation_handler.child()?,
             )?;
         }
     } else {
@@ -255,7 +257,7 @@ pub fn load_qpy(
                 qpy_file_header.qpy_version,
                 metadata_deserializer,
                 use_symengine,
-                annotation_factories,
+                annotation_handler.child()?,
             )?;
         }
     }
@@ -272,7 +274,7 @@ pub fn py_load_qpy(
     annotation_factories: Option<Bound<PyDict>>,
 ) -> Result<Vec<Py<PyAny>>, QpyError> {
     let annotation_factories = annotation_factories.unwrap_or(PyDict::new(py));
-
+    let annotation_handler = AnnotationHandler::python(&annotation_factories.clone().unbind())?;
     // Read all data from file object
     // TODO: When we read from a rust native stream, maybe we can seek according to the circuit offsets instead of reading everything at once
     let data: Bytes = file_obj.call_method0("read")?.extract()?;
@@ -282,6 +284,6 @@ pub fn py_load_qpy(
         &data,
         version,
         metadata_deserializer.as_ref(),
-        &annotation_factories,
+        annotation_handler,
     )
 }

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -124,7 +124,7 @@ pub struct QPYWriteData<'a> {
     pub circuit_data: &'a CircuitData,
     pub version: u8,
     pub standalone_var_indices: HashMap<u128, u16>, // mapping from the variable's UUID to its index in the standalone variables list
-    pub annotation_handler: AnnotationHandler<'a>,
+    pub annotation_handler: AnnotationHandler,
 }
 
 // Data that is needed globally while reading the circuit
@@ -136,7 +136,7 @@ pub struct QPYReadData<'a> {
     pub standalone_vars: HashMap<u16, qiskit_circuit::Var>,
     pub standalone_stretches: HashMap<u16, qiskit_circuit::Stretch>,
     pub vectors: HashMap<Uuid, Arc<SymbolVector>>,
-    pub annotation_handler: AnnotationHandler<'a>,
+    pub annotation_handler: AnnotationHandler,
 }
 
 // this is how tags for various value types are encoded in a QPY file
@@ -573,7 +573,7 @@ pub(crate) fn load_value(
                     qpy_data.version,
                     None,
                     qpy_data.use_symengine,
-                    qpy_data.annotation_handler.annotation_factories,
+                    qpy_data.annotation_handler.child()?,
                 )?;
                 Ok(GenericValue::Circuit(circuit))
             })
@@ -640,7 +640,7 @@ pub(crate) fn serialize_generic_value(
                 None,
                 false,
                 qpy_data.version,
-                qpy_data.annotation_handler.annotation_factories,
+                qpy_data.annotation_handler.child()?,
             )?;
             let serialized_circuit = serialize(&packed_circuit)?;
             Ok((ValueType::Circuit, serialized_circuit))
@@ -655,7 +655,7 @@ pub(crate) fn serialize_generic_value(
                 None,
                 false,
                 qpy_data.version,
-                qpy_data.annotation_handler.annotation_factories,
+                qpy_data.annotation_handler.child()?,
             )?;
             let serialized_circuit = serialize(&packed_circuit)?;
             Ok((ValueType::Circuit, serialized_circuit))

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -103,6 +103,13 @@ class _AnnotationSerializationState:
             (namespace, serializer)
             for (namespace, (_, serializer)) in self.serializers.items()
         )
+    
+    def dump_states(self) -> list[tuple[str, bytes]]:
+        """Return the serialized state for each serializer, in index order."""
+        return [
+            (namespace, serializer.dump_state())
+            for namespace, serializer in self.iter_serializers()
+        ]
 
 
 class _AnnotationDeserializationState:

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -103,7 +103,7 @@ class _AnnotationSerializationState:
             (namespace, serializer)
             for (namespace, (_, serializer)) in self.serializers.items()
         )
-    
+
     def dump_states(self) -> list[tuple[str, bytes]]:
         """Return the serialized state for each serializer, in index order."""
         return [


### PR DESCRIPTION
# Summary
Rewrites the `AnnotationHandler` for the QPY module to reduce code duplication and provide an interface for future, non-python based, handler.

# Details
The existing `AnnotationHanlder` in the QPY module is written in Rust but mostly mimics what the Python `_AnnotationSerializationState` class does, using pyo3 calls. This was originally done in this manner in case we'll remove `_AnnotationSerializationState` but it seem irrelevant now. Instead, we need to allow for the possibility of rust native annotation handler for a Python-free path, even if currently that handler does nothing. So the goal of this PR is both to add such a handler and to shrink the python handler back into being a simple wrapper around `_AnnotationSerializationState`.

This PR rewrites the AnnotationHandler struct. It now has two variants, a Native variant which does nothing currently, since we do not support annotations in pure Rust yet, and  Python variant maintaining python pointers to the factories and serialization/deserialization states used in the Python _AnnotationSerializationState class. This handler acts as a wrapper for the python code, and uses the child method to create a copy of itself to use in recursive circuit parsing.

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
