### PR TITLE
Remove unused code from the QPY module

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -27,7 +27,7 @@ use numpy::IntoPyArray;
 use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyAny, PyBytes, PyDict, PyList, PyString, PyTuple, PyType};
+use pyo3::types::{IntoPyDict, PyAny, PyDict, PyList, PyString, PyTuple, PyType};
 use qiskit_circuit::bit::{
     ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
@@ -1620,40 +1620,6 @@ pub(crate) fn unpack_circuit(
         circuit.setattr("_layout", layout)?;
     }
     Ok(circuit.unbind().as_any().clone())
-}
-
-#[pyfunction]
-#[pyo3(name = "read_circuit")]
-#[pyo3(signature = (file_obj, version, metadata_deserializer, use_symengine, annotation_factories))]
-pub(crate) fn py_read_circuit(
-    py: Python,
-    file_obj: &Bound<PyAny>,
-    version: u8,
-    metadata_deserializer: &Bound<PyAny>,
-    use_symengine: bool,
-    annotation_factories: &Bound<PyDict>,
-) -> Result<Py<PyAny>, QpyError> {
-    let pos = file_obj.call_method0("tell")?.extract::<usize>()?;
-    let bytes = file_obj.call_method0("read")?;
-    let serialized_circuit: &[u8] = bytes
-        .cast::<PyBytes>()
-        .map_err(|_| QpyError::InvalidPythonType {
-            python_type: "PyBytes".to_string(),
-            name: "serialized_circuit".to_string(),
-        })?
-        .as_bytes();
-    let (packed_circuit, bytes_read) =
-        deserialize_with_args::<formats::QPYCircuit, (u8,)>(serialized_circuit, (version,))?;
-    let unpacked_circuit = unpack_circuit(
-        py,
-        &packed_circuit,
-        version,
-        Some(metadata_deserializer),
-        use_symengine,
-        annotation_factories,
-    )?;
-    file_obj.call_method1("seek", (pos + bytes_read,))?;
-    Ok(unpacked_circuit)
 }
 
 // handling for non control flow gates with conditionals, for backwards compatability

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -1039,7 +1039,6 @@ fn pack_custom_instruction(
             Some(serialize(&pack_circuit(
                 &mut gate.getattr("_definition")?.extract()?,
                 Some(py.None().bind(py)),
-                false,
                 qpy_data.version,
                 qpy_data.annotation_handler.annotation_factories,
             )?)?)
@@ -1054,7 +1053,6 @@ fn pack_custom_instruction(
                 pack_circuit(
                     &mut defn,
                     Some(py.None().bind(py)),
-                    false,
                     qpy_data.version,
                     qpy_data.annotation_handler.annotation_factories,
                 )
@@ -1205,7 +1203,6 @@ fn pack_standalone_vars(
 pub(crate) fn pack_circuit(
     circuit: &mut QuantumCircuitData,
     metadata_serializer: Option<&Bound<PyAny>>,
-    _use_symengine: bool,
     version: u8,
     annotation_factories: &Bound<PyDict>,
 ) -> Result<formats::QPYCircuit, QpyError> {
@@ -1248,31 +1245,4 @@ pub(crate) fn pack_circuit(
         calibrations,
         layout,
     })
-}
-
-#[pyfunction]
-#[pyo3(name = "write_circuit")]
-#[pyo3(signature = (file_obj, circuit, metadata_serializer, use_symengine, version, annotation_factories))]
-pub(crate) fn py_write_circuit(
-    py: Python,
-    file_obj: &Bound<PyAny>,
-    circuit: &Bound<PyAny>,
-    metadata_serializer: &Bound<PyAny>,
-    use_symengine: bool,
-    version: u8,
-    annotation_factories: &Bound<PyDict>,
-) -> PyResult<usize> {
-    let packed_circuit = pack_circuit(
-        &mut circuit.extract()?,
-        Some(metadata_serializer),
-        use_symengine,
-        version,
-        annotation_factories,
-    )?;
-    let serialized_circuit = serialize(&packed_circuit)?;
-    file_obj.call_method1(
-        "write",
-        (pyo3::types::PyBytes::new(py, &serialized_circuit),),
-    )?;
-    Ok(serialized_circuit.len())
 }

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -60,7 +60,6 @@ const QPY_WRITE_MIN_VERSION: u8 = 17;
 pub fn dump_qpy(
     mut circuits: Vec<QuantumCircuitData>,
     metadata_serializer: Option<Bound<PyAny>>,
-    use_symengine: bool,
     qpy_version: u8,
     annotation_factories: Bound<PyDict>,
 ) -> Result<Bytes, QpyError> {
@@ -77,21 +76,16 @@ pub fn dump_qpy(
             serialize(&pack_circuit(
                 circuit,
                 metadata_serializer.as_ref(),
-                use_symengine,
                 qpy_version,
                 &annotation_factories,
             )?)
         })
         .collect::<Result<Vec<Bytes>, QpyError>>()?;
-    let symbolic_encoding = match use_symengine {
-        true => SymbolicEncoding::Symengine,
-        false => SymbolicEncoding::Sympy,
-    };
     let qpy_header = QPYFileHeader {
         qpy_version,
         qiskit_version: QISKIT_VERSION,
         num_programs: serialized_circuits.len() as u64,
-        symbolic_encoding,
+        symbolic_encoding: SymbolicEncoding::Sympy,
         type_key: ProgramType::Circuit, //for now, no other value type is used
     };
     let serialized_qpy_header = serialize(&qpy_header)?;
@@ -130,7 +124,6 @@ pub fn py_dump_qpy(
     programs: &Bound<PyAny>,
     file_obj: &Bound<PyAny>,
     metadata_serializer: Option<Bound<PyAny>>,
-    use_symengine: Option<bool>,
     version: u8,
     annotation_factories: Option<Bound<PyDict>>,
 ) -> PyResult<()> {
@@ -138,7 +131,6 @@ pub fn py_dump_qpy(
     let serialized_qpy = dump_qpy(
         programs.extract()?,
         metadata_serializer,
-        use_symengine.unwrap_or(false),
         version,
         annotation_factories,
     )?;

--- a/crates/qpy/src/lib.rs
+++ b/crates/qpy/src/lib.rs
@@ -35,8 +35,6 @@ mod value;
 /// Internal module supplying the QPY capabilities.  The entries in it should largely
 /// be re-exposed directly to public Python space.
 pub fn qpy(module: &Bound<PyModule>) -> PyResult<()> {
-    module.add_function(wrap_pyfunction!(circuit_writer::py_write_circuit, module)?)?;
-    module.add_function(wrap_pyfunction!(circuit_reader::py_read_circuit, module)?)?;
     module.add_function(wrap_pyfunction!(interface::py_dump_qpy, module)?)?;
     module.add_function(wrap_pyfunction!(interface::py_load_qpy, module)?)?;
     Ok(())

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -638,7 +638,6 @@ pub(crate) fn serialize_generic_value(
             let packed_circuit = pack_circuit(
                 &mut circuit.extract(py)?, // TODO: can we avoid cloning here?
                 None,
-                false,
                 qpy_data.version,
                 qpy_data.annotation_handler.annotation_factories,
             )?;
@@ -653,7 +652,6 @@ pub(crate) fn serialize_generic_value(
             let packed_circuit = pack_circuit(
                 &mut quantum_circuit_data,
                 None,
-                false,
                 qpy_data.version,
                 qpy_data.annotation_handler.annotation_factories,
             )?;

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -202,7 +202,6 @@ def dump(
             programs,
             file_obj,
             metadata_serializer,
-            bool(use_symengine),
             version,
             annotation_factories,
         )

--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -364,7 +364,7 @@ class TestUseSymengineFlag(QpyCircuitTestCase):
         # Also check the qpy symbolic expression encoding is correct in the
         # payload
         with io.BytesIO() as file_obj:
-            dump(qc, file_obj, use_symengine=Booly(use_symengine))
+            dump(qc, file_obj, use_symengine=Booly(use_symengine), version=13)
             file_obj.seek(0)
             header_data = FILE_HEADER_V10._make(
                 struct.unpack(


### PR DESCRIPTION
# Summary
Removes the `py_read_circuit` and `py_write_circuit` methods and the `use_symengine` parameter.

# Details

* Removed the py_read_circuit and py_write_circuit which are no longer used now that we have the direct dump and load path which were added in #15749.
* Removed the use_symengine parameter from the dump functions as it is always false and ignored inside the code itself, whcih is downright misleading (we will need to change it if we decide to support QPY<17 in Rust, although it seems unlikely at this stage).


### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
