### PR TITLE
Move deeply recursive `SymbolExpr` parse trees to heap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "ariadne"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2405,7 @@ dependencies = [
  "rayon",
  "rustworkx-core",
  "smallvec",
+ "stacker",
  "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -3152,6 +3181,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 itertools.workspace = true
 nalgebra.workspace = true
 uuid.workspace = true
+stacker = "0.1"
 nom.workspace = true
 nom-unicode.workspace = true
 nom-language.workspace = true

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -213,7 +213,7 @@ fn parse_addsub<'a>(
     sym_fn: &impl Fn(&'a str) -> Option<Symbol>,
 ) -> IResult<&'a str, SymbolExpr, VerboseError<&'a str>> {
     let parse_muldiv = |s| parse_muldiv(s, sym_fn);
-    permutation((
+    let mut parser = permutation((
         parse_muldiv,
         many0(
             (
@@ -237,8 +237,12 @@ fn parse_addsub<'a>(
             BinaryOp::Sub => &acc - &x.1,
             _ => acc,
         })
-    })
-    .parse(s)
+    });
+    // `parse_addsub` is the "top" of the recursive expression parse; all recursive cycles have to
+    // pass through it.  Each time we reach here, check how much stack space we're using, and if
+    // it's too much, move into the heap to continue, so we can grow without overflowing, but don't
+    // need a heap allocation unless the recursion gets crazy.
+    stacker::maybe_grow(32 * 1024, 1024 * 1024, || parser.parse(s))
 }
 
 pub fn parse_expression<'a>(

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -1071,6 +1071,22 @@ class TestParameterExpression(QiskitTestCase):
         expected = x + y - 3.0
         self.assertEqual(expected, sub2)
 
+    def test_deep_string_parse(self):
+        """Test that the string parser can handle very deep expressions."""
+        n = 100_000
+        a = Parameter("a")
+        expr_str = "a" + " ** a" * n
+        # This is an explicitly private constructor, but the purpose of the test is for _any_ string
+        # constructor; we can change it over to a new API if/when we expose one.
+        out = ParameterExpression({"a": a}, expr_str)
+        expected = a
+        for _ in range(n):
+            # TODO: actually this seems like a weirdness in the parser: ` ** ` should be
+            # right-associative (so it should be `a**expected`).  We have to use `**` in the test to
+            # avoid complexity explosion via attempted simplification.
+            expected = expected**a
+        self.assertStructurallyEqual(out, expected)
+
     def test_structurally_equal_simplification(self):
         x = Parameter("x")
         y = Parameter("y")


### PR DESCRIPTION
The parser is implemented as a recursive descent, which makes it liable to overflowing the stack in deep nesting, such as `-(-(-(... a )))...`. This doesn't rewrite the parser to be non-recursive, but since all recursion cycles go through a single function, it's easy to add in a "is the stack getting out of hand?" check into it, and spill to the heap if so.

The entire `SymbolExpr` class has recursion trouble in its `*_opt` functions still, so the resulting expressions can still cause overflow problems when used.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
