### PR TITLE
Use correct `Symbol` directly during string parsing

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -855,20 +855,13 @@ impl PyParameterExpression {
     #[new]
     #[pyo3(signature = (name_map, expr))]
     pub fn py_new(name_map: HashMap<String, PyParameter>, expr: String) -> PyResult<Self> {
-        // We first parse the expression and then update the symbols with the ones
-        // the user provided. The replacement relies on the names to match.
-        // This is hacky and we likely want a more reliably conversion from a SymPy object,
-        // if we decide we want to continue supporting this.
-        let expr = parse_expression(&expr)
-            .map_err(|_| PyRuntimeError::new_err("Failed parsing input expression"))?;
         let symbol_map: HashMap<String, Symbol> = name_map
             .iter()
             .map(|(string, param)| (string.clone(), Symbol::clone(&param.0)))
             .collect();
-
-        let replaced_expr = symbol_expr::replace_symbol(&expr, &symbol_map);
-
-        let inner = ParameterExpression::new(replaced_expr, symbol_map);
+        let expr = parse_expression(&expr, &|name| symbol_map.get(name).cloned())
+            .map_err(|_| PyRuntimeError::new_err("Failed parsing input expression"))?;
+        let inner = ParameterExpression::new(expr, symbol_map);
         Ok(Self { inner })
     }
 

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -3781,31 +3781,6 @@ impl PartialOrd for Value {
     }
 }
 
-/// Replace [Symbol]s in a [SymbolExpr] according to the name map. This
-/// is used to reconstruct a parameter expression from a string.
-pub fn replace_symbol(symbol_expr: &SymbolExpr, name_map: &HashMap<String, Symbol>) -> SymbolExpr {
-    match symbol_expr {
-        SymbolExpr::Symbol(existing_symbol) => {
-            let name = existing_symbol.repr(false);
-            if let Some(new_symbol) = name_map.get(&name) {
-                SymbolExpr::Symbol(Arc::new(new_symbol.clone()))
-            } else {
-                symbol_expr.clone()
-            }
-        }
-        SymbolExpr::Value(_) => symbol_expr.clone(), // nothing to do
-        SymbolExpr::Binary { op, lhs, rhs } => SymbolExpr::Binary {
-            op: op.clone(),
-            lhs: Arc::new(replace_symbol(lhs, name_map)),
-            rhs: Arc::new(replace_symbol(rhs, name_map)),
-        },
-        SymbolExpr::Unary { op, expr } => SymbolExpr::Unary {
-            op: op.clone(),
-            expr: Arc::new(replace_symbol(expr, name_map)),
-        },
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -44,7 +44,10 @@ fn parse_imaginary_value(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str
 
 // parse string as symbol
 // symbol starting with alphabet and can contain numbers and '_', '\', '$', '[', ']'
-fn parse_symbol(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_symbol<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
     // At this point, we just consume the entire name string, regardless of index; it's up to a
     // "name map" later to replace names with complete `Symbol` implementations, since the string
     // form doesn't carry sufficient information to correctly assign UUIDs or base vectors.
@@ -55,12 +58,19 @@ fn parse_symbol(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
         )
         .and(opt(delimited(char('['), digit1, char(']')))),
     )
-    .map(|v: &str| SymbolExpr::Symbol(Arc::new(Symbol::standalone(v.to_owned(), None))))
+    .map(|v: &str| {
+        let sym = sym_fn(v).unwrap_or_else(|| Symbol::standalone(v.to_owned(), None));
+        SymbolExpr::Symbol(Arc::new(sym))
+    })
     .parse(s)
 }
 
 // parse unary operations
-fn parse_unary(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_unary<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_addsub = |s| parse_addsub(s, sym_fn);
     (
         delimited(multispace0, alphanumeric1, multispace0),
         delimited(
@@ -92,10 +102,19 @@ fn parse_unary(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
         .parse(s)
 }
 
-// sign is separately parsed in this function
-fn parse_sign(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_expr<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_unary = |s| parse_unary(s, sym_fn);
+    let parse_symbol = |s| parse_symbol(s, sym_fn);
+    let parse_addsub = |s| parse_addsub(s, sym_fn);
     (
-        delimited(multispace0, alt((char('-'), char('+'))), multispace0),
+        opt(delimited(
+            multispace0,
+            alt((char('-'), char('+'))),
+            multispace0,
+        )),
         alt((
             parse_imaginary_value,
             parse_value,
@@ -108,37 +127,22 @@ fn parse_sign(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
             ),
         )),
     )
-        .map(|(op, expr)| {
-            if op == '+' {
-                expr
-            } else {
-                SymbolExpr::Unary {
-                    op: UnaryOp::Neg,
-                    expr: Arc::new(expr),
-                }
-            }
+        .map(|(op, expr)| match op {
+            Some('-') => SymbolExpr::Unary {
+                op: UnaryOp::Neg,
+                expr: Arc::new(expr),
+            },
+            _ => expr,
         })
         .parse(s)
 }
 
-fn parse_expr(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
-    alt((
-        parse_imaginary_value,
-        parse_value,
-        parse_sign,
-        parse_unary,
-        parse_symbol,
-        delimited(
-            char('('),
-            delimited(multispace0, parse_addsub, multispace0),
-            char(')'),
-        ),
-    ))
-    .parse(s)
-}
-
 // parse pow
-fn parse_pow(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_pow<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_expr = |s| parse_expr(s, sym_fn);
     permutation((
         parse_expr,
         many0((multispace0, tag("**"), multispace0, parse_expr).map(|(_, _, _, rhs)| rhs)),
@@ -148,7 +152,11 @@ fn parse_pow(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
 }
 
 // parse mul and div
-fn parse_muldiv(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_muldiv<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_pow = |s| parse_pow(s, sym_fn);
     permutation((
         parse_pow,
         many0(
@@ -178,7 +186,11 @@ fn parse_muldiv(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
 }
 
 // parse add and sub
-fn parse_addsub(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
+fn parse_addsub<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_muldiv = |s| parse_muldiv(s, sym_fn);
     permutation((
         parse_muldiv,
         many0(
@@ -207,7 +219,11 @@ fn parse_addsub(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
     .parse(s)
 }
 
-pub fn parse_expression(s: &str) -> Result<SymbolExpr, String> {
+pub fn parse_expression<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> Result<SymbolExpr, String> {
+    let parse_addsub = |s| parse_addsub(s, sym_fn);
     match all_consuming(parse_addsub).parse(s) {
         Ok(o) => Ok(o.1),
         Err(e) => match e {

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -48,9 +48,6 @@ fn parse_symbol<'a>(
     s: &'a str,
     sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
 ) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
-    // At this point, we just consume the entire name string, regardless of index; it's up to a
-    // "name map" later to replace names with complete `Symbol` implementations, since the string
-    // form doesn't carry sufficient information to correctly assign UUIDs or base vectors.
     recognize(
         pair(
             alt((alpha1, tag("_"), tag("\\"), tag("$"))),

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -99,7 +99,8 @@ fn parse_unary<'a>(
         .parse(s)
 }
 
-fn parse_expr<'a>(
+// sign is separately parsed in this function
+fn parse_sign<'a>(
     s: &'a str,
     sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
 ) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
@@ -107,11 +108,7 @@ fn parse_expr<'a>(
     let parse_symbol = |s| parse_symbol(s, sym_fn);
     let parse_addsub = |s| parse_addsub(s, sym_fn);
     (
-        opt(delimited(
-            multispace0,
-            alt((char('-'), char('+'))),
-            multispace0,
-        )),
+        delimited(multispace0, alt((char('-'), char('+'))), multispace0),
         alt((
             parse_imaginary_value,
             parse_value,
@@ -124,14 +121,42 @@ fn parse_expr<'a>(
             ),
         )),
     )
-        .map(|(op, expr)| match op {
-            Some('-') => SymbolExpr::Unary {
-                op: UnaryOp::Neg,
-                expr: Arc::new(expr),
-            },
-            _ => expr,
+        .map(|(op, expr)| {
+            if op == '+' {
+                expr
+            } else {
+                SymbolExpr::Unary {
+                    op: UnaryOp::Neg,
+                    expr: Arc::new(expr),
+                }
+            }
         })
         .parse(s)
+}
+
+fn parse_expr<'a>(
+    s: &'a str,
+    sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
+) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
+    let parse_sign = |s| parse_sign(s, sym_fn);
+    let parse_unary = |s| parse_unary(s, sym_fn);
+    let parse_symbol = |s| parse_symbol(s, sym_fn);
+    let parse_addsub = |s| parse_addsub(s, sym_fn);
+    alt((
+        parse_imaginary_value,
+        // Note that `parse_value` will consume a possible `-` or `+` and fold it into the value, so
+        // this ordering of `parse_value` and `parse_sign` in the alternatives can affect the parse.
+        parse_value,
+        parse_sign,
+        parse_unary,
+        parse_symbol,
+        delimited(
+            char('('),
+            delimited(multispace0, parse_addsub, multispace0),
+            char(')'),
+        ),
+    ))
+    .parse(s)
 }
 
 // parse pow


### PR DESCRIPTION
We can thread the symbol mapping through the `nom` parsing as a separate context object, so we automatically construct the correct symbols immediately, rather than having to re-walk the tree and add them.

This removes one (but by no means all) recursive algorithm acting in `SymbolExpr`.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
