### PR TITLE
Emit bare `barrier;` for global barriers in OpenQASM 3 export

### DIFF
--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1065,14 +1065,19 @@ impl<'a> QASM3Builder {
             .circuit_data
             .qargs_interner()
             .get(instr.qubits);
-        let mut qubit_ids = Vec::new();
         let qubits_registry = self.circuit_scope.circuit_data.qubits();
 
-        for q in qargs {
-            let id = self.lookup_bit(&BitType::ShareableQubit(
-                qubits_registry.get(*q).unwrap().clone(),
-            ))?;
-            qubit_ids.push(id.to_owned());
+        // Emit a bare `barrier;` when the instruction covers every qubit in the
+        // current scope (OpenQASM 3 global barrier; see #13485).
+        let is_global = qargs.len() == qubits_registry.len();
+        let mut qubit_ids = Vec::new();
+        if !is_global {
+            for q in qargs {
+                let id = self.lookup_bit(&BitType::ShareableQubit(
+                    qubits_registry.get(*q).unwrap().clone(),
+                ))?;
+                qubit_ids.push(id.to_owned());
+            }
         }
         stmts.push(Statement::QuantumInstruction(QuantumInstruction::Barrier(
             Barrier {

--- a/crates/qasm3/src/printer.rs
+++ b/crates/qasm3/src/printer.rs
@@ -541,15 +541,20 @@ impl<'a> BasicPrinter<'a> {
 
     fn visit_quantum_barrier(&mut self, instruction: &Barrier) {
         self.start_line();
-        write!(self.stream, "barrier ").unwrap();
-        let index_identifier_vec: Vec<Expression> = instruction
-            .index_identifier_list
-            .iter()
-            .cloned()
-            .map(Expression::IdentifierOrSubscripted)
-            .collect();
-        let index_identifier_list: &[Expression] = &index_identifier_vec;
-        self.visit_expression_sequence(index_identifier_list, "", "", ", ");
+        if instruction.index_identifier_list.is_empty() {
+            // Global barrier: OpenQASM 3 allows a bare `barrier;` with no operands.
+            write!(self.stream, "barrier").unwrap();
+        } else {
+            write!(self.stream, "barrier ").unwrap();
+            let index_identifier_vec: Vec<Expression> = instruction
+                .index_identifier_list
+                .iter()
+                .cloned()
+                .map(Expression::IdentifierOrSubscripted)
+                .collect();
+            let index_identifier_list: &[Expression] = &index_identifier_vec;
+            self.visit_expression_sequence(index_identifier_list, "", "", ", ");
+        }
         self.end_statement();
     }
 

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1090,8 +1090,17 @@ class QASM3Builder:
             elif isinstance(instruction.operation, Gate):
                 nodes = [self.build_gate_call(instruction)]
             elif isinstance(instruction.operation, Barrier):
-                operands = [self._lookup_bit(operand) for operand in instruction.qubits]
-                nodes = [ast.QuantumBarrier(operands)]
+                # Emit a bare `barrier;` when the instruction covers every qubit in
+                # the current scope.  OpenQASM 3 treats that as a global barrier, and
+                # it avoids listing every qubit for wide circuits (see #13485).
+                circuit_qubits = self.scope.circuit.qubits
+                if len(instruction.qubits) == len(circuit_qubits) and set(
+                    instruction.qubits
+                ) == set(circuit_qubits):
+                    nodes = [ast.QuantumBarrier([])]
+                else:
+                    operands = [self._lookup_bit(operand) for operand in instruction.qubits]
+                    nodes = [ast.QuantumBarrier(operands)]
             elif isinstance(instruction.operation, Measure):
                 measurement = ast.QuantumMeasurement(
                     [self._lookup_bit(operand) for operand in instruction.qubits]

--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -445,8 +445,12 @@ class BasicPrinter:
 
     def _visit_QuantumBarrier(self, node: ast.QuantumBarrier) -> None:
         self._start_line()
-        self.stream.write("barrier ")
-        self._visit_sequence(node.indexIdentifierList, separator=", ")
+        if node.indexIdentifierList:
+            self.stream.write("barrier ")
+            self._visit_sequence(node.indexIdentifierList, separator=", ")
+        else:
+            # Global barrier: OpenQASM 3 allows a bare `barrier;` with no operands.
+            self.stream.write("barrier")
         self._end_statement()
 
     def _visit_ProgramBlock(self, node: ast.ProgramBlock) -> None:

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -199,7 +199,7 @@ class TestCircuitQASM3(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",
                 "cr[1] = measure qr[1];",
@@ -239,7 +239,7 @@ class TestCircuitQASM3(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",
                 "cr[1] = measure qr[1];",
@@ -280,7 +280,7 @@ class TestCircuitQASM3(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",
@@ -1974,7 +1974,7 @@ qubit[5] q;
 stretch a;
 stretch b;
 stretch c;
-barrier q[0], q[1], q[2], q[3], q[4];
+barrier;
 cx q[0], q[1];
 U(pi/4, 0, pi/2) q[2];
 cx q[3], q[4];
@@ -1983,7 +1983,7 @@ delay[a] q[1];
 delay[b] q[2];
 delay[c] q[3];
 delay[c] q[4];
-barrier q[0], q[1], q[2], q[3], q[4];
+barrier;
 """
         self.assertEqual(dumps(qc), expected)
 
@@ -3029,7 +3029,7 @@ class TestQASM3ExporterRust(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",
                 "cr[1] = measure qr[1];",
@@ -3069,7 +3069,7 @@ class TestQASM3ExporterRust(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",
                 "cr[1] = measure qr[1];",
@@ -3110,7 +3110,7 @@ class TestQASM3ExporterRust(QiskitTestCase):
                 "qubit[2] qr;",
                 "h qr[0];",
                 "cx qr[0], qr[1];",
-                "barrier qr[0], qr[1];",
+                "barrier;",
                 "composite_circ qr[0], qr[1];",
                 "composite_circ qr[0], qr[1];",
                 "cr[0] = measure qr[0];",


### PR DESCRIPTION
## Summary
- When a `Barrier` covers every qubit in the current export scope, dump OpenQASM 3's global form `barrier;` instead of listing each qubit.
- Applies to the Python exporter and the experimental Rust exporter.
- Updates export test expectations accordingly.

Fixes #13485

## Test plan
- [ ] `pytest test/python/qasm3/test_export.py -k barrier`
- [ ] Confirm partial barriers (e.g. `qc.barrier(0, 1)`) still list operands
- [ ] Confirm `qc.barrier()` round-trips via import of bare `barrier;`