### PR TITLE
Add `Param::Int` variant for `Dt` in Rust.

### DIFF
--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -53,6 +53,7 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                                         Param::ParameterExpression(_) => Err(QiskitError::new_err(
                                             "Circuit contains parameterized delays, can't compute a duration estimate with this circuit",
                                         )),
+                                        Param::Int(int) => Ok(*int as f64 * dt),
                                     }
                                 } else {
                                     Err(QiskitError::new_err(

--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -53,7 +53,7 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                                         Param::ParameterExpression(_) => Err(QiskitError::new_err(
                                             "Circuit contains parameterized delays, can't compute a duration estimate with this circuit",
                                         )),
-                                        Param::Int(int) => Ok(*int as f64 * dt),
+                                        Param::Int(value) => Ok(*value as f64 * dt),
                                     }
                                 } else {
                                     Err(QiskitError::new_err(

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1539,7 +1539,7 @@ impl CInstruction {
             .params_view()
             .iter()
             .map(|p| match p {
-                Param::Float(_) | Param::ParameterExpression(_) => {
+                Param::Float(_) | Param::ParameterExpression(_) | Param::Int(_) => {
                     Some(Box::into_raw(Box::new(p.clone())))
                 }
                 _ => None,

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -206,6 +206,7 @@ pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
         Param::ParameterExpression(expr) => expr.to_string(),
         Param::Float(f) => f.to_string(),
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+        Param::Int(int) => int.to_string(),
     };
     let out = CString::new(str.to_string()).unwrap();
     out.into_raw()
@@ -1032,5 +1033,6 @@ pub unsafe extern "C" fn qk_param_as_real(param: *const Param) -> f64 {
         },
         Param::Float(f) => *f,
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+        Param::Int(int) => *int as f64, // Lossy conversion,
     }
 }

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -206,9 +206,9 @@ pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
         Param::ParameterExpression(expr) => expr.to_string(),
         Param::Float(f) => f.to_string(),
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
-        Param::Int(int) => int.to_string(),
+        Param::Int(u) => u.to_string(),
     };
-    let out = CString::new(str.to_string()).unwrap();
+    let out = CString::new(str).unwrap();
     out.into_raw()
 }
 
@@ -1033,6 +1033,6 @@ pub unsafe extern "C" fn qk_param_as_real(param: *const Param) -> f64 {
         },
         Param::Float(f) => *f,
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
-        Param::Int(int) => *int as f64, // Lossy conversion,
+        Param::Int(u) => *u as f64, // Lossy conversion,
     }
 }

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -999,6 +999,9 @@ pub unsafe extern "C" fn qk_param_equal(lhs: *const Param, rhs: *const Param) ->
 /// ``NAN`` is returned. Note that for ``QkParam`` representing complex values the real part is
 /// returned.
 ///
+/// If the parameter in originally an `int` instance, it will be coerced into a double, resulting
+/// in a lossy conversion.
+///
 /// @param param A pointer to the ``QkParam`` to evaluate.
 ///
 /// @return The value, if casting was successful, otherwise ``NAN``.

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -1454,7 +1454,7 @@ pub unsafe extern "C" fn qk_target_op_get(
                     .params_view()
                     .iter()
                     .map(|param| match param {
-                        Param::Float(_) | Param::ParameterExpression(_) => {
+                        Param::Float(_) | Param::ParameterExpression(_) | Param::Int(_) => {
                             std::ptr::from_ref(param)
                         }
                         Param::Obj(_) => panic!("Objects are not supported in the C API."),

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1268,6 +1268,13 @@ impl CircuitData {
                         }
                     })?
                 }
+                Param::Int(int) => {
+                    let map: HashMap<&Symbol, Value> = HashMap::from([(
+                        symbol,
+                        Value::Int((*int).try_into().expect("unsigned integer is too big")),
+                    )]);
+                    expr.bind(&map, false)?
+                }
             };
             // Param::from_expr() only errors in the python path when calling Python
             Ok(Param::from_expr(new_expr, coerce)?)
@@ -1408,7 +1415,7 @@ impl CircuitData {
                             // All "user" operations (e.g. PyOperation) use Parameters::Param.
                             let previous_param = &previous.params_view()[parameter];
                             let new_param = match previous_param {
-                                Param::Float(_) => inconsistent(),
+                                Param::Float(_) | Param::Int(_) => inconsistent(),
                                 Param::ParameterExpression(expr) => {
                                     let new_param =
                                         bind_expr(expr, &symbol, value.as_ref(), false)?;

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1268,6 +1268,13 @@ impl CircuitData {
                         }
                     })?
                 }
+                Param::Int(int) => {
+                    let map: HashMap<&Symbol, Value> = HashMap::from([(
+                        symbol,
+                        Value::Int((*int).try_into().expect("unsigned integer is too big")),
+                    )]);
+                    expr.bind(&map, false)?
+                }
             };
             // Param::from_expr() only errors in the python path when calling Python
             Ok(Param::from_expr(new_expr, coerce)?)
@@ -1409,7 +1416,7 @@ impl CircuitData {
                             // All "user" operations (e.g. PyOperation) use Parameters::Param.
                             let previous_param = &previous.params_view()[parameter];
                             let new_param = match previous_param {
-                                Param::Float(_) => inconsistent(),
+                                Param::Float(_) | Param::Int(_) => inconsistent(),
                                 Param::ParameterExpression(expr) => {
                                     let new_param =
                                         bind_expr(expr, &symbol, value.as_ref(), false)?;

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1268,10 +1268,10 @@ impl CircuitData {
                         }
                     })?
                 }
-                Param::Int(int) => {
+                Param::Int(u) => {
                     let map: HashMap<&Symbol, Value> = HashMap::from([(
                         symbol,
-                        Value::Int((*int).try_into().expect("unsigned integer is too big")),
+                        Value::Int((*u).try_into().expect("unsigned integer is too big")),
                     )]);
                     expr.bind(&map, false)?
                 }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1271,7 +1271,7 @@ impl CircuitData {
                 Param::Int(u) => {
                     let map: HashMap<&Symbol, Value> = HashMap::from([(
                         symbol,
-                        Value::Int((*u).try_into().expect("unsigned integer is too big")),
+                        Value::Int((*u).try_into().map_err(|_| ParameterError::InvalidValue)?),
                     )]);
                     expr.bind(&map, false)?
                 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -845,6 +845,9 @@ impl TextDrawer {
                                     delay_unit
                                 )
                             }
+                            Param::Int(duration) => {
+                                format!("Delay({}[{}])", duration, delay_unit)
+                            }
                             Param::ParameterExpression(expr) => {
                                 format!("Delay({}[{}])", expr, delay_unit)
                             }
@@ -895,6 +898,7 @@ impl TextDrawer {
                 Param::Float(f) => format!("PPR({})", F64UiFormatter::new(5).format_with_pi(*f)),
                 Param::ParameterExpression(e) => format!("PPR({})", e),
                 Param::Obj(o) => format!("PPR({:?})", o),
+                Param::Int(i) => format!("PPR({:?})", i),
             },
             OperationRef::PauliProductMeasurement(ppm) => {
                 format!("PPM{}", if ppm.neg { "(-)" } else { "" })

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -863,6 +863,9 @@ impl TextDrawer {
                                     delay_unit
                                 )
                             }
+                            Param::Int(duration) => {
+                                format!("Delay({}[{}])", duration, delay_unit)
+                            }
                             Param::ParameterExpression(expr) => {
                                 format!("Delay({}[{}])", expr, delay_unit)
                             }
@@ -913,6 +916,7 @@ impl TextDrawer {
                 Param::Float(f) => format!("PPR({})", F64UiFormatter::new(5).format_with_pi(*f)),
                 Param::ParameterExpression(e) => format!("PPR({})", e),
                 Param::Obj(o) => format!("PPR({:?})", o),
+                Param::Int(i) => format!("PPR({:?})", i),
             },
             OperationRef::PauliProductMeasurement(ppm) => {
                 format!("PPM{}", if ppm.neg { "(-)" } else { "" })

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -916,7 +916,7 @@ impl TextDrawer {
                 Param::Float(f) => format!("PPR({})", F64UiFormatter::new(5).format_with_pi(*f)),
                 Param::ParameterExpression(e) => format!("PPR({})", e),
                 Param::Obj(o) => format!("PPR({:?})", o),
-                Param::Int(i) => format!("PPR({:?})", i),
+                Param::Int(u) => format!("PPR({:?})", u),
             },
             OperationRef::PauliProductMeasurement(ppm) => {
                 format!("PPM{}", if ppm.neg { "(-)" } else { "" })

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -443,6 +443,7 @@ impl CircuitInstruction {
                                     &ParameterExpression::from_f64(*left) == right.as_ref()
                                 }
                                 Param::Obj(right) => right.bind(py).eq(left)?,
+                                Param::Int(right) => left == &(*right as f64),
                             },
                             Param::ParameterExpression(left) => match right {
                                 Param::Float(right) => {
@@ -450,8 +451,19 @@ impl CircuitInstruction {
                                 }
                                 Param::ParameterExpression(right) => left == right,
                                 Param::Obj(right) => right.bind(py).eq(left.as_ref().clone())?,
+                                Param::Int(right) => {
+                                    left.as_ref() == &ParameterExpression::try_from(*right)?
+                                }
                             },
                             Param::Obj(left) => left.bind(py).eq(right)?,
+                            Param::Int(left) => match right {
+                                Param::Float(right) => &(*left as f64) == right,
+                                Param::ParameterExpression(right) => {
+                                    &ParameterExpression::try_from(*left)? == right.as_ref()
+                                }
+                                Param::Obj(right) => right.bind(py).eq(left)?,
+                                Param::Int(right) => left == right,
+                            },
                         };
                         if !eq {
                             return Ok(false);

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -29,9 +29,10 @@ use crate::duration::Duration;
 use crate::imports::{CONTROLLED_GATE, WARNINGS_WARN};
 use crate::instruction::{Instruction, Parameters, create_py_op};
 use crate::operations::{
-    ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, Operation,
-    OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation, PyInstruction,
-    PyOpKind, StandardGate, StandardInstruction, StandardInstructionType, Store, UnitaryGate,
+    ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, DelayUnit,
+    Operation, OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation,
+    PyInstruction, PyOpKind, StandardGate, StandardInstruction, StandardInstructionType, Store,
+    UnitaryGate,
 };
 use crate::packed_instruction::PackedOperation;
 use crate::parameter::parameter_expression::ParameterExpression;
@@ -1011,13 +1012,16 @@ pub fn extract_params<T: CircuitBlock>(
         OperationRef::StandardInstruction(i) => {
             match &i {
                 StandardInstruction::Barrier(_) => None,
-                StandardInstruction::Delay(_) => {
+                StandardInstruction::Delay(unit) => {
                     // If the delay's duration is a Python int, we preserve it rather than
                     // coercing it to a float (e.g. when unit is 'dt').
                     Some(Parameters::Params(
                         params
                             .try_iter()?
-                            .map(|p| Param::extract_no_coerce(p?.as_borrowed()))
+                            .map(|p| match unit {
+                                DelayUnit::DT => Param::extract_no_coerce(p?.as_borrowed()),
+                                _ => Ok(p?.extract::<Param>()?),
+                            })
                             .collect::<PyResult<_>>()?,
                     ))
                 }

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -444,6 +444,7 @@ impl CircuitInstruction {
                                     &ParameterExpression::from_f64(*left) == right.as_ref()
                                 }
                                 Param::Obj(right) => right.bind(py).eq(left)?,
+                                Param::Int(right) => left == &(*right as f64),
                             },
                             Param::ParameterExpression(left) => match right {
                                 Param::Float(right) => {
@@ -451,8 +452,19 @@ impl CircuitInstruction {
                                 }
                                 Param::ParameterExpression(right) => left == right,
                                 Param::Obj(right) => right.bind(py).eq(left.as_ref().clone())?,
+                                Param::Int(right) => {
+                                    left.as_ref() == &ParameterExpression::try_from(*right)?
+                                }
                             },
                             Param::Obj(left) => left.bind(py).eq(right)?,
+                            Param::Int(left) => match right {
+                                Param::Float(right) => &(*left as f64) == right,
+                                Param::ParameterExpression(right) => {
+                                    &ParameterExpression::try_from(*left)? == right.as_ref()
+                                }
+                                Param::Obj(right) => right.bind(py).eq(left)?,
+                                Param::Int(right) => left == right,
+                            },
                         };
                         if !eq {
                             return Ok(false);

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -454,14 +454,18 @@ impl CircuitInstruction {
                                 Param::ParameterExpression(right) => left == right,
                                 Param::Obj(right) => right.bind(py).eq(left.as_ref().clone())?,
                                 Param::Int(right) => {
-                                    left.as_ref() == &ParameterExpression::try_from(*right)?
+                                    let right_val: crate::parameter::symbol_expr::Value =
+                                        (*right).try_into()?;
+                                    left.as_ref() == &ParameterExpression::from(right_val)
                                 }
                             },
                             Param::Obj(left) => left.bind(py).eq(right)?,
                             Param::Int(left) => match right {
                                 Param::Float(right) => &(*left as f64) == right,
                                 Param::ParameterExpression(right) => {
-                                    &ParameterExpression::try_from(*left)? == right.as_ref()
+                                    let left_val: crate::parameter::symbol_expr::Value =
+                                        (*left).try_into()?;
+                                    &ParameterExpression::from(left_val) == right.as_ref()
                                 }
                                 Param::Obj(right) => right.bind(py).eq(left)?,
                                 Param::Int(right) => left == right,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6427,7 +6427,7 @@ impl DAGCircuit {
                 &mut self.global_phase,
                 Param::ParameterExpression(angle),
             )),
-            Param::Obj(_) => Err(DAGError::ObjGlobalPhase),
+            Param::Obj(_) | Param::Int(_) => Err(DAGError::ObjGlobalPhase),
         }
     }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6417,7 +6417,7 @@ impl DAGCircuit {
                 &mut self.global_phase,
                 Param::ParameterExpression(angle),
             )),
-            Param::Obj(_) => Err(DAGError::ObjGlobalPhase),
+            Param::Obj(_) | Param::Int(_) => Err(DAGError::ObjGlobalPhase),
         }
     }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -132,9 +132,13 @@ impl Param {
             [Self::Int(int), Self::Float(float)] | [Self::Float(float), Self::Int(int)] => {
                 Ok(float == &(*int as f64))
             }
-            [Self::Int(_), Self::ParameterExpression(_)]
-            | [Self::ParameterExpression(_), Self::Int(_)] => Ok(false),
-            [Self::Int(_), Self::Obj(_)] | [Self::Obj(_), Self::Int(_)] => Ok(false),
+            [Self::Int(int), Self::ParameterExpression(expr)]
+            | [Self::ParameterExpression(expr), Self::Int(int)] => {
+                Ok(ParameterExpression::try_from(*int).map(|i_expr| i_expr == **expr)?)
+            }
+            [Self::Int(int), Self::Obj(obj)] | [Self::Obj(obj), Self::Int(int)] => {
+                Python::attach(|py| obj.bind(py).eq(int))
+            }
         }
     }
 
@@ -193,6 +197,7 @@ impl Param {
                     if coerce_to_float {
                         Ok(Self::Float(i as f64)) // coerce integer to float
                     } else {
+                        // Only extract to integer if the value fits within an unsigned integer
                         if let Ok(unsigned) = i.try_into() {
                             Ok(Self::Int(unsigned))
                         } else {
@@ -223,6 +228,7 @@ impl Param {
         Ok(if ob.is_instance_of::<PyFloat>() {
             Param::Float(ob.extract()?)
         } else if ob.is_instance_of::<PyInt>() {
+            // Only unsigned integers should be represented
             if let Ok(int) = ob.extract() {
                 Param::Int(int)
             } else {

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -53,6 +53,7 @@ pub use crate::standard_gate::*;
 #[derive(Clone, Debug)]
 pub enum Param {
     ParameterExpression(Arc<ParameterExpression>),
+    Int(u64),
     Float(f64),
     Obj(Py<PyAny>),
 }
@@ -70,6 +71,7 @@ impl<'py> IntoPyObject<'py> for &Param {
                 let py_expr = PyParameterExpression::from(expr.as_ref().clone());
                 py_expr.coerce_into_py(py)?.into_bound_py_any(py)
             }
+            Param::Int(big_uint) => big_uint.into_bound_py_any(py),
         }
     }
 }
@@ -95,6 +97,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Param {
         } else if let Ok(val) = b.extract::<f64>() {
             // TODO: remove this branch when we raise the NumPy version to 2.4.
             Param::Float(val)
+        } else if let Ok(int) = b.extract::<u64>() {
+            Param::Int(int)
         } else {
             Param::Obj(b.to_owned().unbind())
         })
@@ -124,6 +128,13 @@ impl Param {
             [Self::Float(_), Self::Obj(_)] => Ok(false),
             [Self::Obj(_a), Self::ParameterExpression(_b)] => Ok(false),
             [Self::ParameterExpression(_a), Self::Obj(_b)] => Ok(false),
+            [Self::Int(int), Self::Int(other_int)] => Ok(int == other_int),
+            [Self::Int(int), Self::Float(float)] | [Self::Float(float), Self::Int(int)] => {
+                Ok(float == &(*int as f64))
+            }
+            [Self::Int(_), Self::ParameterExpression(_)]
+            | [Self::ParameterExpression(_), Self::Int(_)] => Ok(false),
+            [Self::Int(_), Self::Obj(_)] | [Self::Obj(_), Self::Int(_)] => Ok(false),
         }
     }
 
@@ -139,7 +150,7 @@ impl Param {
     /// Get an iterator over any `Symbol` instances tracked within this `Param`.
     pub fn iter_parameters(&self) -> PyResult<Box<dyn Iterator<Item = Symbol> + '_>> {
         match self {
-            Param::Float(_) => Ok(Box::new(::std::iter::empty())),
+            Param::Float(_) | Param::Int(_) => Ok(Box::new(::std::iter::empty())),
             Param::ParameterExpression(expr) => Ok(Box::new(expr.iter_symbols().cloned())),
             Param::Obj(obj) => {
                 Python::attach(|py| -> PyResult<Box<dyn Iterator<Item = Symbol>>> {
@@ -228,6 +239,7 @@ impl Param {
             Param::ParameterExpression(exp) => Param::ParameterExpression(exp.clone()),
             Param::Float(float) => Param::Float(*float),
             Param::Obj(obj) => Param::Obj(obj.clone_ref(py)),
+            Param::Int(int) => Param::Int(*int),
         }
     }
 
@@ -1203,6 +1215,7 @@ pub fn clone_param(param: &Param) -> Param {
         Param::Float(theta) => Param::Float(*theta),
         Param::ParameterExpression(theta) => Param::ParameterExpression(theta.clone()),
         Param::Obj(_) => unreachable!(),
+        Param::Int(int) => Param::Int(*int),
     }
 }
 
@@ -1210,6 +1223,7 @@ pub fn clone_param(param: &Param) -> Param {
 pub fn multiply_param(param: &Param, mult: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(theta * mult),
+        Param::Int(theta) => Param::Float(mult * (*theta as f64)),
         Param::ParameterExpression(theta) => {
             // safe to unwrap as multiplication with float does not have name conflicts
             Param::ParameterExpression(Arc::new(
@@ -1230,6 +1244,7 @@ pub fn multiply_params(param1: Param, param2: Param) -> Param {
             // TODO we could properly propagate the error here
             Param::ParameterExpression(Arc::new(p1.mul(p2).expect("Name conflict during mul.")))
         }
+        (Param::Int(left), Param::Int(right)) => Param::Int(left * right),
         _ => unreachable!("Unsupported multiplication."),
     }
 }
@@ -1242,14 +1257,13 @@ pub fn add_param(param: &Param, summand: f64) -> Param {
             Arc::new(theta.add(&ParameterExpression::from_f64(summand)).unwrap()),
         ),
         Param::Obj(_) => unreachable!("Unsupported addition of a Param::Obj."),
+        Param::Int(int) => Param::Float(summand + (*int as f64)),
     }
 }
 
 pub fn radd_param(param1: Param, param2: Param) -> Param {
     match [&param1, &param2] {
-        [Param::Float(theta), Param::Float(lambda)] => Param::Float(theta + lambda),
-        [Param::Float(theta), Param::ParameterExpression(_lambda)] => add_param(&param2, *theta),
-        [Param::ParameterExpression(_theta), Param::Float(lambda)] => add_param(&param1, *lambda),
+        [param, Param::Float(float)] | [Param::Float(float), param] => add_param(param, *float),
         [
             Param::ParameterExpression(theta),
             Param::ParameterExpression(lambda),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -98,7 +98,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Param {
             // TODO: remove this branch when we raise the NumPy version to 2.4.
             Param::Float(val)
         } else if let Ok(int) = b.extract::<u64>() {
-            Param::Int(int)
+            Param::Float(int as f64)
         } else {
             Param::Obj(b.to_owned().unbind())
         })

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -53,6 +53,7 @@ pub use crate::standard_gate::*;
 #[derive(Clone, Debug)]
 pub enum Param {
     ParameterExpression(Arc<ParameterExpression>),
+    Int(u64),
     Float(f64),
     Obj(Py<PyAny>),
 }
@@ -70,6 +71,7 @@ impl<'py> IntoPyObject<'py> for &Param {
                 let py_expr = PyParameterExpression::from(expr.as_ref().clone());
                 py_expr.coerce_into_py(py)?.into_bound_py_any(py)
             }
+            Param::Int(big_uint) => big_uint.into_bound_py_any(py),
         }
     }
 }
@@ -95,6 +97,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Param {
         } else if let Ok(val) = b.extract::<f64>() {
             // TODO: remove this branch when we raise the NumPy version to 2.4.
             Param::Float(val)
+        } else if let Ok(int) = b.extract::<u64>() {
+            Param::Int(int)
         } else {
             Param::Obj(b.to_owned().unbind())
         })
@@ -124,6 +128,13 @@ impl Param {
             [Self::Float(_), Self::Obj(_)] => Ok(false),
             [Self::Obj(_a), Self::ParameterExpression(_b)] => Ok(false),
             [Self::ParameterExpression(_a), Self::Obj(_b)] => Ok(false),
+            [Self::Int(int), Self::Int(other_int)] => Ok(int == other_int),
+            [Self::Int(int), Self::Float(float)] | [Self::Float(float), Self::Int(int)] => {
+                Ok(float == &(*int as f64))
+            }
+            [Self::Int(_), Self::ParameterExpression(_)]
+            | [Self::ParameterExpression(_), Self::Int(_)] => Ok(false),
+            [Self::Int(_), Self::Obj(_)] | [Self::Obj(_), Self::Int(_)] => Ok(false),
         }
     }
 
@@ -139,7 +150,7 @@ impl Param {
     /// Get an iterator over any `Symbol` instances tracked within this `Param`.
     pub fn iter_parameters(&self) -> PyResult<Box<dyn Iterator<Item = Symbol> + '_>> {
         match self {
-            Param::Float(_) => Ok(Box::new(::std::iter::empty())),
+            Param::Float(_) | Param::Int(_) => Ok(Box::new(::std::iter::empty())),
             Param::ParameterExpression(expr) => Ok(Box::new(expr.iter_symbols().cloned())),
             Param::Obj(obj) => {
                 Python::attach(|py| -> PyResult<Box<dyn Iterator<Item = Symbol>>> {
@@ -228,6 +239,7 @@ impl Param {
             Param::ParameterExpression(exp) => Param::ParameterExpression(exp.clone()),
             Param::Float(float) => Param::Float(*float),
             Param::Obj(obj) => Param::Obj(obj.clone_ref(py)),
+            Param::Int(int) => Param::Int(*int),
         }
     }
 
@@ -1195,6 +1207,7 @@ pub fn clone_param(param: &Param) -> Param {
         Param::Float(theta) => Param::Float(*theta),
         Param::ParameterExpression(theta) => Param::ParameterExpression(theta.clone()),
         Param::Obj(_) => unreachable!(),
+        Param::Int(int) => Param::Int(*int),
     }
 }
 
@@ -1202,6 +1215,7 @@ pub fn clone_param(param: &Param) -> Param {
 pub fn multiply_param(param: &Param, mult: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(theta * mult),
+        Param::Int(theta) => Param::Float(mult * (*theta as f64)),
         Param::ParameterExpression(theta) => {
             // safe to unwrap as multiplication with float does not have name conflicts
             Param::ParameterExpression(Arc::new(
@@ -1222,6 +1236,7 @@ pub fn multiply_params(param1: Param, param2: Param) -> Param {
             // TODO we could properly propagate the error here
             Param::ParameterExpression(Arc::new(p1.mul(p2).expect("Name conflict during mul.")))
         }
+        (Param::Int(left), Param::Int(right)) => Param::Int(left * right),
         _ => unreachable!("Unsupported multiplication."),
     }
 }
@@ -1234,14 +1249,13 @@ pub fn add_param(param: &Param, summand: f64) -> Param {
             Arc::new(theta.add(&ParameterExpression::from_f64(summand)).unwrap()),
         ),
         Param::Obj(_) => unreachable!("Unsupported addition of a Param::Obj."),
+        Param::Int(int) => Param::Float(summand + (*int as f64)),
     }
 }
 
 pub fn radd_param(param1: Param, param2: Param) -> Param {
     match [&param1, &param2] {
-        [Param::Float(theta), Param::Float(lambda)] => Param::Float(theta + lambda),
-        [Param::Float(theta), Param::ParameterExpression(_lambda)] => add_param(&param2, *theta),
-        [Param::ParameterExpression(_theta), Param::Float(lambda)] => add_param(&param1, *lambda),
+        [param, Param::Float(float)] | [Param::Float(float), param] => add_param(param, *float),
         [
             Param::ParameterExpression(theta),
             Param::ParameterExpression(lambda),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -43,7 +43,7 @@ use smallvec::SmallVec;
 use numpy::{PyArray1, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyTuple, PyType};
+use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyInt, PyTuple, PyType};
 use pyo3::{IntoPyObjectExt, Python, intern};
 
 // This is a convenience re-export, since basically everywhere in Qiskit expects all the
@@ -193,9 +193,11 @@ impl Param {
                     if coerce_to_float {
                         Ok(Self::Float(i as f64)) // coerce integer to float
                     } else {
-                        // Int is not a param type and only comes from Python so dump it in
-                        // there until we support DT unit delay from C
-                        Python::attach(|py| Ok(Self::Obj(i.into_py_any(py)?)))
+                        if let Ok(unsigned) = i.try_into() {
+                            Ok(Self::Int(unsigned))
+                        } else {
+                            Python::attach(|py| Ok(Self::Obj(i.into_py_any(py)?)))
+                        }
                     }
                 }
                 Value::Real(f) => Ok(Self::Float(f)),
@@ -220,10 +222,25 @@ impl Param {
     pub fn extract_no_coerce(ob: Borrowed<PyAny>) -> PyResult<Self> {
         Ok(if ob.is_instance_of::<PyFloat>() {
             Param::Float(ob.extract()?)
+        } else if ob.is_instance_of::<PyInt>() {
+            if let Ok(int) = ob.extract() {
+                Param::Int(int)
+            } else {
+                Param::Obj(ob.to_owned().unbind())
+            }
         } else if let Ok(py_expr) = PyParameterExpression::extract_coerce(ob) {
+            if Some(true) == py_expr.inner.is_int() {
+                let Value::Int(int) = py_expr.inner.try_to_value(true)? else {
+                    return Ok(Param::Obj(ob.to_owned().unbind()));
+                };
+                let Ok(int) = int.try_into() else {
+                    return Ok(Param::Obj(ob.to_owned().unbind()));
+                };
+                Param::Int(int)
+            }
             // don't get confused by the `coerce` name here -- we promise to not coerce to
-            // Param::Float. But if it's an int or complex we need to store it as an Obj.
-            if Some(true) == py_expr.inner.is_int() || Some(true) == py_expr.inner.is_complex() {
+            // Param::Float. But if it's complex we need to store it as an Obj.
+            else if Some(true) == py_expr.inner.is_complex() {
                 Param::Obj(ob.to_owned().unbind())
             } else {
                 Param::ParameterExpression(Arc::new(py_expr.inner))

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1242,22 +1242,37 @@ pub fn clone_param(param: &Param) -> Param {
     }
 }
 
-/// Multiply a ``Param`` with a float.
+/// Multiply a [`Param`] with a float.
+///
+/// Multiplying is only supported between variants [`Param::Float`] and
+/// [`Param::ParameterExpression`]. [`Param::Int`] is not currently supported.
+///
+/// # Panics
+///
+/// The operation will panic if any of the parameters is [`Param::Int`] or [`Param::Obj`].
 pub fn multiply_param(param: &Param, mult: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(theta * mult),
-        Param::Int(theta) => Param::Float(mult * (*theta as f64)),
         Param::ParameterExpression(theta) => {
             // safe to unwrap as multiplication with float does not have name conflicts
             Param::ParameterExpression(Arc::new(
                 theta.mul(&ParameterExpression::from_f64(mult)).unwrap(),
             ))
         }
-        Param::Obj(_) => unreachable!("Unsupported multiplication of a Param::Obj."),
+        Param::Obj(_) | Param::Int(_) => {
+            unreachable!("Unsupported multiplication of a Param::Obj.")
+        }
     }
 }
 
 /// Multiply two ``Param``s.
+///
+/// Multiplication is only supported between variants [`Param::Float`] and
+/// [`Param::ParameterExpression`]. [`Param::Int`] is not currently supported.
+///
+/// # Panics
+///
+/// The operation will panic if any of the parameters is [`Param::Int`] or [`Param::Obj`].
 pub fn multiply_params(param1: Param, param2: Param) -> Param {
     match (&param1, &param2) {
         (Param::Float(theta), Param::Float(lambda)) => Param::Float(theta * lambda),
@@ -1272,6 +1287,14 @@ pub fn multiply_params(param1: Param, param2: Param) -> Param {
     }
 }
 
+/// Adda a [`Param`] with a float.
+///
+/// Addition is only supported between variants [`Param::Float`] and
+/// [`Param::ParameterExpression`]. [`Param::Int`] is not currently supported.
+///
+/// # Panics
+///
+/// The operation will panic if any of the parameters is [`Param::Int`] or [`Param::Obj`].
 pub fn add_param(param: &Param, summand: f64) -> Param {
     match param {
         Param::Float(theta) => Param::Float(*theta + summand),
@@ -1279,11 +1302,20 @@ pub fn add_param(param: &Param, summand: f64) -> Param {
             // safe to unwrap as addition with float does not have name conflicts
             Arc::new(theta.add(&ParameterExpression::from_f64(summand)).unwrap()),
         ),
-        Param::Obj(_) => unreachable!("Unsupported addition of a Param::Obj."),
-        Param::Int(int) => Param::Float(summand + (*int as f64)),
+        Param::Obj(_) | Param::Int(_) => {
+            unreachable!("Unsupported addition of a Param::Obj or Param::Int.")
+        }
     }
 }
 
+/// Adds two [`Param`] instances.
+///
+/// Addition is only supported between variants [`Param::Float`] and
+/// [`Param::ParameterExpression`]. [`Param::Int`] is not currently supported.
+///
+/// # Panics
+///
+/// The operation will panic if any of the parameters is [`Param::Int`] or [`Param::Obj`].
 pub fn radd_param(param1: Param, param2: Param) -> Param {
     match [&param1, &param2] {
         [param, Param::Float(float)] | [Param::Float(float), param] => add_param(param, *float),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -160,7 +160,8 @@ impl Param {
             }
             [Self::Int(int), Self::ParameterExpression(expr)]
             | [Self::ParameterExpression(expr), Self::Int(int)] => {
-                Ok(ParameterExpression::try_from(*int).map(|i_expr| i_expr == **expr)?)
+                let int_as_val: Value = (*int).try_into()?;
+                Ok(ParameterExpression::from(int_as_val) == **expr)
             }
             [Self::Int(int), Self::Obj(obj)] | [Self::Obj(obj), Self::Int(int)] => {
                 Python::attach(|py| obj.bind(py).eq(int))

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -50,11 +50,37 @@ use pyo3::{IntoPyObjectExt, Python, intern};
 // `StandardGate` definitions to be in this file.
 pub use crate::standard_gate::*;
 
+/// Represent all possible parameters that can be used on an operation
+/// for Qiskit.
+///
+/// This enumeration has 3(+1) variants:
+/// - [`Param::ParameterExpression`]: Representing an unbound parameter.
+/// - [`Param::Float`]: Represents a bound parameter with a real value
+/// associated with it.
+/// - [`Param::Int`]: Used exclusively to represent a duration in terms of
+/// `Dt` for a [`StandardInstruction::Delay`].
+/// - [`Param::Obj`]: (only used when python is involved). Represents
+/// parameters that are historically not representable in Rust.
 #[derive(Clone, Debug)]
 pub enum Param {
+    /// Represents an unbound parameter as either a symbol or an expression
+    /// comprised of a mix of symbols and numbers. This is used for when a
+    /// certain value is shared between operations in a circuit, and will
+    /// accept a value right before the circuit runs.
     ParameterExpression(Arc<ParameterExpression>),
+    /// Used exclusively to represent a duration in terms of `Dt` for a
+    /// [`StandardInstruction::Delay`]. `Dt` represents a native cycle of time
+    /// for a QPU and therefore this parameter can only represent amounts of
+    /// said magnitude.
     Int(u64),
+    /// Represents a bound parameter with a real value associated with it.
+    /// This, alongside [`Param::ParameterExpression`], is the most common
+    /// way a parameter is associated with a [`StandardGate`] in Qiskit,
+    /// since it usually represents a rotation in terms of radians and as
+    /// these are irrational numbers they are best represented by a
+    /// floating point number.
     Float(f64),
+    /// Represents parameters that are historically not representable in Rust.
     Obj(Py<PyAny>),
 }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -71,7 +71,7 @@ impl<'py> IntoPyObject<'py> for &Param {
                 let py_expr = PyParameterExpression::from(expr.as_ref().clone());
                 py_expr.coerce_into_py(py)?.into_bound_py_any(py)
             }
-            Param::Int(big_uint) => big_uint.into_bound_py_any(py),
+            Param::Int(value) => value.into_bound_py_any(py),
         }
     }
 }

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -322,7 +322,7 @@ impl ParameterExpression {
         value.into()
     }
 
-    /// Initialize from an f64.
+    /// Initialize from an i64.
     pub fn from_i64(value: i64) -> Self {
         Self {
             expr: SymbolExpr::Value(Value::Int(value)),

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -13,6 +13,7 @@
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
 use num_complex::Complex64;
+use std::num::TryFromIntError;
 use std::sync::{Arc, atomic};
 use thiserror::Error;
 use uuid::Uuid;
@@ -318,8 +319,13 @@ impl ParameterExpression {
 
     /// Initialize from an f64.
     pub fn from_f64(value: f64) -> Self {
+        value.into()
+    }
+
+    /// Initialize from an f64.
+    pub fn from_i64(value: i64) -> Self {
         Self {
-            expr: SymbolExpr::Value(Value::Real(value)),
+            expr: SymbolExpr::Value(Value::Int(value)),
             name_map: HashMap::new(),
         }
     }
@@ -747,6 +753,33 @@ impl ParameterExpression {
         }
         Ok(merged)
     }
+}
+
+impl From<f64> for ParameterExpression {
+    fn from(value: f64) -> Self {
+        Self {
+            expr: SymbolExpr::Value(Value::Real(value)),
+            name_map: HashMap::new(),
+        }
+    }
+}
+
+impl From<i64> for ParameterExpression {
+    fn from(value: i64) -> Self {
+        Self {
+            expr: SymbolExpr::Value(Value::Int(value)),
+            name_map: HashMap::new(),
+        }
+    }
+}
+
+impl TryFrom<u64> for ParameterExpression {
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let as_i64: i64 = value.try_into()?;
+        Ok(as_i64.into())
+    }
+
+    type Error = TryFromIntError;
 }
 
 /// A parameter expression.

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -13,7 +13,6 @@
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
 use num_complex::Complex64;
-use std::num::TryFromIntError;
 use std::sync::{Arc, atomic};
 use thiserror::Error;
 use uuid::Uuid;
@@ -319,15 +318,7 @@ impl ParameterExpression {
 
     /// Initialize from an f64.
     pub fn from_f64(value: f64) -> Self {
-        value.into()
-    }
-
-    /// Initialize from an i64.
-    pub fn from_i64(value: i64) -> Self {
-        Self {
-            expr: SymbolExpr::Value(Value::Int(value)),
-            name_map: HashMap::new(),
-        }
+        Value::from(value).into()
     }
 
     /// Load from a sequence of [OPReplay]s. Used in serialization.
@@ -755,31 +746,13 @@ impl ParameterExpression {
     }
 }
 
-impl From<f64> for ParameterExpression {
-    fn from(value: f64) -> Self {
+impl From<Value> for ParameterExpression {
+    fn from(value: Value) -> Self {
         Self {
-            expr: SymbolExpr::Value(Value::Real(value)),
+            expr: SymbolExpr::Value(value),
             name_map: HashMap::new(),
         }
     }
-}
-
-impl From<i64> for ParameterExpression {
-    fn from(value: i64) -> Self {
-        Self {
-            expr: SymbolExpr::Value(Value::Int(value)),
-            name_map: HashMap::new(),
-        }
-    }
-}
-
-impl TryFrom<u64> for ParameterExpression {
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        let as_i64: i64 = value.try_into()?;
-        Ok(as_i64.into())
-    }
-
-    type Error = TryFromIntError;
 }
 
 /// A parameter expression.

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -3628,6 +3628,15 @@ impl From<i64> for Value {
     }
 }
 
+impl TryFrom<u64> for Value {
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let as_i64: i64 = value.try_into()?;
+        Ok(as_i64.into())
+    }
+
+    type Error = <i64 as TryFrom<u64>>::Error;
+}
+
 impl From<Complex64> for Value {
     fn from(v: Complex64) -> Self {
         if (-SYMEXPR_EPSILON..SYMEXPR_EPSILON).contains(&v.im) {

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -61,7 +61,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
             Param::Float(f) => *f,
             Param::ParameterExpression(_) => 1.0,
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
-            Param::Int(_) => todo!(),
+            Param::Int(_) => panic!("StandardGate does not have Param::Int parameters"),
         })
         .collect::<Vec<f64>>();
 

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -55,7 +55,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
             Param::Float(f) => *f,
             Param::ParameterExpression(_) => 1.0,
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
-            Param::Int(_) => todo!(),
+            Param::Int(_) => panic!("StandardGate does not have Param::Int parameters"),
         })
         .collect::<Vec<f64>>();
 

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -55,6 +55,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
             Param::Float(f) => *f,
             Param::ParameterExpression(_) => 1.0,
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
+            Param::Int(_) => todo!(),
         })
         .collect::<Vec<f64>>();
 

--- a/crates/circuit/src/standard_gate/standard_generators.rs
+++ b/crates/circuit/src/standard_gate/standard_generators.rs
@@ -61,6 +61,7 @@ pub fn standard_gate_exponent(gate: StandardGate, params: &[Param]) -> Option<Sp
             Param::Float(f) => *f,
             Param::ParameterExpression(_) => 1.0,
             Param::Obj(_) => panic!("StandardGate does not have Param::Obj parameters"),
+            Param::Int(_) => todo!(),
         })
         .collect::<Vec<f64>>();
 

--- a/crates/qasm3/src/ast.rs
+++ b/crates/qasm3/src/ast.rs
@@ -118,9 +118,32 @@ pub struct BitstringLiteral {
     pub width: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum DurationValue {
+    Dt(u64),
+    Float(f64),
+}
+
+impl Display for DurationValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            DurationValue::Dt(u) => write!(f, "{}", u),
+            DurationValue::Float(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+impl DurationValue {
+    pub fn try_float(&self) -> Option<f64> {
+        match self {
+            DurationValue::Dt(_) => None,
+            DurationValue::Float(f) => Some(*f),
+        }
+    }
+}
 #[derive(Debug, Clone)]
 pub struct DurationLiteral {
-    pub value: f64,
+    pub value: DurationValue,
     pub unit: DurationUnit,
 }
 

--- a/crates/qasm3/src/ast.rs
+++ b/crates/qasm3/src/ast.rs
@@ -12,6 +12,8 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
+use qiskit_circuit::operations::DelayUnit;
+
 #[allow(dead_code)]
 pub enum Node<'a> {
     Program(&'a Program),
@@ -118,54 +120,44 @@ pub struct BitstringLiteral {
     pub width: u32,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum DurationValue {
-    Dt(u64),
-    Float(f64),
-}
-
-impl Display for DurationValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            DurationValue::Dt(u) => write!(f, "{}", u),
-            DurationValue::Float(v) => write!(f, "{}", v),
-        }
-    }
-}
-
-impl DurationValue {
-    pub fn try_float(&self) -> Option<f64> {
-        match self {
-            DurationValue::Dt(_) => None,
-            DurationValue::Float(f) => Some(*f),
-        }
-    }
-}
 #[derive(Debug, Clone)]
-pub struct DurationLiteral {
-    pub value: DurationValue,
-    pub unit: DurationUnit,
+pub enum DurationLiteral {
+    Nanosecond(f64),
+    Microsecond(f64),
+    Millisecond(f64),
+    Second(f64),
+    Sample(u64),
 }
 
-#[derive(Debug, Clone)]
-pub enum DurationUnit {
-    Nanosecond,
-    Microsecond,
-    Millisecond,
-    Second,
-    Sample,
-}
-
-impl Display for DurationUnit {
+impl Display for DurationLiteral {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let unit_str = match self {
-            DurationUnit::Nanosecond => "ns",
-            DurationUnit::Microsecond => "us",
-            DurationUnit::Millisecond => "ms",
-            DurationUnit::Second => "s",
-            DurationUnit::Sample => "dt",
-        };
-        write!(f, "{unit_str}")
+        match self {
+            DurationLiteral::Nanosecond(unit) => write!(f, "{unit}ns"),
+            DurationLiteral::Microsecond(unit) => write!(f, "{unit}us"),
+            DurationLiteral::Millisecond(unit) => write!(f, "{unit}ms"),
+            DurationLiteral::Second(unit) => write!(f, "{unit}s"),
+            DurationLiteral::Sample(unit) => write!(f, "{unit}dt"),
+        }
+    }
+}
+
+impl DurationLiteral {
+    /// Creates a [`DurationLiteral`] from a [`DelayUnit`] with a provided floating point value.
+    pub fn try_from_float(delay_unit: DelayUnit, value: f64) -> Result<Self, DelayUnit> {
+        match delay_unit {
+            DelayUnit::NS => Ok(Self::Nanosecond(value)),
+            DelayUnit::PS => Ok(Self::Nanosecond(value / 1000.0)),
+            DelayUnit::US => Ok(Self::Microsecond(value)),
+            DelayUnit::MS => Ok(Self::Millisecond(value)),
+            DelayUnit::S => Ok(Self::Second(value)),
+            _ => Err(delay_unit),
+        }
+    }
+}
+
+impl From<u64> for DurationLiteral {
+    fn from(value: u64) -> Self {
+        Self::Sample(value)
     }
 }
 

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -24,7 +24,6 @@ use std::io::Write;
 
 use crate::printer::BasicPrinter;
 use hashbrown::{HashMap, HashSet};
-use pyo3::Python;
 use pyo3::prelude::*;
 use qiskit_circuit::bit::{
     ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
@@ -1176,27 +1175,20 @@ impl<'a> QASM3Builder {
             ));
         };
         let param = &instr.params_view()[0];
-        let duration: f64 = Python::attach(|py| match param {
+
+        let duration: f64 = match param {
             Param::Float(val) => *val,
+            Param::Int(int) => *int as f64, // lossy conversion
             Param::ParameterExpression(p) => match p.try_to_value(true) {
                 Ok(symbol_expr::Value::Real(val)) => val,
                 _ => {
                     panic!("Failed to parse parameter value")
                 }
             },
-            Param::Obj(obj) => {
-                let py_obj = obj.bind(py);
-                let py_str = py_obj.str().expect("Failed to call str() on Parameter");
-                let name = py_str
-                    .str()
-                    .expect("Failed to convert PyString to &str")
-                    .to_string();
-                match name.parse::<f64>() {
-                    Ok(val) => val,
-                    Err(_) => panic!("Failed to parse parameter value"),
-                }
+            Param::Obj(_) => {
+                unreachable!("Should not use obj as a parameter for duration.")
             }
-        });
+        };
 
         let mut map = HashMap::new();
         map.insert(DelayUnit::NS, DurationUnit::Nanosecond);
@@ -1255,22 +1247,24 @@ impl<'a> QASM3Builder {
             self.define_gate(instr)?;
         }
         let params = if self.disable_constants {
-            Python::attach(|_py| {
-                instr
-                    .params_view()
-                    .iter()
-                    .map(|param| match param {
-                        Param::Float(val) => Expression::Parameter(Parameter {
-                            obj: val.to_string(),
-                        }),
-                        Param::ParameterExpression(p) => {
-                            let name = p.to_string();
-                            Expression::Parameter(Parameter { obj: name })
-                        }
-                        Param::Obj(_) => panic!("Objects not supported yet"),
-                    })
-                    .collect::<Vec<_>>()
-            })
+            instr
+                .params_view()
+                .iter()
+                .map(|param| match param {
+                    Param::Float(val) => Expression::Parameter(Parameter {
+                        obj: val.to_string(),
+                    }),
+                    Param::ParameterExpression(p) => {
+                        let name = p.to_string();
+                        Expression::Parameter(Parameter { obj: name })
+                    }
+                    Param::Obj(_) => panic!("Objects not supported yet"),
+                    Param::Int(i) => {
+                        let name = i.to_string();
+                        Expression::Parameter(Parameter { obj: name })
+                    }
+                })
+                .collect::<Vec<_>>()
         } else {
             return Err(QASM3ExporterError::Error(
                 "Constant parameters not supported yet".to_string(),

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -14,11 +14,11 @@ use std::sync::Arc;
 
 use crate::ast::{
     Alias, Barrier, BitArray, Break, ClassicalDeclaration, ClassicalType, Continue, Delay,
-    Designator, DurationLiteral, DurationUnit, Expression, Float, GateCall, Header, IODeclaration,
-    IOModifier, Identifier, IdentifierOrSubscripted, Include, IndexSet, IntegerLiteral, Node,
-    Parameter, Program, QuantumBlock, QuantumDeclaration, QuantumGateDefinition,
-    QuantumGateSignature, QuantumInstruction, QuantumMeasurement, QuantumMeasurementAssignment,
-    Reset, Statement, SubscriptedIdentifier, Version,
+    Designator, DurationLiteral, DurationUnit, DurationValue, Expression, Float, GateCall, Header,
+    IODeclaration, IOModifier, Identifier, IdentifierOrSubscripted, Include, IndexSet,
+    IntegerLiteral, Node, Parameter, Program, QuantumBlock, QuantumDeclaration,
+    QuantumGateDefinition, QuantumGateSignature, QuantumInstruction, QuantumMeasurement,
+    QuantumMeasurementAssignment, Reset, Statement, SubscriptedIdentifier, Version,
 };
 use std::io::Write;
 
@@ -1176,18 +1176,34 @@ impl<'a> QASM3Builder {
         };
         let param = &instr.params_view()[0];
 
-        let duration: f64 = match param {
-            Param::Float(val) => *val,
-            Param::Int(int) => *int as f64, // lossy conversion
+        let duration: DurationValue = match param {
+            Param::Float(val) => DurationValue::Float(*val),
+            Param::Int(int) => DurationValue::Dt(*int),
             Param::ParameterExpression(p) => match p.try_to_value(true) {
-                Ok(symbol_expr::Value::Real(val)) => val,
+                Ok(symbol_expr::Value::Real(val)) => DurationValue::Float(val),
+                Ok(symbol_expr::Value::Int(val)) => {
+                    if let Ok(val) = val.try_into() {
+                        DurationValue::Dt(val)
+                    } else {
+                        DurationValue::Float(val as f64) // Lossy conversion.
+                    }
+                }
                 _ => {
                     panic!("Failed to parse parameter value")
                 }
             },
-            Param::Obj(_) => {
-                unreachable!("Should not use obj as a parameter for duration.")
-            }
+            Param::Obj(obj) => Python::attach(|py| {
+                let py_obj = obj.bind(py);
+                let py_str = py_obj.str().expect("Failed to call str() on Parameter");
+                let name = py_str
+                    .str()
+                    .expect("Failed to convert PyString to &str")
+                    .to_string();
+                match name.parse::<f64>() {
+                    Ok(val) => DurationValue::Float(val),
+                    Err(_) => panic!("Failed to parse parameter value"),
+                }
+            }),
         };
 
         let mut map = HashMap::new();
@@ -1205,7 +1221,11 @@ impl<'a> QASM3Builder {
             None => {
                 if delay_unit == DelayUnit::PS {
                     DurationLiteral {
-                        value: duration / 1000.0,
+                        value: DurationValue::Float(
+                            duration.try_float().expect(
+                                "Ps values should be floats, an integer was found instead.",
+                            ) / 1000.0,
+                        ),
                         unit: DurationUnit::Nanosecond,
                     }
                 } else {

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1178,11 +1178,17 @@ impl<'a> QASM3Builder {
 
         let duration: DurationValue = match param {
             Param::Float(val) => DurationValue::Float(*val),
-            Param::Int(int) => DurationValue::Dt(*int),
+            Param::Int(int) => match delay_unit {
+                // Any param with an integer value should only be reserved for DT
+                DelayUnit::DT => DurationValue::Dt(*int),
+                _ => DurationValue::Float(*int as f64), // Lossy conversion
+            },
             Param::ParameterExpression(p) => match p.try_to_value(true) {
                 Ok(symbol_expr::Value::Real(val)) => DurationValue::Float(val),
                 Ok(symbol_expr::Value::Int(val)) => {
-                    if let Ok(val) = val.try_into() {
+                    if let Ok(val) = val.try_into()
+                        && matches!(delay_unit, DelayUnit::DT)
+                    {
                         DurationValue::Dt(val)
                     } else {
                         DurationValue::Float(val as f64) // Lossy conversion.

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -14,11 +14,11 @@ use std::sync::Arc;
 
 use crate::ast::{
     Alias, Barrier, BitArray, Break, ClassicalDeclaration, ClassicalType, Continue, Delay,
-    Designator, DurationLiteral, DurationUnit, DurationValue, Expression, Float, GateCall, Header,
-    IODeclaration, IOModifier, Identifier, IdentifierOrSubscripted, Include, IndexSet,
-    IntegerLiteral, Node, Parameter, Program, QuantumBlock, QuantumDeclaration,
-    QuantumGateDefinition, QuantumGateSignature, QuantumInstruction, QuantumMeasurement,
-    QuantumMeasurementAssignment, Reset, Statement, SubscriptedIdentifier, Version,
+    Designator, DurationLiteral, Expression, Float, GateCall, Header, IODeclaration, IOModifier,
+    Identifier, IdentifierOrSubscripted, Include, IndexSet, IntegerLiteral, Node, Parameter,
+    Program, QuantumBlock, QuantumDeclaration, QuantumGateDefinition, QuantumGateSignature,
+    QuantumInstruction, QuantumMeasurement, QuantumMeasurementAssignment, Reset, Statement,
+    SubscriptedIdentifier, Version,
 };
 use std::io::Write;
 
@@ -1176,29 +1176,23 @@ impl<'a> QASM3Builder {
         };
         let param = &instr.params_view()[0];
 
-        let duration: DurationValue = match param {
-            Param::Float(val) => DurationValue::Float(*val),
-            Param::Int(int) => match delay_unit {
-                // Any param with an integer value should only be reserved for DT
-                DelayUnit::DT => DurationValue::Dt(*int),
-                _ => DurationValue::Float(*int as f64), // Lossy conversion
-            },
+        let duration: DurationLiteral = match param {
+            Param::Float(val) => float_to_duration_literal(*val, delay_unit)?,
+            Param::Int(val) => int_to_duration_literal(*val, delay_unit)?,
             Param::ParameterExpression(p) => match p.try_to_value(true) {
-                Ok(symbol_expr::Value::Real(val)) => DurationValue::Float(val),
+                Ok(symbol_expr::Value::Real(val)) => float_to_duration_literal(val, delay_unit)?,
                 Ok(symbol_expr::Value::Int(val)) => {
-                    if let Ok(val) = val.try_into()
-                        && matches!(delay_unit, DelayUnit::DT)
-                    {
-                        DurationValue::Dt(val)
+                    if let Ok(val) = val.try_into() {
+                        int_to_duration_literal(val, delay_unit)?
                     } else {
-                        DurationValue::Float(val as f64) // Lossy conversion.
+                        float_to_duration_literal(val as f64, delay_unit)? // Lossy conversion.
                     }
                 }
                 _ => {
                     panic!("Failed to parse parameter value")
                 }
             },
-            Param::Obj(obj) => Python::attach(|py| {
+            Param::Obj(obj) => Python::attach(|py| -> Result<DurationLiteral, _> {
                 let py_obj = obj.bind(py);
                 let py_str = py_obj.str().expect("Failed to call str() on Parameter");
                 let name = py_str
@@ -1206,40 +1200,10 @@ impl<'a> QASM3Builder {
                     .expect("Failed to convert PyString to &str")
                     .to_string();
                 match name.parse::<f64>() {
-                    Ok(val) => DurationValue::Float(val),
+                    Ok(val) => float_to_duration_literal(val, delay_unit),
                     Err(_) => panic!("Failed to parse parameter value"),
                 }
-            }),
-        };
-
-        let mut map = HashMap::new();
-        map.insert(DelayUnit::NS, DurationUnit::Nanosecond);
-        map.insert(DelayUnit::US, DurationUnit::Microsecond);
-        map.insert(DelayUnit::MS, DurationUnit::Millisecond);
-        map.insert(DelayUnit::S, DurationUnit::Second);
-        map.insert(DelayUnit::DT, DurationUnit::Sample);
-
-        let duration_literal: DurationLiteral = match map.get(&delay_unit) {
-            Some(found) => DurationLiteral {
-                value: duration,
-                unit: found.clone(),
-            },
-            None => {
-                if delay_unit == DelayUnit::PS {
-                    DurationLiteral {
-                        value: DurationValue::Float(
-                            duration.try_float().expect(
-                                "Ps values should be floats, an integer was found instead.",
-                            ) / 1000.0,
-                        ),
-                        unit: DurationUnit::Nanosecond,
-                    }
-                } else {
-                    return Err(QASM3ExporterError::Error(format!(
-                        "Unknown delay unit: {delay_unit}"
-                    )));
-                }
-            }
+            })?,
         };
 
         let mut qubits = Vec::new();
@@ -1256,10 +1220,7 @@ impl<'a> QASM3Builder {
             ))?;
             qubits.push(id.to_owned());
         }
-        Ok(Delay {
-            duration: duration_literal,
-            qubits,
-        })
+        Ok(Delay { duration, qubits })
     }
 
     fn build_gate_call(&mut self, instr: &PackedInstruction) -> ExporterResult<GateCall> {
@@ -1390,5 +1351,32 @@ impl<'a> QASM3Builder {
                 operation.name()
             )))
         }
+    }
+}
+
+fn float_to_duration_literal(
+    val: f64,
+    unit: DelayUnit,
+) -> Result<DurationLiteral, QASM3ExporterError> {
+    match DurationLiteral::try_from_float(unit, val) {
+        Ok(literal) => Ok(literal),
+        Err(incorrect_unit) => Err(QASM3ExporterError::Error(format!(
+            "The Delay instruction has incorrect units: Floating point '{val}' cannot be used for '{}'.",
+            incorrect_unit
+        ))),
+    }
+}
+
+fn int_to_duration_literal(
+    val: u64,
+    unit: DelayUnit,
+) -> Result<DurationLiteral, QASM3ExporterError> {
+    // Any param with an integer value should only be reserved for DT
+    match unit {
+        DelayUnit::DT => Ok(DurationLiteral::from(val)),
+        _ => Err(QASM3ExporterError::Error(format!(
+            "The Delay instruction has incorrect units: Integer '{val}' cannot be used for '{}'.",
+            unit
+        ))),
     }
 }

--- a/crates/qasm3/src/printer.rs
+++ b/crates/qasm3/src/printer.rs
@@ -259,7 +259,7 @@ impl<'a> BasicPrinter<'a> {
     }
 
     fn visit_duration_literal(&mut self, expression: &DurationLiteral) {
-        write!(self.stream, "{}{}", expression.value, expression.unit).unwrap();
+        write!(self.stream, "{}", expression).unwrap();
     }
 
     fn visit_unary(&mut self, expression: &Unary) {

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -304,6 +304,11 @@ pub fn instruction_values_to_params(
             .map(|value| -> Result<_, QpyError> {
                 match value {
                     GenericValue::Float64(float) => Ok(Param::Float(float)),
+                    GenericValue::Int64(i64) => {
+                        // When an i64 value is found to be a parameter
+                        // turn it into a u64 as its digital footprint is the same.
+                        Ok(Param::Int(u64::try_from(i64)?))
+                    }
                     GenericValue::ParameterExpression(exp) => Ok(Param::ParameterExpression(exp)),
                     GenericValue::ParameterExpressionSymbol(symbol)
                     | GenericValue::ParameterExpressionVectorSymbol(symbol) => {

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -305,8 +305,8 @@ pub fn instruction_values_to_params(
                 match value {
                     GenericValue::Float64(float) => Ok(Param::Float(float)),
                     GenericValue::Int64(i64) => {
-                        // When an i64 value is found to be a parameter
-                        // turn it into a u64 as its digital footprint is the same.
+                        // Truncates u64 to i64::MAX due to having no correct way
+                        // to preserve unsigned integers. See #16972.
                         Ok(Param::Int(u64::try_from(i64)?))
                     }
                     GenericValue::ParameterExpression(exp) => Ok(Param::ParameterExpression(exp)),

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -406,3 +406,105 @@ pub fn py_load_qpy(
         })
         .collect()
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+
+    use super::*;
+    use qiskit_circuit::Qubit;
+    use qiskit_circuit::operations::{DelayUnit, OperationRef, Param, StandardInstruction};
+    use qiskit_circuit::packed_instruction::PackedOperation;
+    use smallvec::smallvec;
+
+    /// Builds the [`ExtraCircuitData`] required to serialize a native circuit that carries no
+    /// Python-only metadata or transpiler layout.
+    fn native_extra_data(circuit: &CircuitData, name: &str, version: u8) -> ExtraCircuitData {
+        ExtraCircuitData {
+            name: Some(name.to_string()),
+            // Circuit metadata is always decoded with `json.loads`, and older Qiskit
+            // releases require the decoded value to be a dictionary.
+            metadata: "{}".into(),
+            layout: serialize(&pack_layout(None, circuit, version).unwrap()).unwrap(),
+        }
+    }
+
+    /// A circuit containing a single `Delay` measured in `dt` should survive a native
+    /// QPY dump/load round trip: the instruction, its `dt` unit, and its integer-typed
+    /// duration are all preserved.
+    #[test]
+    fn delay_in_dt_roundtrip() {
+        let version = QPY_WRITE_MIN_VERSION;
+
+        // Build a 1-qubit circuit with a `Delay` instruction of 13 dt value.
+        let circuit = CircuitData::from_packed_operations(
+            1,
+            0,
+            [Ok((
+                PackedOperation::from_standard_instruction(StandardInstruction::Delay(
+                    DelayUnit::DT,
+                )),
+                smallvec![Param::Int(13)],
+                vec![Qubit(0)],
+                Vec::with_capacity(0),
+            ))],
+            0.0.into(),
+        )
+        .unwrap();
+
+        // Round trip through the native QPY dump/load entry points.
+        let extra = native_extra_data(&circuit, "delay_dt_circuit", version);
+        let payload = dump_qpy(vec![circuit], vec![extra], version, None, None).unwrap();
+        let loaded = load_qpy(&payload, None, None).unwrap();
+
+        // Exactly one circuit, with exactly one instruction.
+        assert_eq!(loaded.len(), 1);
+        let loaded_circuit = &loaded[0].circuit_data;
+        assert_eq!(loaded_circuit.num_qubits(), 1);
+        assert_eq!(loaded_circuit.len(), 1);
+
+        // That instruction is a `Delay` whose unit round-tripped as `dt`.
+        let inst = &loaded_circuit.data()[0];
+        let OperationRef::StandardInstruction(StandardInstruction::Delay(unit)) = inst.op.view()
+        else {
+            panic!(
+                "expected a standard Delay instruction, got {:?}",
+                inst.op.view()
+            );
+        };
+        assert_eq!(unit, DelayUnit::DT);
+
+        // The duration parameter is preserved.
+        assert!(matches!(inst.params_view(), [Param::Int(d)] if *d == 13));
+    }
+
+    /// A duration bigger than `i64::MAX` is not currently supported by QPY
+    /// See #16972.
+    #[test]
+    fn delay_in_dt_over_limit() {
+        let version = QPY_WRITE_MIN_VERSION;
+
+        // Build a 1-qubit circuit with a `Delay` instruction of 13 dt value.
+        let circuit = CircuitData::from_packed_operations(
+            1,
+            0,
+            [Ok((
+                PackedOperation::from_standard_instruction(StandardInstruction::Delay(
+                    DelayUnit::DT,
+                )),
+                smallvec![Param::Int(u64::MAX)],
+                vec![Qubit(0)],
+                Vec::with_capacity(0),
+            ))],
+            0.0.into(),
+        )
+        .unwrap();
+
+        // Round trip through the native QPY dump/load entry points.
+        let extra = native_extra_data(&circuit, "delay_dt_circuit", version);
+        assert!(matches!(
+            dump_qpy(vec![circuit], vec![extra], version, None, None),
+            Err(QpyError::IntConversionError(_))
+        ))
+    }
+}

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -581,6 +581,16 @@ pub(crate) fn pack_param_obj(
         Param::Obj(py_object) => qpy_data.caller.attach("Python parameter", |py| {
             py_pack_param(py_object.bind(py), qpy_data, endian)
         })?,
+        Param::Int(int) => match resolved {
+            Endian::Little => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: int.to_le_bytes().into(),
+            },
+            Endian::Big => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: int.to_be_bytes().into(),
+            },
+        },
     })
 }
 

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -582,6 +582,16 @@ pub(crate) fn pack_param_obj(
         Param::Obj(py_object) => {
             Python::attach(|py| py_pack_param(py_object.bind(py), qpy_data, endian))?
         }
+        Param::Int(int) => match endian {
+            Endian::Little => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: int.to_le_bytes().into(),
+            },
+            Endian::Big => formats::GenericDataPack {
+                type_key: ValueType::Integer,
+                data: int.to_be_bytes().into(),
+            },
+        },
     })
 }
 

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -582,7 +582,7 @@ pub(crate) fn pack_param_obj(
         Param::Obj(py_object) => {
             Python::attach(|py| py_pack_param(py_object.bind(py), qpy_data, endian))?
         }
-        Param::Int(int) => match endian {
+        Param::Int(int) => match resolved {
             Endian::Little => formats::GenericDataPack {
                 type_key: ValueType::Integer,
                 data: int.to_le_bytes().into(),

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -582,13 +582,16 @@ pub(crate) fn pack_param_obj(
             py_pack_param(py_object.bind(py), qpy_data, endian)
         })?,
         Param::Int(int) => match resolved {
+            // Current support requires the unsigned integer
+            // to be truncates to fit within an `i64`.
+            // TODO: Update this model to fully support `u64`.
             Endian::Little => formats::GenericDataPack {
                 type_key: ValueType::Integer,
-                data: int.to_le_bytes().into(),
+                data: i64::try_from(*int)?.to_le_bytes().into(),
             },
             Endian::Big => formats::GenericDataPack {
                 type_key: ValueType::Integer,
-                data: int.to_be_bytes().into(),
+                data: i64::try_from(*int)?.to_be_bytes().into(),
             },
         },
     })

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -640,7 +640,7 @@ fn replace_node(
             Param::Float(_) => dag
                 .add_global_phase(target_dag.global_phase())
                 .map_err(|e| BasisTranslatorError::BasisDAGCircuitError(e.to_string())),
-            Param::Obj(_) => Ok(()),
+            Param::Obj(_) | Param::Int(_) => Ok(()),
         }?
     }
 
@@ -665,6 +665,16 @@ fn param_expr_assignment(
                 let val = Python::attach(|py| val.extract::<Value>(py))
                     .map_err(|_| ParameterError::InvalidValue)?;
                 bind_map.insert(key, val);
+            }
+            Param::Int(int) => {
+                bind_map.insert(
+                    key,
+                    Value::Int(
+                        (*int)
+                            .try_into()
+                            .expect("Unsigned integer does not fit in an i64 slot."),
+                    ),
+                );
             }
         }
     }

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -638,7 +638,7 @@ fn replace_node(
             Param::Float(_) => dag
                 .add_global_phase(target_dag.global_phase())
                 .map_err(|e| BasisTranslatorError::BasisDAGCircuitError(e.to_string())),
-            Param::Obj(_) => Ok(()),
+            Param::Obj(_) | Param::Int(_) => Ok(()),
         }?
     }
 
@@ -663,6 +663,16 @@ fn param_expr_assignment(
                 let val = Python::attach(|py| val.extract::<Value>(py))
                     .map_err(|_| ParameterError::InvalidValue)?;
                 bind_map.insert(key, val);
+            }
+            Param::Int(int) => {
+                bind_map.insert(
+                    key,
+                    Value::Int(
+                        (*int)
+                            .try_into()
+                            .expect("Unsigned integer does not fit in an i64 slot."),
+                    ),
+                );
             }
         }
     }

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -131,9 +131,9 @@ fn push_node_back(
             .first()
             .ok_or_else(|| PyValueError::new_err("Delay instruction missing duration parameter"))?;
         let duration = match param {
-            Param::Obj(val) => {
+            Param::Int(val) => {
                 // Try to extract as different numeric types
-                Python::attach(|py| val.bind(py).extract::<u64>())
+                Ok(*val)
             }
             Param::Float(f) => Ok(*f as u64),
             _ => Err(TranspilerError::new_err(

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -135,7 +135,6 @@ fn push_node_back(
                 // Try to extract as different numeric types
                 Ok(*val)
             }
-            Param::Float(f) => Ok(*f as u64),
             _ => Err(TranspilerError::new_err(
                 "The provided Delay duration is not in terms of dt.",
             )),

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -67,6 +67,9 @@ class Delay(Instruction):
             unit = "dt"
         elif unit not in {"s", "ms", "us", "ns", "ps", "dt"}:
             raise CircuitError(f"Unknown unit {unit} is specified.")
+        if isinstance(duration, int) and unit != "dt":
+            # Integer durations should only exist when using dt units
+            duration = float(duration)
         return duration, unit
 
     broadcast_arguments = Gate.broadcast_arguments

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -779,7 +779,7 @@ c[1] = measure q[1];
                 "qubit[2] qr;",
                 "stretch s;",
                 "stretch t;",
-                "delay[100ms] qr[0];",
+                "delay[100.0ms] qr[0];",
                 "delay[100.0ms] qr[0];",
                 "delay[0.002ns] qr[1];",
                 "delay[s / 2.0] qr[1];",


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
### Summary
Fixes #16717

The following commits add a new variant to the `Param` enum called `Int`. This variant is to be used exclusively for representing `dt` units as `Parameters` for delay. Removing the reliance on Python to correctly analyze these.

The bulk of the changes here add the correct handling for the cases in which this type of parameter is found.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [x] I used the following tool to generate or modify code: Claude Opus 4.8 for QPY tests.

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
