### PR TITLE
Remove stale note about symengine from qpy.dump docs

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -159,21 +159,11 @@ def dump(
                 from the QPY format at that version will persist. This should only be used if
                 compatibility with loading the payload with an older version of Qiskit is necessary.
 
-            .. note::
-
-                If serializing a :class:`.QuantumCircuit` that contains
-                :class:`.ParameterExpression` objects with ``version`` set low with the intent to
-                load the payload using a historical release of Qiskit, it is safest to set the
-                ``use_symengine`` flag to ``False``.  Versions of Qiskit prior to 1.2.4 cannot load
-                QPY files containing ``symengine``-serialized :class:`.ParameterExpression` objects
-                unless the version of ``symengine`` used between the loading and generating
-                environments matches.
         annotation_factories: Mapping of namespaces to functions that create new instances of
             :class:`.annotation.QPUSerializer`, for handling the dumping of custom
             :class:`.Annotation` objects.  The subsequent call to :func:`load` will need to use
             similar serializer objects, that understand the custom output format of those
             serializers.
-
 
     Raises:
         TypeError: When invalid data type is input.


### PR DESCRIPTION
This commit removes a stale note from the qpy.dump docs about symengine compatibility. Since Qiskit 2.0 set the QPY_COMPATIBILITY_VERSION to QPY format version 13 the dump function no longer supports using symengine or sympy symbolic encoding for ParameterExpression objects in a circuit. The argument persists for backwards compatibility but has no impact on the generated QPY. The warning about using symengine encoding doesn't matter anymore, and only would make a difference in QPY format versions 10, 11, and 12 which can no longer be generated with qpy.dump().

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
