### PR TITLE
Use sympy srepr parser for template substitution

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -872,6 +872,15 @@ impl PyParameterExpression {
         Ok(Self { inner })
     }
 
+    pub fn _set_name_map(&mut self, name_map: HashMap<String, PyParameter>) {
+        let symbol_map: HashMap<String, Symbol> = name_map
+            .iter()
+            .map(|(string, param)| (string.clone(), Symbol::clone(&param.0)))
+            .collect();
+        self.inner.expr = symbol_expr::replace_symbol(&self.inner.expr, &symbol_map);
+        self.inner.name_map = symbol_map;
+    }
+
     #[allow(non_snake_case)]
     #[staticmethod]
     pub fn _Value(value: &Bound<PyAny>) -> PyResult<Self> {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -872,15 +872,6 @@ impl PyParameterExpression {
         Ok(Self { inner })
     }
 
-    pub fn _set_name_map(&mut self, name_map: HashMap<String, PyParameter>) {
-        let symbol_map: HashMap<String, Symbol> = name_map
-            .iter()
-            .map(|(string, param)| (string.clone(), Symbol::clone(&param.0)))
-            .collect();
-        self.inner.expr = symbol_expr::replace_symbol(&self.inner.expr, &symbol_map);
-        self.inner.name_map = symbol_map;
-    }
-
     #[allow(non_snake_case)]
     #[staticmethod]
     pub fn _Value(value: &Bound<PyAny>) -> PyResult<Self> {

--- a/qiskit/qpy/binary_io/parse_sympy_repr.py
+++ b/qiskit/qpy/binary_io/parse_sympy_repr.py
@@ -48,9 +48,10 @@ METHOD_MAPPING = {
     "Abs": "abs",
     "sin": "sin",
     "tan": "tan",
-    "atan": "atan",
-    "acos": "acos",
-    "asin": "asin",
+    "cos": "cos",
+    "atan": "arctan",
+    "acos": "arccos",
+    "asin": "arcsin",
     "exp": "exp",
     "conjugate": "conjugate",
 }
@@ -77,6 +78,8 @@ UNARY = {
     "acos",
     "asin",
     "conjugate",
+    "exp",
+    "log",
     "Symbol",
     "Integer",
     "Complex",
@@ -121,7 +124,7 @@ class ParseSympyWalker(ast.NodeVisitor):
         if isinstance(node.func, ast.Name):
             name = node.func.id
         else:
-            raise QpyError("Unknown node type")
+            raise QpyError(f"Unknown node type: {node.func}")
 
         if name not in ALLOWED_CALLERS:
             raise QpyError(f"{name} is not part of a valid sympy expression srepr")
@@ -154,6 +157,8 @@ class ParseSympyWalker(ast.NodeVisitor):
                 # If rational has one arg it's a no-op because
                 # ParameterExpression doesn't have a Rational type
                 if len(out_args) < 2:
+                    obj = out_args[0]
+                else:
                     lhs = out_args.pop()
                     rhs = out_args.pop()
                     # If there is a 3rd argument that is the GCD which isn't supported by
@@ -166,9 +171,7 @@ class ParseSympyWalker(ast.NodeVisitor):
                         raise QpyError(
                             f"Invalid Rational too many arguments Rational({lhs}, {rhs}, *{out_args})"
                         )
-                    else:
-                        obj = lhs / rhs
-                        self.stack.append(obj)
+                    obj = lhs / rhs
             else:
                 function = FUNCTION_MAPPING[name]
                 out_args.reverse()

--- a/qiskit/qpy/binary_io/parse_sympy_repr.py
+++ b/qiskit/qpy/binary_io/parse_sympy_repr.py
@@ -13,6 +13,7 @@
 """Parser for sympy expressions srepr from ParameterExpression internals."""
 
 import ast
+import operator
 
 from qiskit.qpy.exceptions import QpyError
 from qiskit.circuit.parameter import Parameter
@@ -43,11 +44,6 @@ ALLOWED_CALLERS = {
 }
 
 METHOD_MAPPING = {
-    "Add": "__add__",
-    "Sub": "__sub__",
-    "Mul": "__mul__",
-    "Div": "__div__",
-    "Pow": "__pow__",
     "log": "log",
     "Abs": "abs",
     "sin": "sin",
@@ -59,19 +55,19 @@ METHOD_MAPPING = {
     "conjugate": "conjugate",
 }
 
-REVERSE_METHOD_MAPPING = {
-    "Add": "__radd__",
-    "Sub": "__rsub__",
-    "Mul": "__rmul__",
-    "Div": "__rdiv__",
-    "Pow": "__rpow__",
-}
-
 FUNCTION_MAPPING = {
     "Symbol": Parameter,
     "Integer": int,
     "Complex": complex,
     "Float": float,
+}
+
+OPERATOR_FUNCTIONS = {
+    "Add": operator.add,
+    "Sub": operator.sub,
+    "Mul": operator.mul,
+    "Div": operator.truediv,
+    "Pow": operator.pow,
 }
 
 UNARY = {
@@ -146,19 +142,12 @@ class ParseSympyWalker(ast.NodeVisitor):
             for arg in args:
                 self.visit(arg)
             out_args = [self.stack.pop() for _ in range(len(args))]
-            method = METHOD_MAPPING.get(name, None)
-            if method is not None:
+            func = OPERATOR_FUNCTIONS.get(name, None)
+            if func is not None:
                 obj = out_args.pop()
                 out_args.reverse()
                 for arg in out_args:
-                    if (
-                        name in REVERSE_METHOD_MAPPING
-                        and isinstance(arg, ParameterExpression)
-                        and not isinstance(obj, ParameterExpression)
-                    ):
-                        obj = getattr(arg, REVERSE_METHOD_MAPPING[name])(obj)
-                    else:
-                        obj = getattr(obj, method)(arg)
+                    obj = func(obj, arg)
             elif name == "Rational":
                 # If rational has one arg it's a no-op because
                 # ParameterExpression doesn't have a Rational type

--- a/qiskit/qpy/binary_io/parse_sympy_repr.py
+++ b/qiskit/qpy/binary_io/parse_sympy_repr.py
@@ -15,7 +15,8 @@
 import ast
 
 from qiskit.qpy.exceptions import QpyError
-from qiskit.utils.optionals import HAS_SYMPY
+from qiskit.circuit.parameter import Parameter
+from qiskit.circuit.parameterexpression import ParameterExpression
 
 
 ALLOWED_CALLERS = {
@@ -39,6 +40,38 @@ ALLOWED_CALLERS = {
     "asin",
     "exp",
     "conjugate",
+}
+
+METHOD_MAPPING = {
+    "Add": "__add__",
+    "Sub": "__sub__",
+    "Mul": "__mul__",
+    "Div": "__div__",
+    "Pow": "__pow__",
+    "log": "log",
+    "Abs": "abs",
+    "sin": "sin",
+    "tan": "tan",
+    "atan": "atan",
+    "acos": "acos",
+    "asin": "asin",
+    "exp": "exp",
+    "conjugate": "conjugate",
+}
+
+REVERSE_METHOD_MAPPING = {
+    "Add": "__radd__",
+    "Sub": "__rsub__",
+    "Mul": "__rmul__",
+    "Div": "__rdiv__",
+    "Pow": "__rpow__",
+}
+
+FUNCTION_MAPPING = {
+    "Symbol": Parameter,
+    "Integer": int,
+    "Complex": complex,
+    "Float": float,
 }
 
 UNARY = {
@@ -88,7 +121,6 @@ class ParseSympyWalker(ast.NodeVisitor):
 
         This can only be parameter expression allowed sympy call types.
         """
-        import sympy
 
         if isinstance(node.func, ast.Name):
             name = node.func.id
@@ -103,22 +135,57 @@ class ParseSympyWalker(ast.NodeVisitor):
             if len(args) != 1:
                 raise QpyError(f"{name} has an invalid number of args in sympy srepr")
             self.visit(args[0])
-            obj = getattr(sympy, name)(self.stack.pop())
+            method = METHOD_MAPPING.get(name, None)
+            if method is not None:
+                obj = getattr(self.stack.pop(), method)()
+            else:
+                function = FUNCTION_MAPPING[name]
+                obj = function(self.stack.pop())
             self.stack.append(obj)
         else:
             for arg in args:
                 self.visit(arg)
             out_args = [self.stack.pop() for _ in range(len(args))]
-            out_args.reverse()
-            obj = getattr(sympy, name)(*out_args)
+            method = METHOD_MAPPING.get(name, None)
+            if method is not None:
+                obj = out_args.pop()
+                out_args.reverse()
+                for arg in out_args:
+                    if (
+                        name in REVERSE_METHOD_MAPPING
+                        and isinstance(arg, ParameterExpression)
+                        and not isinstance(obj, ParameterExpression)
+                    ):
+                        obj = getattr(arg, REVERSE_METHOD_MAPPING[name])(obj)
+                    else:
+                        obj = getattr(obj, method)(arg)
+            elif name == "Rational":
+                # If rational has one arg it's a no-op because
+                # ParameterExpression doesn't have a Rational type
+                if len(out_args) < 2:
+                    lhs = out_args.pop()
+                    rhs = out_args.pop()
+                    # If there is a 3rd argument that is the GCD which isn't supported by
+                    # ParameterExpression
+                    if len(out_args) == 1:
+                        raise QpyError(
+                            "An expression can not contain a Sympy Rational with a GCD set"
+                        )
+                    elif len(out_args) > 0:
+                        raise QpyError(
+                            f"Invalid Rational too many arguments Rational({lhs}, {rhs}, *{out_args})"
+                        )
+                    else:
+                        obj = lhs / rhs
+                        self.stack.append(obj)
+            else:
+                function = FUNCTION_MAPPING[name]
+                out_args.reverse()
+                obj = function(*out_args)
             self.stack.append(obj)
 
 
-@HAS_SYMPY.require_in_call(
-    "Sympy is required to parse parameter expressions encoded using sympy's "
-    "srepr in QPY format versions < 13"
-)
-def parse_sympy_repr(sympy_repr: str):
+def parse_sympy_repr(sympy_repr: str) -> ParameterExpression:
     """Parse a given sympy srepr into a symbolic expression object."""
     tree = ast.parse(sympy_repr, mode="eval")
     visitor = ParseSympyWalker()

--- a/qiskit/qpy/binary_io/parse_sympy_repr.py
+++ b/qiskit/qpy/binary_io/parse_sympy_repr.py
@@ -56,7 +56,6 @@ METHOD_MAPPING = {
 }
 
 FUNCTION_MAPPING = {
-    "Symbol": Parameter,
     "Integer": int,
     "Complex": complex,
     "Float": float,
@@ -90,8 +89,9 @@ class ParseSympyWalker(ast.NodeVisitor):
     """A custom ast walker that is passed the sympy srepr from QPY < 13 and creates a custom
     expression."""
 
-    def __init__(self):
+    def __init__(self, name_map: dict[str, Parameter]):
         self.stack = []
+        self.name_map = name_map
 
     def visit_UnaryOp(self, node: ast.UnaryOp):
         """Visit a python unary op node"""
@@ -134,6 +134,8 @@ class ParseSympyWalker(ast.NodeVisitor):
             method = METHOD_MAPPING.get(name, None)
             if method is not None:
                 obj = getattr(self.stack.pop(), method)()
+            elif name == "Symbol":
+                obj = self.name_map[self.stack.pop()]
             else:
                 function = FUNCTION_MAPPING[name]
                 obj = function(self.stack.pop())
@@ -174,9 +176,9 @@ class ParseSympyWalker(ast.NodeVisitor):
             self.stack.append(obj)
 
 
-def parse_sympy_repr(sympy_repr: str) -> ParameterExpression:
+def parse_sympy_repr(sympy_repr: str, name_map: dict[str, Parameter]) -> ParameterExpression:
     """Parse a given sympy srepr into a symbolic expression object."""
     tree = ast.parse(sympy_repr, mode="eval")
-    visitor = ParseSympyWalker()
+    visitor = ParseSympyWalker(name_map)
     visitor.visit(tree)
     return visitor.stack.pop()

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -548,8 +548,8 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
         else:
             raise exceptions.QpyError(f"Invalid parameter expression map type: {elem_key}")
         name_map[symbol.name] = value
-
-    return ParameterExpression(name_map, str(expr_))
+    expr_._set_name_map(name_map)
+    return expr_
 
 
 def _read_parameter_expression_v13(file_obj, vectors, version):

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -469,7 +469,6 @@ def _read_parameter_expression(file_obj):
     )
 
     sympy_str = file_obj.read(data.expr_size).decode(common.ENCODE)
-    expr_ = parse_sympy_repr(sympy_str)
     name_map = {}
     for _ in range(data.map_elements):
         elem_data = formats.PARAM_EXPR_MAP_ELEM(
@@ -495,7 +494,7 @@ def _read_parameter_expression(file_obj):
         else:
             raise exceptions.QpyError(f"Invalid parameter expression map type: {elem_key}")
         name_map[symbol.name] = value
-    expr_._set_name_map(name_map)
+    expr_ = parse_sympy_repr(sympy_str, name_map)
     return expr_
 
 
@@ -509,7 +508,6 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
         sympy_str = common.load_symengine_payload(payload)
     else:
         sympy_str = payload.decode(common.ENCODE)
-    expr_ = parse_sympy_repr(sympy_str)
 
     name_map = {}
     for _ in range(data.map_elements):
@@ -548,7 +546,7 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
         else:
             raise exceptions.QpyError(f"Invalid parameter expression map type: {elem_key}")
         name_map[symbol.name] = value
-    expr_._set_name_map(name_map)
+    expr_ = parse_sympy_repr(sympy_str, name_map)
     return expr_
 
 

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -506,10 +506,10 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
 
     payload = file_obj.read(data.expr_size)
     if use_symengine:
-        expr_ = common.load_symengine_payload(payload)
+        sympy_str = common.load_symengine_payload(payload)
     else:
         sympy_str = payload.decode(common.ENCODE)
-        expr_ = parse_sympy_repr(sympy_str)
+    expr_ = parse_sympy_repr(sympy_str)
 
     name_map = {}
     for _ in range(data.map_elements):

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -495,8 +495,8 @@ def _read_parameter_expression(file_obj):
         else:
             raise exceptions.QpyError(f"Invalid parameter expression map type: {elem_key}")
         name_map[symbol.name] = value
-
-    return ParameterExpression(name_map, str(expr_))
+    expr_._set_name_map(name_map)
+    return expr_
 
 
 def _read_parameter_expression_v3(file_obj, vectors, use_symengine):

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -19,7 +19,7 @@ import io
 import struct
 import uuid
 
-from qiskit.utils.optionals import HAS_SYMENGINE
+from qiskit.utils.optionals import HAS_SYMENGINE, HAS_SYMPY
 
 from qiskit.qpy import formats, exceptions
 
@@ -320,6 +320,7 @@ def mapping_from_binary(binary_data, deserializer, **kwargs):
 
 
 @HAS_SYMENGINE.require_in_call("QPY versions 10 through 12 with symengine parameter serialization")
+@HAS_SYMPY.require_in_call("QPY versions 10 through 12 with symengine parameter serialization")
 def load_symengine_payload(payload: bytes):
     """Load a symengine expression from it's serialized cereal payload."""
     # This is a horrible hack to workaround the symengine version checking
@@ -331,6 +332,7 @@ def load_symengine_payload(payload: bytes):
     from symengine.lib.symengine_wrapper import (  # pylint: disable = no-name-in-module
         load_basic,
     )
+    import sympy
 
     symengine_version = symengine.__version__.split(".")
     major = payload[2]
@@ -361,4 +363,4 @@ def load_symengine_payload(payload: bytes):
         payload = bytearray(payload)
         payload[3] = minor_version
         payload = bytes(payload)
-    return load_basic(payload)
+    return sympy.srepr(sympy.sympify(load_basic(payload)))

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -25,6 +25,13 @@ from qiskit.converters.dagdependency_to_dag import dagdependency_to_dag
 from qiskit.utils import optionals as _optionals
 
 
+def sympy_expr_to_param(sympy_expr, name_map) -> ParameterExpression:
+    from qiskit.qpy.binary_io.parse_sympy_repr import parse_sympy_repr
+    from sympy import srepr
+
+    return parse_sympy_repr(srepr(sympy_expr), name_map)
+
+
 class SubstitutionConfig:
     """
     Class to store the configuration of a given match substitution, which circuit
@@ -590,10 +597,10 @@ class TemplateSubstitution:
             # No solutions.
             return None
         # If there's multiple solutions, arbitrarily pick the first one.
-        sol = {
-            param.name: ParameterExpression(circ_dict, str(expr))
-            for param, expr in sym_sol[0].items()
-        }
+        sol = {}
+        for param, expr in sym_sol[0].items():
+            expression = sympy_expr_to_param(expr, circ_dict)
+            sol[param.name] = expression
         fake_bind = {key: sol[key.name] for key in temp_symbols}
 
         for node in template_dag_dep.get_nodes():

--- a/releasenotes/notes/sympy-required-for-all-qpy-under-13-148262f69d7eb1ef.yaml
+++ b/releasenotes/notes/sympy-required-for-all-qpy-under-13-148262f69d7eb1ef.yaml
@@ -1,0 +1,12 @@
+---
+upgrade_qpy:
+  - Deserializing QPY payload formats 10 through 12 with :func:`qpy.load` that contain any
+    :class:`.ParameterExpression` objects when the payload is using
+    ``symengine`` expression encoding now also requires the ``sympy`` optional
+    dependency to be installed. The optional extra ``qpy_compat`` which is used to install
+    the optional dependencies that are needed for loading older payload formats already installs
+    this.
+  - Using :func:`qpy.load` to deserializing QPY payload formats < 10 and QPY formats 10 through
+    12 with ``sympy`` expression encoding no longer requires ``sympy`` to be installed. Previously
+    the ``sympy`` was required to recreate any :class:`.ParameterExpression`
+    objects in the payload, but starting in this release they are directly created from the payload.

--- a/test/python/qpy/test_sympy_repr_parser.py
+++ b/test/python/qpy/test_sympy_repr_parser.py
@@ -1,0 +1,163 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for python write/rust read flow and vice versa"""
+
+from ddt import ddt, idata, unpack
+
+from qiskit.circuit import Parameter, ParameterExpression
+from qiskit.qpy import QpyError
+from qiskit.qpy.binary_io.parse_sympy_repr import parse_sympy_repr
+
+from test import QiskitTestCase
+
+TEST_PARAMS = [
+    ("Add(Symbol('a'), Symbol('b'))", lambda: Parameter("a") + Parameter("b")),
+    ("Sub(Symbol('a'), Symbol('b'))", lambda: Parameter("a") - Parameter("b")),
+    ("Mul(Symbol('a'), Symbol('b'))", lambda: Parameter("a") * Parameter("b")),
+    ("Div(Symbol('a'), Symbol('b'))", lambda: Parameter("a") / Parameter("b")),
+    ("Pow(Symbol('a'), Symbol('b'))", lambda: Parameter("a") ** Parameter("b")),
+    ("Add(Symbol('a'), 3.12345)", lambda: Parameter("a") + 3.12345),
+    ("Sub(Symbol('a'), 3.12345)", lambda: Parameter("a") - 3.12345),
+    ("Mul(Symbol('a'), 3.12345)", lambda: Parameter("a") * 3.12345),
+    ("Div(Symbol('a'), 3.12345)", lambda: Parameter("a") / 3.12345),
+    ("Add(3.12345, Symbol('a'))", lambda: 3.12345 + Parameter("a")),
+    ("Sub(3.12345, Symbol('a'))", lambda: 3.12345 - Parameter("a")),
+    ("Mul(3.12345, Symbol('a'))", lambda: 3.12345 * Parameter("a")),
+    ("Div(3.12345, Symbol('a'))", lambda: 3.12345 / Parameter("a")),
+    ("Pow(Symbol('a'), 3.1234)", lambda: Parameter("a") ** 3.1234),
+    ("Add(Symbol('a'), sin(Symbol('b')))", lambda: Parameter("a") + Parameter("b").sin()),
+    ("Sub(Symbol('a'), sin(Symbol('b')))", lambda: Parameter("a") - Parameter("b").sin()),
+    ("Mul(Symbol('a'), sin(Symbol('b')))", lambda: Parameter("a") * Parameter("b").sin()),
+    ("Div(Symbol('a'), sin(Symbol('b')))", lambda: Parameter("a") / Parameter("b").sin()),
+    ("Pow(Symbol('a'), sin(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").sin()),
+    ("Add(Symbol('a'), cos(Symbol('b')))", lambda: Parameter("a") + Parameter("b").cos()),
+    ("Sub(Symbol('a'), cos(Symbol('b')))", lambda: Parameter("a") - Parameter("b").cos()),
+    ("Mul(Symbol('a'), cos(Symbol('b')))", lambda: Parameter("a") * Parameter("b").cos()),
+    ("Div(Symbol('a'), cos(Symbol('b')))", lambda: Parameter("a") / Parameter("b").cos()),
+    ("Pow(Symbol('a'), cos(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").cos()),
+    ("Add(Symbol('a'), tan(Symbol('b')))", lambda: Parameter("a") + Parameter("b").tan()),
+    ("Sub(Symbol('a'), tan(Symbol('b')))", lambda: Parameter("a") - Parameter("b").tan()),
+    ("Mul(Symbol('a'), tan(Symbol('b')))", lambda: Parameter("a") * Parameter("b").tan()),
+    ("Div(Symbol('a'), tan(Symbol('b')))", lambda: Parameter("a") / Parameter("b").tan()),
+    ("Pow(Symbol('a'), tan(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").tan()),
+    ("Add(Symbol('a'), log(Symbol('b')))", lambda: Parameter("a") + Parameter("b").log()),
+    ("Sub(Symbol('a'), log(Symbol('b')))", lambda: Parameter("a") - Parameter("b").log()),
+    ("Mul(Symbol('a'), log(Symbol('b')))", lambda: Parameter("a") * Parameter("b").log()),
+    ("Div(Symbol('a'), log(Symbol('b')))", lambda: Parameter("a") / Parameter("b").log()),
+    ("Pow(Symbol('a'), log(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").log()),
+    ("Add(Symbol('a'), asin(Symbol('b')))", lambda: Parameter("a") + Parameter("b").arcsin()),
+    ("Sub(Symbol('a'), asin(Symbol('b')))", lambda: Parameter("a") - Parameter("b").arcsin()),
+    ("Mul(Symbol('a'), asin(Symbol('b')))", lambda: Parameter("a") * Parameter("b").arcsin()),
+    ("Div(Symbol('a'), asin(Symbol('b')))", lambda: Parameter("a") / Parameter("b").arcsin()),
+    ("Pow(Symbol('a'), asin(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").arcsin()),
+    ("Add(Symbol('a'), acos(Symbol('b')))", lambda: Parameter("a") + Parameter("b").arccos()),
+    ("Sub(Symbol('a'), acos(Symbol('b')))", lambda: Parameter("a") - Parameter("b").arccos()),
+    ("Mul(Symbol('a'), acos(Symbol('b')))", lambda: Parameter("a") * Parameter("b").arccos()),
+    ("Div(Symbol('a'), acos(Symbol('b')))", lambda: Parameter("a") / Parameter("b").arccos()),
+    ("Pow(Symbol('a'), acos(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").arccos()),
+    ("Add(Symbol('a'), atan(Symbol('b')))", lambda: Parameter("a") + Parameter("b").arctan()),
+    ("Sub(Symbol('a'), atan(Symbol('b')))", lambda: Parameter("a") - Parameter("b").arctan()),
+    ("Mul(Symbol('a'), atan(Symbol('b')))", lambda: Parameter("a") * Parameter("b").arctan()),
+    ("Div(Symbol('a'), atan(Symbol('b')))", lambda: Parameter("a") / Parameter("b").arctan()),
+    ("Pow(Symbol('a'), atan(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").arctan()),
+    ("Add(Symbol('a'), exp(Symbol('b')))", lambda: Parameter("a") + Parameter("b").exp()),
+    ("Sub(Symbol('a'), exp(Symbol('b')))", lambda: Parameter("a") - Parameter("b").exp()),
+    ("Mul(Symbol('a'), exp(Symbol('b')))", lambda: Parameter("a") * Parameter("b").exp()),
+    ("Div(Symbol('a'), exp(Symbol('b')))", lambda: Parameter("a") / Parameter("b").exp()),
+    ("Pow(Symbol('a'), exp(Symbol('b')))", lambda: Parameter("a") ** Parameter("b").exp()),
+    (
+        "Add(Symbol('a'), conjugate(Symbol('b')))",
+        lambda: Parameter("a") + Parameter("b").conjugate(),
+    ),
+    (
+        "Sub(Symbol('a'), conjugate(Symbol('b')))",
+        lambda: Parameter("a") - Parameter("b").conjugate(),
+    ),
+    (
+        "Mul(Symbol('a'), conjugate(Symbol('b')))",
+        lambda: Parameter("a") * Parameter("b").conjugate(),
+    ),
+    (
+        "Div(Symbol('a'), conjugate(Symbol('b')))",
+        lambda: Parameter("a") / Parameter("b").conjugate(),
+    ),
+    (
+        "Pow(Symbol('a'), conjugate(Symbol('b')))",
+        lambda: Parameter("a") ** Parameter("b").conjugate(),
+    ),
+    ("Complex(3.14)", lambda: 3.14 + 0j),
+    ("Float(3)", lambda: float(3)),
+    ("Rational(3.14)", lambda: 3.14),
+    ("Rational(3.14, 2)", lambda: 3.14 / 2),
+    ("Integer(3.14)", lambda: 3),
+    (
+        "Abs(Add(Symbol('a'), conjugate(Symbol('b'))))",
+        (Parameter("a") + Parameter("b").conjugate()).abs,
+    ),
+    (
+        "Abs(Sub(Symbol('a'), conjugate(Symbol('b'))))",
+        (Parameter("a") - Parameter("b").conjugate()).abs,
+    ),
+    (
+        "Abs(Mul(Symbol('a'), conjugate(Symbol('b'))))",
+        (Parameter("a") * Parameter("b").conjugate()).abs,
+    ),
+    (
+        "Abs(Div(Symbol('a'), conjugate(Symbol('b'))))",
+        (Parameter("a") / Parameter("b").conjugate()).abs,
+    ),
+    (
+        "Abs(Pow(Symbol('a'), conjugate(Symbol('b'))))",
+        (Parameter("a") ** Parameter("b").conjugate()).abs,
+    ),
+]
+
+
+@ddt
+class TestQPYRoundtrip(QiskitTestCase):
+    """Test QPY's sympy repr parser."""
+
+    @unpack
+    @idata(TEST_PARAMS)
+    def test_expressions(self, srepr_str, generator_expected):
+        expected = generator_expected()
+        if isinstance(expected, ParameterExpression):
+            name_map = {x.name: x for x in expected.parameters}
+        else:
+            name_map = {}
+        result = parse_sympy_repr(srepr_str, name_map)
+        self.assertEqual(result, expected, f"{result} != {expected}")
+
+    def test_invalid_ops(self):
+        py_repr_str = "parse_sympy_repr('foo')"
+        name_map = {"foo": Parameter("foo")}
+        with self.assertRaises(QpyError):
+            parse_sympy_repr(py_repr_str, name_map)
+
+    def test_large_expr(self):
+        a = Parameter("a")
+        b = Parameter("b")
+        c = Parameter("c")
+        d = Parameter("d")
+        final_expr = (
+            a**2
+            + ((a**2 * (a + 0.25 * b.sin())).cos() + d.tan() + d.arccos() - d.arcsin() + d.arctan())
+            * (-d).exp()
+            + (a**2 * (a + 0.25 * b.sin())).log()
+            - a.sin()
+            - b.conjugate()
+        ).abs()
+        srepr_str = "Abs(Add(Pow(Symbol('a'), Integer(2)), Mul(Add(cos(Mul(Pow(Symbol('a'), Integer(2)), Add(Symbol('a'), Mul(Rational(1, 4), sin(Symbol('b')))))), tan(Symbol('d')), acos(Symbol('d')), Mul(Integer(-1), asin(Symbol('d'))), atan(Symbol('d'))), exp(Mul(Integer(-1), Symbol('d')))), log(Mul(Pow(Symbol('a'), Integer(2)), Add(Symbol('a'), Mul(Rational(1, 4), sin(Symbol('b')))))), Mul(Integer(-1), sin(Symbol('a'))), Mul(Integer(-1), conjugate(Symbol('b')))))"
+        name_map = {"a": a, "b": b, "c": c, "d": d}
+        result = parse_sympy_repr(srepr_str, name_map)
+        self.assertEqual(result, final_expr, f"{result} != {final_expr}")


### PR DESCRIPTION
Internally the template optimization transpiler pass uses sympy
directly and at a certain point it needs to go from this sympy
expression to a ParameterExpression object. Previously this was done by
running str(sympy_expr) to get a string representation of the expression
and then have that string parsed by the internal parser built into rust
internals of the ParameterExpression. This is actually the sole use of
that internal string parser and it isn't needed as we can just use the
srepr parser that QPY already uses. This commit removes the use of this
alternative parsing path and uses the qpy path.

Part of #14817

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->