### PR TITLE
Use relative-phase Toffoli gates in VBE adders and fix fixed-width addition

### DIFF
--- a/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
@@ -19,6 +19,10 @@ from .adder import Adder
 class VBERippleCarryAdder(Adder):
     r"""The VBE ripple carry adder [1].
 
+    Carry computations that are later uncomputed use relative-phase Toffoli gates,
+    whose phases cancel with their inverse. The final carry computation remains exact
+    when the circuit has a carry-out qubit.
+
     This circuit performs inplace addition of two equally-sized quantum registers.
     As an example, a classical adder circuit that performs full addition (i.e. including
     a carry-in bit) on two 2-qubit sized registers is as follows:

--- a/qiskit/synthesis/arithmetic/adders/vbe_ripple_carry_adder.py
+++ b/qiskit/synthesis/arithmetic/adders/vbe_ripple_carry_adder.py
@@ -20,8 +20,11 @@ from qiskit.circuit import QuantumRegister, AncillaRegister, QuantumCircuit, Bit
 def adder_ripple_v95(num_state_qubits: int, kind: str = "half") -> QuantumCircuit:
     r"""The VBE ripple carry adder [1].
 
-    This method uses :math:`4n + O(1)` CCX gates and :math:`4n + 1` CX gates at a depth
-    of :math:`6n - 2` [2].
+    This method uses :math:`4n + O(1)` RCCX gates, at most two CCX gates, and
+    :math:`4n + O(1)` CX gates at a depth of :math:`6n + O(1)` [2]. The relative
+    phases introduced while computing the carry bits cancel during uncomputation.
+    The two exact CCX gates are only required when writing a carry-out bit; a
+    fixed-sized adder uses no exact CCX gates.
 
     This circuit performs inplace addition of two equally-sized quantum registers.
     As an example, a classical adder circuit that performs full addition (i.e. including
@@ -29,25 +32,26 @@ def adder_ripple_v95(num_state_qubits: int, kind: str = "half") -> QuantumCircui
 
     .. parsed-literal::
 
-                  ┌────────┐                       ┌───────────┐┌──────┐
-           cin_0: ┤0       ├───────────────────────┤0          ├┤0     ├
-                  │        │                       │           ││      │
-             a_0: ┤1       ├───────────────────────┤1          ├┤1     ├
-                  │        │┌────────┐     ┌──────┐│           ││  Sum │
-             a_1: ┤        ├┤1       ├──■──┤1     ├┤           ├┤      ├
-                  │        ││        │  │  │      ││           ││      │
-             b_0: ┤2 Carry ├┤        ├──┼──┤      ├┤2 Carry_dg ├┤2     ├
-                  │        ││        │┌─┴─┐│      ││           │└──────┘
-             b_1: ┤        ├┤2 Carry ├┤ X ├┤2 Sum ├┤           ├────────
-                  │        ││        │└───┘│      ││           │
-          cout_0: ┤        ├┤3       ├─────┤      ├┤           ├────────
-                  │        ││        │     │      ││           │
-        helper_0: ┤3       ├┤0       ├─────┤0     ├┤3          ├────────
-                  └────────┘└────────┘     └──────┘└───────────┘
+                  ┌───────────┐                       ┌──────────────┐┌──────┐
+           cin_0: ┤0          ├───────────────────────┤0             ├┤0     ├
+                  │           │                       │              ││      │
+             a_0: ┤1          ├───────────────────────┤1             ├┤1     ├
+                  │           │┌────────┐     ┌──────┐│              ││  Sum │
+             a_1: ┤           ├┤1       ├──■──┤1     ├┤              ├┤      ├
+                  │           ││        │  │  │      ││              ││      │
+             b_0: ┤2 Carry_rp ├┤        ├──┼──┤      ├┤2 Carry_rp_dg ├┤2     ├
+                  │           ││        │┌─┴─┐│      ││              │└──────┘
+             b_1: ┤           ├┤2 Carry ├┤ X ├┤2 Sum ├┤              ├────────
+                  │           ││        │└───┘│      ││              │
+          cout_0: ┤           ├┤3       ├─────┤      ├┤              ├────────
+                  │           ││        │     │      ││              │
+        helper_0: ┤3          ├┤0       ├─────┤0     ├┤3             ├────────
+                  └───────────┘└────────┘     └──────┘└──────────────┘└──────┘
 
 
     Here *Carry* and *Sum* gates correspond to the gates introduced in [1].
-    *Carry_dg* correspond to the inverse of the *Carry* gate. Note that
+    *Carry_rp* is a relative-phase implementation of *Carry*, and *Carry_rp_dg*
+    is its inverse. Note that
     in this implementation the input register qubits are ordered as all qubits from
     the first input register, followed by all qubits from the second input register.
     This is different ordering as compared to Figure 2 in [1], which leads to a different
@@ -111,7 +115,14 @@ def adder_ripple_v95(num_state_qubits: int, kind: str = "half") -> QuantumCircui
     qc_carry.cx(1, 2)
     qc_carry.ccx(0, 2, 3)
     carry_gate = qc_carry.to_gate()
-    carry_gate_dg = carry_gate.inverse()
+
+    # Relative-phase Carry gates can be used whenever the carry is later uncomputed.
+    qc_carry_rp = QuantumCircuit(4, name="Carry_rp")
+    qc_carry_rp.rccx(1, 2, 3)
+    qc_carry_rp.cx(1, 2)
+    qc_carry_rp.rccx(0, 2, 3)
+    carry_gate_rp = qc_carry_rp.to_gate()
+    carry_gate_rp_dg = carry_gate_rp.inverse()
 
     # corresponds to Sum gate in [1]
     qc_sum = QuantumCircuit(3, name="Sum")
@@ -123,23 +134,31 @@ def adder_ripple_v95(num_state_qubits: int, kind: str = "half") -> QuantumCircui
     i = 0
     if kind == "half":
         i += 1
-        circuit.ccx(qr_a[0], qr_b[0], carries[0])
+        if num_state_qubits == 1:
+            circuit.ccx(qr_a[0], qr_b[0], carries[0])
+        else:
+            circuit.rccx(qr_a[0], qr_b[0], carries[0])
     elif kind == "fixed":
         i += 1
         if num_state_qubits == 1:
             circuit.cx(qr_a[0], qr_b[0])
         else:
-            circuit.ccx(qr_a[0], qr_b[0], carries[0])
+            circuit.rccx(qr_a[0], qr_b[0], carries[0])
 
     for inp, out in zip(carries[:-1], carries[1:]):
-        circuit.append(carry_gate, [inp, qr_a[i], qr_b[i], out])
+        # A Carry that writes the carry-out is not uncomputed, so it must remain exact.
+        gate = carry_gate if kind in ["full", "half"] and out == qr_cout[0] else carry_gate_rp
+        circuit.append(gate, [inp, qr_a[i], qr_b[i], out])
         i += 1
 
     if kind in ["full", "half"]:  # final CX (cancels for the 'fixed' case)
         circuit.cx(qr_a[-1], qr_b[-1])
 
-    if len(carries) > 1:
-        circuit.append(sum_gate, [carries[-2], qr_a[-1], qr_b[-1]])
+    if carries and (kind == "fixed" or len(carries) > 1):
+        # Fixed adders have no carry-out, so their last helper is the carry into
+        # the most-significant bit. Otherwise, that carry is the penultimate one.
+        carry = carries[-1] if kind == "fixed" else carries[-2]
+        circuit.append(sum_gate, [carry, qr_a[-1], qr_b[-1]])
 
     i -= 2
     for j, (inp, out) in enumerate(zip(reversed(carries[:-1]), reversed(carries[1:]))):
@@ -148,12 +167,12 @@ def adder_ripple_v95(num_state_qubits: int, kind: str = "half") -> QuantumCircui
                 i += 1
             else:
                 continue
-        circuit.append(carry_gate_dg, [inp, qr_a[i], qr_b[i], out])
+        circuit.append(carry_gate_rp_dg, [inp, qr_a[i], qr_b[i], out])
         circuit.append(sum_gate, [inp, qr_a[i], qr_b[i]])
         i -= 1
 
     if kind in ["half", "fixed"] and num_state_qubits > 1:
-        circuit.ccx(qr_a[0], qr_b[0], carries[0])
+        circuit.rccx(qr_a[0], qr_b[0], carries[0])
         circuit.cx(qr_a[0], qr_b[0])
 
     return circuit

--- a/releasenotes/notes/optimize-vbe-rccx-6f1d7f45f20844bb.yaml
+++ b/releasenotes/notes/optimize-vbe-rccx-6f1d7f45f20844bb.yaml
@@ -1,0 +1,15 @@
+---
+features_synthesis:
+  - |
+    Updated :func:`.adder_ripple_v95` to use relative-phase Toffoli gates for
+    carry computations that are later uncomputed. For an :math:`n`-bit full
+    adder, this reduces the CX count from :math:`24n - 14` to
+    :math:`16n - 6` and the T-count from :math:`22n - 10` to :math:`12n` at
+    optimization level 2, without changing the implemented unitary. Half and
+    fixed-sized VBE adders receive analogous reductions; the exact Toffoli gates
+    that write a carry-out bit are preserved.
+fixes:
+  - |
+    Corrected :func:`.adder_ripple_v95` for ``kind="fixed"`` to add the final
+    carry into the most-significant sum bit. Previously, fixed-sized VBE adders
+    with at least two state qubits implemented an incorrect permutation.

--- a/test/python/circuit/library/test_adders.py
+++ b/test/python/circuit/library/test_adders.py
@@ -62,9 +62,9 @@ class TestAdder(QiskitTestCase):
     ):
         """Assert that adder correctly implements the summation.
 
-        This test prepares a equal superposition state in both input registers, then performs
-        the addition on the superposition and checks that the output state is the expected
-        superposition of all possible additions.
+        This test prepares a superposition with a distinct amplitude for every input, then
+        performs the addition and checks the output state. The distinct amplitudes ensure
+        that both the input-output mapping and relative phases are verified.
 
         Args:
             num_state_qubits: The number of bits in the numbers that are added.
@@ -75,26 +75,22 @@ class TestAdder(QiskitTestCase):
                 into a third register of appropriate size.
             kind: The kind of adder; "fixed", "half", or "full".
         """
-        circuit = QuantumCircuit(*adder.qregs)
-
-        # create equal superposition
         if kind == "full":
             num_superpos_qubits = 2 * num_state_qubits + 1
         else:
             num_superpos_qubits = 2 * num_state_qubits
-        circuit.h(range(num_superpos_qubits))
 
-        # apply adder circuit
-        circuit.compose(adder, inplace=True)
-
-        # obtain the statevector and the probabilities, we don't trace out the ancilla qubits
-        # as we verify that all ancilla qubits have been uncomputed to state 0 again
-        statevector = Statevector(circuit)
-        probabilities = statevector.probabilities()
-        pad = "0" * circuit.num_ancillas  # state of the ancillas
+        # Use a distinct positive amplitude for each input basis state. Input qubits are
+        # the least-significant qubits and all output and helper qubits start in state 0.
+        amplitudes = np.arange(1, 2**num_superpos_qubits + 1, dtype=float)
+        amplitudes /= np.linalg.norm(amplitudes)
+        initial_state = np.zeros(2**adder.num_qubits, dtype=complex)
+        initial_state[: len(amplitudes)] = amplitudes
+        statevector = Statevector(initial_state).evolve(adder)
+        pad = "0" * adder.num_ancillas  # state of the ancillas
 
         # compute the expected results
-        expectations = np.zeros_like(probabilities)
+        expected_state = np.zeros_like(statevector.data)
         num_bits_sum = num_state_qubits + 1
         # iterate over all possible inputs
         for x in range(2**num_state_qubits):
@@ -112,6 +108,11 @@ class TestAdder(QiskitTestCase):
                 bin_y = bin(y)[2:].zfill(num_state_qubits)
 
                 for i, addition in enumerate(additions):
+                    if kind == "full":
+                        input_index = i | (x << 1) | (y << (num_state_qubits + 1))
+                    else:
+                        input_index = x | (y << num_state_qubits)
+
                     bin_res = bin(addition)[2:].zfill(num_bits_sum)
                     if kind == "full":
                         cin = str(i)
@@ -126,9 +127,9 @@ class TestAdder(QiskitTestCase):
                         )
 
                     index = int(bin_index, 2)
-                    expectations[index] += 1 / 2**num_superpos_qubits
+                    expected_state[index] = initial_state[input_index]
 
-        np.testing.assert_array_almost_equal(expectations, probabilities)
+        np.testing.assert_array_almost_equal(expected_state, statevector.data)
 
     @data(
         (3, "cdkm", "half"),
@@ -176,7 +177,22 @@ class TestAdder(QiskitTestCase):
                     with self.assertWarns(DeprecationWarning):
                         circuit = ADDER_CIRCUITS[adder](num_state_qubits, kind)
 
-        self.assertAdditionIsCorrect(num_state_qubits, circuit, True, kind)
+                self.assertAdditionIsCorrect(num_state_qubits, circuit, True, kind)
+
+    @data(
+        ("full", 8, 2),
+        ("half", 6, 2),
+        ("fixed", 6, 0),
+    )
+    @unpack
+    def test_vbe_relative_phase_toffoli_counts(self, kind, expected_rccx, expected_ccx):
+        """Test that only carry-out computations use exact Toffoli gates."""
+        circuit = adder_ripple_v95(3, kind=kind).decompose(
+            gates_to_decompose=["Carry", "Carry_rp", "Carry_rp_dg", "Sum"]
+        )
+        counts = circuit.count_ops()
+        self.assertEqual(counts.get("rccx", 0), expected_rccx)
+        self.assertEqual(counts.get("ccx", 0), expected_ccx)
 
     @data(
         adder_ripple_c04,
@@ -214,7 +230,7 @@ class TestAdder(QiskitTestCase):
         # an operation we expect to be in the circuit with given plugin name
         expected_ops = {
             "ripple_c04": "MAJ",
-            "ripple_v95": "Carry",
+            "ripple_v95": "Carry_rp",
             "ripple_r25": "ccx",
             "qft_d00": "cp",
             "modular_v17": "rccx",

--- a/test/python/synthesis/test_arithmetic_counts.py
+++ b/test/python/synthesis/test_arithmetic_counts.py
@@ -21,7 +21,7 @@ from ddt import data, ddt, unpack
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.arithmetic.adders import ModularAdderGate
 from qiskit.circuit.library.arithmetic.multipliers import MultiplierGate
-from qiskit.synthesis.arithmetic import adder_modular_v17
+from qiskit.synthesis.arithmetic import adder_modular_v17, adder_ripple_v95
 from qiskit.transpiler import (
     generate_preset_clifford_t_pass_manager,
     generate_preset_pass_manager,
@@ -39,6 +39,9 @@ class TestAdderSynthesisCounts(QiskitTestCase):
         # Need optimization level 2 for small modular adder counts
         self.pm = generate_preset_pass_manager(
             optimization_level=2, basis_gates=["u", "cx"], seed_transpiler=12345
+        )
+        self.clifford_t_pm = generate_preset_clifford_t_pass_manager(
+            optimization_level=2, seed_transpiler=12345
         )
 
     @data(
@@ -67,6 +70,22 @@ class TestAdderSynthesisCounts(QiskitTestCase):
         cx_count = transpiled.count_ops().get("cx", 0)
         self.assertLessEqual(cx_count, 16 * num_qubits - 13)
         self.assertEqual(transpiled.num_qubits, 2 * num_qubits)
+
+    @data(
+        ("fixed", 2, -23, -16),
+        ("half", 2, -15, -4),
+        ("full", 1, -6, 0),
+    )
+    @unpack
+    def test_vbe_adder_counts(self, kind, min_num_qubits, cx_offset, t_offset):
+        """Test CX and T-count upper bounds of the optimized VBE adder."""
+        for num_qubits in range(min_num_qubits, 17):
+            circuit = adder_ripple_v95(num_qubits, kind=kind)
+            cx_count = self.pm.run(circuit).count_ops().get("cx", 0)
+            clifford_t_ops = self.clifford_t_pm.run(circuit).count_ops()
+            t_count = clifford_t_ops.get("t", 0) + clifford_t_ops.get("tdg", 0)
+            self.assertLessEqual(cx_count, 16 * num_qubits + cx_offset)
+            self.assertLessEqual(t_count, 12 * num_qubits + t_offset)
 
 
 @ddt


### PR DESCRIPTION
This PR replaces the CCX gates in VBE carry compute-uncompute pairs with RCCX gates in the spirit of #16695 as suggested by @ShellyGarion. This PR also fixes a pre-existing error in fixed-sized VBE addition. HLS default selection is unchanged.

## Correctness fix

For `kind="fixed"`, the carry list contains only helper qubits because there is no carry-out. The carry entering the most-significant bit is therefore `carries[-1]`. The previous implementation used `carries[-2]`: for two-bit adders this skipped the final sum operation entirely, while larger adders used the carry from one bit position too early.

The previous test prepared a uniform superposition and compared output probabilities. Since an arithmetic circuit permutes computational-basis states, an incorrect permutation leaves that distribution unchanged. The shared adder test now assigns a distinct amplitude to every input state and compares the complete statevector. This verifies the arithmetic mapping, relative phases, and helper-qubit uncomputation for every tested adder implementation, not only VBE.

## Direct VBE improvement

| Kind | CX before | CX after | T/Tdg before | T/Tdg after |
|---|---:|---:|---:|---:|
| Fixed (`n >= 3`) | `24n - 35` | `16n - 23` | `22n - 32` | `12n - 16` |
| Half (`n >= 2`) | `24n - 27` | `16n - 15` | `22n - 20` | `12n - 4` |
| Full | `24n - 14` | `16n - 6` | `22n - 10` | `12n` |

<img width="2180" height="1969" alt="vbe-resource-counts" src="https://github.com/user-attachments/assets/01bb9a6f-2539-406c-a076-c9a5fa46d948" />

The complete benchmark covers fixed, half, and full VBE adders for every width from `n = 1` through `n = 16`. None of the comparisons regress. All counts use optimization level 2 with `seed_transpiler=12345`. CX counts use the `u`/`cx` basis, and T-counts use the preset Clifford+T pass manager.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: Codex (GPT 5.6)
- [ ] I used the following tool to generate or modify code: