### PR TITLE
Add Rust-native circuit annotations

### DIFF
--- a/crates/circuit/src/annotation.rs
+++ b/crates/circuit/src/annotation.rs
@@ -13,6 +13,176 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
+use std::any::Any;
+use std::fmt::Debug;
+
+/// Private traits that allow [`Annotation`] trait objects to be cloned.
+mod annotation_traits {
+    use crate::annotation::Annotation;
+
+    /// A trait which implements dynamically cloning [`Annotation`] dyn objects.
+    ///
+    /// If an annotation implements [`Clone`], this trait will be automatically implemented.
+    #[diagnostic::on_unimplemented(
+        message = "Clone is required to correctly implement Annotation on {Self}.",
+        label = "This type needs an implementation of Clone",
+        note = "Consider annotating {Self} with `#[derive(Clone)]`"
+    )]
+    pub trait ClonableAnnotation {
+        fn clone_dyn(&self) -> Box<dyn Annotation>;
+    }
+
+    impl<A: Clone + Annotation> ClonableAnnotation for A {
+        fn clone_dyn(&self) -> Box<dyn Annotation> {
+            Box::new(self.clone())
+        }
+    }
+}
+
+use annotation_traits::ClonableAnnotation;
+
+/// A native Rust annotation that can be attached to circuit instructions.
+///
+/// Implementors can use this trait to store annotation payloads directly in Rust-owned circuit
+/// data.  Existing Python-space annotations are represented by [`PyAnnotationObject`].
+pub trait Annotation: Any + Debug + Send + Sync + ClonableAnnotation {
+    /// The namespace that consumers use to dispatch annotation handling.
+    fn namespace(&self) -> &str;
+
+    /// Compare this annotation with another annotation.
+    fn equals(&self, other: &dyn Annotation) -> bool;
+
+    /// Compare this annotation with another annotation while attached to Python.
+    fn py_eq(&self, _py: Python<'_>, other: &dyn Annotation) -> PyResult<bool> {
+        Ok(self.equals(other))
+    }
+
+    /// Convert this annotation to its Python representation.
+    ///
+    /// Native Rust annotations that do not have a Python representation should leave the default
+    /// implementation in place.  Python-backed annotations implement this by cloning the stored
+    /// Python object reference.
+    fn to_python(&self, _py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Err(pyo3::exceptions::PyTypeError::new_err(format!(
+            "annotation '{}' does not have a Python representation",
+            self.namespace()
+        )))
+    }
+}
+
+impl Clone for Box<dyn Annotation> {
+    fn clone(&self) -> Self {
+        self.clone_dyn()
+    }
+}
+
+impl PartialEq for dyn Annotation {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other)
+    }
+}
+
+impl dyn Annotation + '_ {
+    /// Cast a reference to a concrete annotation type.
+    pub fn downcast_ref<T: Annotation + 'static>(&self) -> Option<&T> {
+        let self_as_any: &dyn Any = self;
+        self_as_any.downcast_ref()
+    }
+}
+
+/// Python-backed annotation payload.
+#[derive(Clone, Debug)]
+pub struct PyAnnotationObject {
+    annotation: Py<PyAny>,
+    namespace: String,
+}
+
+impl PyAnnotationObject {
+    /// Build a Rust-owned annotation wrapper from a Python annotation object.
+    pub fn new(py: Python<'_>, annotation: Py<PyAny>) -> Self {
+        let namespace = annotation
+            .bind(py)
+            .getattr(intern!(py, "namespace"))
+            .ok()
+            .and_then(|namespace| namespace.extract().ok())
+            .unwrap_or_default();
+        Self {
+            annotation,
+            namespace,
+        }
+    }
+
+    /// Borrow the wrapped Python object.
+    pub fn as_python(&self) -> &Py<PyAny> {
+        &self.annotation
+    }
+}
+
+impl Annotation for PyAnnotationObject {
+    fn namespace(&self) -> &str {
+        self.namespace.as_str()
+    }
+
+    fn equals(&self, other: &dyn Annotation) -> bool {
+        Python::attach(|py| self.py_eq(py, other).unwrap_or(false))
+    }
+
+    fn py_eq(&self, py: Python<'_>, other: &dyn Annotation) -> PyResult<bool> {
+        let Some(other) = other.downcast_ref::<Self>() else {
+            return Ok(false);
+        };
+        self.annotation.bind(py).eq(other.annotation.bind(py))
+    }
+
+    fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Ok(self.annotation.clone_ref(py))
+    }
+}
+
+impl From<PyAnnotationObject> for Box<dyn Annotation> {
+    fn from(value: PyAnnotationObject) -> Self {
+        Box::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct NativeAnnotation {
+        namespace: &'static str,
+        value: u64,
+    }
+
+    impl Annotation for NativeAnnotation {
+        fn namespace(&self) -> &str {
+            self.namespace
+        }
+
+        fn equals(&self, other: &dyn Annotation) -> bool {
+            other.downcast_ref::<Self>() == Some(self)
+        }
+    }
+
+    #[test]
+    fn native_annotations_clone_and_compare_as_trait_objects() {
+        let annotation: Box<dyn Annotation> = Box::new(NativeAnnotation {
+            namespace: "test.native",
+            value: 5,
+        });
+
+        let cloned = annotation.clone();
+        assert_eq!(annotation.namespace(), "test.native");
+        assert!(annotation.equals(cloned.as_ref()));
+
+        let different: Box<dyn Annotation> = Box::new(NativeAnnotation {
+            namespace: "test.native",
+            value: 8,
+        });
+        assert!(!annotation.equals(different.as_ref()));
+    }
+}
 
 /// An arbitrary annotation for instructions.
 ///

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -22,6 +22,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::{PyResult, intern};
 
+use crate::annotation::PyAnnotationObject;
 use crate::circuit_data::{CircuitData, PyCircuitData};
 use crate::dag_circuit::DAGCircuit;
 use crate::duration::Duration;
@@ -757,7 +758,12 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
                         } else {
                             None
                         };
-                        let annotations = ob.getattr(intern!(py, "annotations"))?.extract()?;
+                        let py_annotations: Vec<Py<PyAny>> =
+                            ob.getattr(intern!(py, "annotations"))?.extract()?;
+                        let annotations = py_annotations
+                            .into_iter()
+                            .map(|annotation| PyAnnotationObject::new(py, annotation).into())
+                            .collect();
                         ControlFlow::Box {
                             duration,
                             annotations,

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -20,6 +20,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, vec};
 
+use crate::annotation::Annotation;
 use crate::bit::{ClassicalRegister, ShareableClbit};
 use crate::circuit_data::{CircuitData, PyCircuitData};
 use crate::classical::expr;
@@ -540,7 +541,7 @@ impl<'py> IntoPyObject<'py> for LoopParam {
 pub enum ControlFlow {
     Box {
         duration: Option<BoxDuration>,
-        annotations: Vec<Py<PyAny>>,
+        annotations: Vec<Box<dyn Annotation>>,
     },
     BreakLoop,
     ContinueLoop,
@@ -585,7 +586,7 @@ impl ControlFlowInstruction {
                         return Ok(false);
                     }
                     for (a, b) in self_annotations.iter().zip(other_annotations) {
-                        if !a.bind(py).eq(b)? {
+                        if !a.py_eq(py, b.as_ref())? {
                             return Ok(false);
                         }
                     }
@@ -670,6 +671,10 @@ impl ControlFlowInstruction {
                     },
                     None => (None, None),
                 };
+                let annotations = annotations
+                    .iter()
+                    .map(|annotation| annotation.to_python(py))
+                    .collect::<PyResult<Vec<_>>>()?;
                 imports::BOX_OP.get(py).call1(
                     py,
                     (

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -28,6 +28,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyAny, PyDict, PyList, PyString, PyTuple, PyType};
+use qiskit_circuit::annotation::{Annotation, PyAnnotationObject};
 use qiskit_circuit::bit::{
     ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
@@ -332,15 +333,18 @@ pub fn instruction_values_to_params(
 fn unpack_annotations(
     packed_annotations: &Option<formats::InstructionsAnnotationPack>,
     qpy_data: &mut QPYReadData,
-) -> Result<Vec<Py<PyAny>>, QpyError> {
+) -> Result<Vec<Box<dyn Annotation>>, QpyError> {
     if let Some(annotations_vec) = packed_annotations {
         annotations_vec
             .annotations
             .iter()
             .map(|annotation| {
-                qpy_data
+                let py_annotation = qpy_data
                     .annotation_handler
-                    .load(annotation.namespace_index, annotation.payload.clone())
+                    .load(annotation.namespace_index, annotation.payload.clone())?;
+                Ok(Python::attach(|py| {
+                    Box::new(PyAnnotationObject::new(py, py_annotation)) as Box<dyn Annotation>
+                }))
             })
             .collect::<Result<_, QpyError>>()
     } else {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -27,6 +27,7 @@ use qiskit_util::IndexSet;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyTuple};
+use qiskit_circuit::annotation::Annotation;
 use qiskit_circuit::bit::{
     ClassicalRegister, PyClbit, PyQubit, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };
@@ -113,13 +114,15 @@ fn pack_instructions(
 }
 
 pub(crate) fn pack_annotations(
-    annotations: &[Py<PyAny>],
+    annotations: &[Box<dyn Annotation>],
     qpy_data: &mut QPYWriteData,
 ) -> PyResult<Option<formats::InstructionsAnnotationPack>> {
     let annotations_pack: Vec<formats::InstructionAnnotationPack> = annotations
         .iter()
         .map(|annotation| {
-            let (namespace_index, payload) = qpy_data.annotation_handler.serialize(annotation)?;
+            let py_annotation = Python::attach(|py| annotation.to_python(py))?;
+            let (namespace_index, payload) =
+                qpy_data.annotation_handler.serialize(&py_annotation)?;
             Ok(formats::InstructionAnnotationPack {
                 namespace_index,
                 payload,

--- a/releasenotes/notes/rust-native-annotations-16661.yaml
+++ b/releasenotes/notes/rust-native-annotations-16661.yaml
@@ -1,0 +1,9 @@
+---
+features_circuits:
+  - |
+    Added a Rust-native ``Annotation`` trait for storing instruction-local
+    annotations in circuit data. Existing Python annotations attached to
+    :class:`.BoxOp` are now wrapped in a Python-backed Rust annotation object,
+    preserving Python equality and QPY serialization behavior.
+
+    See `#16661 <https://github.com/Qiskit/qiskit/issues/16661>`__.


### PR DESCRIPTION
This adds a Rust-native annotation trait for circuit instructions, while preserving the existing Python-facing `Annotation` behavior for `BoxOp`.

The circuit data model can now store annotations as Rust trait objects. Python annotations are wrapped in a Python-backed Rust annotation type, so existing equality and QPY serialization behavior continue to work.

Fixes #16661.

## Details

- Add a cloneable Rust `Annotation` trait for native annotation payloads.
- Add `PyAnnotationObject` as the compatibility wrapper for Python annotation instances.
- Store `BoxOp` annotations as `Vec<Box<dyn Annotation>>` instead of raw Python objects.
- Convert annotations back to Python objects when recreating Python control-flow operations.
- Preserve QPY annotation loading and serialization for Python-backed annotations.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code: