### PR TITLE
Add non-allocating instruction views to C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ name = "qiskit-cext"
 version = "2.6.0-dev"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "hashbrown 0.15.5",
  "mimalloc",
  "nalgebra 0.35.0",

--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -87,6 +87,7 @@ pub static EXPORT_RENAME: &[(&str, &str)] = &[
     ("CDagNodeType", "DagNodeType"),
     ("CDelayUnit", "DelayUnit"),
     ("CInstruction", "CircuitInstruction"),
+    ("CInstructionView", "CircuitInstructionView"),
     ("CInstructionProperties", "InstructionProperties"),
     ("CNeighbors", "Neighbors"),
     ("COperationKind", "OperationKind"),

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -140,6 +140,7 @@ mod circuit {
             export_fn!(qk_control_flow_switch_case_labels_bit_width),
             export_fn!(qk_control_flow_switch_case_labels_uint),
             export_fn!(qk_control_flow_switch_case_labels_clear),
+            export_fn!(qk_circuit_view_instruction),
         ]
     });
 }
@@ -212,6 +213,7 @@ mod dag {
             export_fn!(qk_dag_substitute_node_with_unitary),
             export_fn!(qk_dag_global_phase),
             export_fn!(qk_dag_set_global_phase),
+            export_fn!(qk_dag_view_instruction),
         ]
     });
 }
@@ -249,6 +251,7 @@ mod param {
             export_fn!(qk_param_conjugate),
             export_fn!(qk_param_equal),
             export_fn!(qk_param_as_real),
+            export_fn!(qk_param_type_width),
         ]
     });
 }

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -33,6 +33,7 @@ mimalloc = { workspace = true, optional = true}
 uuid.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
+bytemuck.workspace = true
 
 [features]
 python_binding = ["dep:pyo3"]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1559,6 +1559,8 @@ impl CInstruction {
 /// and thus you are responsible for calling ``qk_circuit_instruction_clear`` to
 /// free it.
 ///
+/// See also [`qk_circuit_view_instruction`], which is the non-allocating version of this function.
+///
 /// @param circuit A pointer to the circuit to get the instruction details for.
 /// @param index The instruction index to get the instruction details of.
 /// @param instruction A pointer to where to write out the ``QkCircuitInstruction``
@@ -1595,6 +1597,161 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
     );
     // SAFETY: per documentation, `instruction` is a pointer to a sufficient allocation.
     unsafe { instruction.write(inst) };
+}
+
+/// A non-owning view of a `QkCircuit` or `QkDag` instruction.
+///
+/// This represents all the same information as a `QkCircuitInstruction`, but all the pointer-typed
+/// fields are raw views onto data borrowed from the respective `QkCircuit` or `QkDag`.  All
+/// pointers are invalidated by any mutation or freeing of the underlying object.
+///
+/// As the data is all borrowed from the native Rust representations without allocation, there are
+/// various complications to accessing the data from C.  See the "Usage notes" section below for
+/// detail.
+///
+/// This is typically created by `qk_circuit_view_instruction` and `qk_dag_view_instruction`.
+///
+/// It is undefined behavior to mutate any data pointed to by this struct.
+///
+/// # Usage notes
+///
+/// The `name` field is *not* nul-terminated, unlikely normal C strings.  It may also include
+/// arbitrary UTF-8 encoded data.  You cannot safely use this member with most C string functions.
+/// To do string comparisons, consider using `strncmp` with `name_len` as the limit.  To use the
+/// string in `printf`-like format specifiers, you must use the variable-width specifier form, such
+/// as:
+///
+/// ```c
+/// QkCircuitInstructionView view;
+/// qk_circuit_view_instruction(qc, 0, &view);
+/// printf("name: '%*s'\n", view.name_len, view.name);
+/// ```
+///
+///
+/// In order to iterate through the `params` field, you must call `qk_param_type_width` at runtime
+/// to discover the width of the `QkParam` field, and then offset the pointer by a byte offset.  For
+/// example:
+///
+/// ```c
+/// QkCircuitInstructionView view;
+/// qk_circuit_view_instruction(qc, 0, &view);
+/// size_t el_size = qk_param_type_width();
+/// for (size_t i=0; i < view.num_params; i++) {
+///     const QkParam *p = (const QkParam *)((const char *)view.params + i*el_size);
+///     // ... do something with `p` ...
+/// }
+/// ```
+#[repr(C)]
+pub struct CInstructionView {
+    /// The `name_len` UTF-8 encoded bytes that represent the instruction name.  This is not
+    /// nul-terminated; you must take care to use functions like `strncmp` bounded by `name_len`
+    name: *const c_char,
+    /// The qubits used by the instruction.
+    qubits: *const u32,
+    /// The clbits used by the instruction.
+    clbits: *const u32,
+    /// An array of `num_params` `QkParam` instances. Offset the pointer by `qk_param_type_width`
+    /// bytes to iterate through valid `*const QkParam` instances; you cannot use regular pointer
+    /// arithmetic because the size of `QkParam` is not specified in the compile-time API.
+    params: *const Param,
+    /// How many bytes the non-nul-terminated UTF-8 string in `name` is.
+    name_len: usize,
+    /// The number of elements of `qubits`.
+    num_qubits: u32,
+    /// The number of elements of `clbits`.
+    num_clbits: u32,
+    /// The number of elements of `params`.
+    num_params: usize,
+}
+impl CInstructionView {
+    /// Create a new instruction from a [`PackedInstruction`].
+    ///
+    /// The result directly views onto data owned by the instruction and the two interners; from
+    /// Rust, logically its lifetime is tied to the lifetimes of the input.
+    pub(crate) fn from_packed_instruction(
+        packed: &PackedInstruction,
+        qargs_interner: &Interner<[Qubit]>,
+        cargs_interner: &Interner<[Clbit]>,
+    ) -> Self {
+        let name = packed.op.name().as_bytes();
+        // `c_char` is either `i8` or `u8` on all supported platforms.
+        let name = bytemuck::cast_slice::<u8, c_char>(name);
+        let qargs = qargs_interner.get(packed.qubits);
+        let cargs = cargs_interner.get(packed.clbits);
+        let params = packed.params_view();
+        Self {
+            name: name.as_ptr(),
+            name_len: name.len(),
+            qubits: bytemuck::cast_slice(qargs).as_ptr(),
+            num_qubits: qargs
+                .len()
+                .try_into()
+                .expect("qargs are unique and each qubit is u32"),
+            clbits: bytemuck::cast_slice(cargs).as_ptr(),
+            num_clbits: cargs
+                .len()
+                .try_into()
+                .expect("cargs are unique and each qubit is u32"),
+            params: params.as_ptr(),
+            num_params: params.len(),
+        }
+    }
+}
+
+/// @ingroup QkCircuit
+/// Write out direct views for an instruction in the circuit.
+///
+/// See `QkCircuitInstructionView` for details on the stored information.  All pointers in the
+/// `QkCircuitInstructionView` are borrowed from `circuit`, and are invalidated by mutating or
+/// freeing the circuit in any way.
+///
+/// You typically allocate space for this view in the calling stack, and must not free or mutate any
+/// of the pointers or the data they point to.
+///
+/// See also [`qk_circuit_get_instruction`] which allocates owned versions of the output of this
+/// function.
+///
+/// @param circuit The circuit to get the instruction from.
+/// @param index The index of the instruction in `circuit`.
+/// @param[out] out The memory location to write the result to.
+///
+/// # Example
+///
+/// ```c
+/// QkCircuit *qc = qk_circuit_new(1, 1);
+/// qk_circuit_measure(qc, 0, 0);
+///
+/// QkCircuitInstructionView view;
+/// qk_circuit_view_instruction(qc, 0, &view);
+/// printf("name: '%.*s'\n", view.name_len, view.name);
+/// ```
+///
+/// This prints "name: 'measure'" to standard output.
+///
+/// # Safety
+///
+/// Behavior is undefined in any of the follow situations:
+///
+/// - `circuit` is not an aligned pointer to a valid `QkCircuit`.
+/// - `index` is not a valid instruction index in the circuit.
+/// - `out` is misaligned or not valid for a single write.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_view_instruction(
+    circuit: *const CircuitData,
+    index: usize,
+    out: *mut CInstructionView,
+) {
+    // SAFETY: per documentation, `circuit` points to valid initialized data.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    // SAFETY: per documentation, `index` is within bounds of the circuit.
+    let inst = unsafe { &circuit.data().get_unchecked(index) };
+    let inst = CInstructionView::from_packed_instruction(
+        inst,
+        circuit.qargs_interner(),
+        circuit.cargs_interner(),
+    );
+    // SAFETY: per documentation, `out` is aligned and valid for a single write.
+    unsafe { out.write(inst) };
 }
 
 /// @ingroup QkCircuit

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1645,23 +1645,23 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 pub struct CInstructionView {
     /// The `name_len` UTF-8 encoded bytes that represent the instruction name.  This is not
     /// nul-terminated; you must take care to use functions like `strncmp` bounded by `name_len`
-    name: *const c_char,
+    pub name: *const c_char,
     /// The qubits used by the instruction.
-    qubits: *const u32,
+    pub qubits: *const u32,
     /// The clbits used by the instruction.
-    clbits: *const u32,
+    pub clbits: *const u32,
     /// An array of `num_params` `QkParam` instances. Offset the pointer by `qk_param_type_width`
     /// bytes to iterate through valid `*const QkParam` instances; you cannot use regular pointer
     /// arithmetic because the size of `QkParam` is not specified in the compile-time API.
-    params: *const Param,
+    pub params: *const Param,
     /// How many bytes the non-nul-terminated UTF-8 string in `name` is.
-    name_len: usize,
+    pub name_len: usize,
     /// The number of elements of `qubits`.
-    num_qubits: u32,
+    pub num_qubits: u32,
     /// The number of elements of `clbits`.
-    num_clbits: u32,
+    pub num_clbits: u32,
     /// The number of elements of `params`.
-    num_params: usize,
+    pub num_params: usize,
 }
 impl CInstructionView {
     /// Create a new instruction from a [`PackedInstruction`].

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -26,7 +26,7 @@ use qiskit_circuit::operations::{
 };
 use qiskit_circuit::{Clbit, Qubit};
 
-use crate::circuit::{CBlocksMode, CInstruction, CVarsMode};
+use crate::circuit::{CBlocksMode, CInstruction, CInstructionView, CVarsMode};
 
 use crate::circuit::unitary_from_pointer;
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
@@ -1261,6 +1261,43 @@ pub unsafe extern "C" fn qk_dag_get_instruction(
     );
     // SAFETY: per documentation, `instruction` is a pointer to a sufficient allocation.
     unsafe { instruction.write(inst) };
+}
+
+/// @ingroup QkDag
+/// Write out direct views for an instruction in the circuit.
+///
+/// This is a mirror of `qk_circuit_view_instruction`; consult its documentation for more detail and
+/// examples.
+///
+/// See also `qk_dag_get_instruction` which allocates owned versions of the output of this function.
+///
+/// @param dag The circuit to get the instruction from.
+/// @param index The index of the instruction in `dag`.
+/// @param[out] out The memory location to write the result to.
+///
+/// # Safety
+///
+/// Behavior is undefined in any of the follow situations:
+///
+/// - `dag` is not an aligned pointer to a valid `QkDag`.
+/// - `index` is not a valid instruction index in the circuit.  An index is invalid if does not
+///   correspond to an "operation node", i.e. calling `qk_dag_node_type(dag, index)` would be
+///   defined and return `QkDagNodeType_Operation`.
+/// - `out` is misaligned or not valid for a single write.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_dag_view_instruction(
+    dag: *const DAGCircuit,
+    index: u32,
+    out: *mut CInstructionView,
+) {
+    // SAFETY: per documentation, `dag` points to valid initialized data.
+    let dag = unsafe { const_ptr_as_ref(dag) };
+    //
+    let inst = &dag.dag()[NodeIndex::new(index as usize)].unwrap_operation();
+    let view =
+        CInstructionView::from_packed_instruction(inst, dag.qargs_interner(), dag.cargs_interner());
+    // SAFETY: per documentation, `out` is aligned and valid for a single write.
+    unsafe { out.write(view) };
 }
 
 /// @ingroup QkDag

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -12,6 +12,7 @@
 
 use num_complex::Complex64;
 use std::ffi::{CStr, CString, c_char};
+use std::mem;
 use std::sync::Arc;
 
 use crate::exit_codes::ExitCode;
@@ -1032,5 +1033,70 @@ pub unsafe extern "C" fn qk_param_as_real(param: *const Param) -> f64 {
         },
         Param::Float(f) => *f,
         Param::Obj(_) => panic!("Param::Obj is not supported in the C API"),
+    }
+}
+
+/// @ingroup QkParam
+/// Get the size in bytes of the opaque `QkParam` type.
+///
+/// @return The size in bytes of the opaque `QkParam` type.
+///
+/// The `QkParam` type is opaque to the C API, and its width is unspecified.  You can use this value
+/// to offset `QkParam *` pointers, if you cast it to a byte-width type and back.
+///
+/// This function returns the same value on every call within any given process.  The value might
+/// change between platforms or Qiskit library versions, and may depend on the build environment of
+/// the Qiskit C API.  You must not rely on this width being any particular value without querying
+/// this function.
+///
+/// # Example
+///
+/// If given a pointer to the first `QkParam` in a contiguous array, such as in
+/// `QkCircuitInstructionView::params`, you can access subsequent elements by offsetting the
+/// pointer by a number of bytes.
+///
+/// ```c
+/// const QkParam *p;  // A pretend pointer to the first of 3 contiguous elements.
+/// const size_t el_size = qk_param_type_width();
+/// for (size_t i = 0; i < 3; i++) {
+///     // Offset the pointer by `el_size` bytes each time.
+///     p = (const QkParam *)((const char *)p + el_size);
+///
+///     char *val = qk_param_str(p);
+///     printf("%zu: %s\n", i, val);
+///     qk_str_free(val);
+/// }
+/// ```
+#[unsafe(no_mangle)]
+pub extern "C" fn qk_param_type_width() -> usize {
+    mem::size_of::<Param>()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_param_offsetting() {
+        let params = [
+            Param::Float(1.0),
+            Param::ParameterExpression(Arc::new(ParameterExpression::from_f64(2.0))),
+            Param::ParameterExpression(Arc::new(ParameterExpression::from_symbol(
+                Symbol::standalone("a".to_owned(), None),
+            ))),
+        ];
+        assert_eq!(mem::size_of::<Param>(), qk_param_type_width());
+        let base = params.as_ptr();
+        assert_eq!(
+            base.wrapping_add(2).addr(),
+            base.cast::<u8>()
+                .wrapping_add(2 * qk_param_type_width())
+                .addr()
+        );
+        let middle_ptr = base
+            .cast::<u8>()
+            .wrapping_add(qk_param_type_width())
+            .cast::<Param>();
+        assert!(params[1].eq(unsafe { &*middle_ptr }).unwrap());
     }
 }

--- a/releasenotes/notes/c-instruction-view-42d37cbdaa00337b.yaml
+++ b/releasenotes/notes/c-instruction-view-42d37cbdaa00337b.yaml
@@ -1,0 +1,14 @@
+---
+features_c:
+  - |
+    Two new functions, :c:func:`qk_circuit_view_instruction` and :c:func:`qk_dag_view_instruction`,
+    were added as mirrors to :c:func:`qk_circuit_get_instruction` and
+    :c:func:`qk_dag_get_instruction`, respectively, writing out a new
+    :c:struct:`QkCircuitInstructionView` object.
+
+    These ``view`` functions produce direct views into the internal data without any allocations,
+    which is more performant, but requires some special handling to use the non-idiomatic data
+    formats from C; see the documentation of :c:struct:`QkCircuitInstructionView`.
+  - |
+    Added :c:func:`qk_param_type_width`, which returns the runtime size in bytes of the opaque
+    ``QkParam`` type.

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1306,13 +1306,13 @@ static int instruction_view_cmp(const QkCircuitInstructionView *a,
                                 const QkCircuitInstructionView *b, const QkParam *const *b_params) {
     int ret = 0;
     if (a->name_len != b->name_len)
-        return (ptrdiff_t)a->name_len - (ptrdiff_t)b->name_len;
+        return a->name_len < b->name_len ? -1 : 1;
     if (a->num_qubits != b->num_qubits)
-        return (int32_t)a->num_qubits - (int32_t)b->num_qubits;
+        return a->num_qubits < b->num_qubits ? -1 : 1;
     if (a->num_clbits != b->num_clbits)
-        return (int32_t)a->num_clbits - (int32_t)b->num_clbits;
+        return a->num_clbits < b->num_clbits ? -1 : 1;
     if (a->num_params != b->num_params)
-        return (ptrdiff_t)a->num_params - (ptrdiff_t)b->num_params;
+        return a->num_params < b->num_params ? -1 : 1;
     if ((ret = strncmp(a->name, b->name, a->name_len)))
         return ret;
     if ((ret = memcmp(a->qubits, b->qubits, sizeof(a->qubits[0]) * a->num_qubits)))

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1299,6 +1299,110 @@ cleanup:
     return result;
 }
 
+/** Compare two instruction views for equality.  The field `b->params` is
+ *  ignored, and replaced by the indirect `b_params`.
+ */
+static int instruction_view_cmp(const QkCircuitInstructionView *a,
+                                const QkCircuitInstructionView *b, const QkParam *const *b_params) {
+    int ret = 0;
+    if (a->name_len != b->name_len)
+        return (ptrdiff_t)a->name_len - (ptrdiff_t)b->name_len;
+    if (a->num_qubits != b->num_qubits)
+        return (int32_t)a->num_qubits - (int32_t)b->num_qubits;
+    if (a->num_clbits != b->num_clbits)
+        return (int32_t)a->num_clbits - (int32_t)b->num_clbits;
+    if (a->num_params != b->num_params)
+        return (ptrdiff_t)a->num_params - (ptrdiff_t)b->num_params;
+    if ((ret = strncmp(a->name, b->name, a->name_len)))
+        return ret;
+    if ((ret = memcmp(a->qubits, b->qubits, sizeof(a->qubits[0]) * a->num_qubits)))
+        return ret;
+    if ((ret = memcmp(a->clbits, b->clbits, sizeof(a->qubits[0]) * a->num_clbits)))
+        return ret;
+    const size_t param_size = qk_param_type_width();
+    for (size_t i = 0; i < a->num_params; i++) {
+        if (!qk_param_equal((const QkParam *)((const char *)a->params + i * param_size),
+                            b_params[i])) {
+            return 1;
+        }
+    }
+    return ret;
+}
+
+static int test_circuit_view_instruction(void) {
+    int res = Ok;
+    QkCircuitInstructionView view, expected;
+    uint32_t args[2] = {0, 1};
+
+    QkCircuit *qc = qk_circuit_new(2, 2);
+    QkParam *params[3] = {
+        qk_param_from_double(1.0),
+        qk_param_new_symbol("a"),
+        qk_param_new_symbol("b"),
+    };
+
+    qk_circuit_gate(qc, QkGate_H, args, NULL);
+    qk_circuit_view_instruction(qc, 0, &view);
+    expected = (QkCircuitInstructionView){"h", args, NULL, NULL, 1, 1, 0, 0};
+    if (instruction_view_cmp(&view, &expected, NULL)) {
+        printf("%s: failed on 'h'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+    qk_circuit_parameterized_gate(qc, QkGate_U, args, (const QkParam *const *)params);
+    qk_circuit_view_instruction(qc, 1, &view);
+    expected = (QkCircuitInstructionView){"u", args, NULL, NULL, 1, 1, 0, 3};
+    if (instruction_view_cmp(&view, &expected, (const QkParam *const *)params)) {
+        printf("%s: failed on 'u'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+    qk_circuit_gate(qc, QkGate_CX, args, NULL);
+    qk_circuit_view_instruction(qc, 2, &view);
+    expected = (QkCircuitInstructionView){"cx", args, NULL, NULL, 2, 2, 0, 0};
+    if (instruction_view_cmp(&view, &expected, NULL)) {
+        printf("%s: failed on 'cx'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+    qk_circuit_barrier(qc, args, 2);
+    qk_circuit_view_instruction(qc, 3, &view);
+    expected = (QkCircuitInstructionView){"barrier", args, NULL, NULL, 7, 2, 0, 0};
+    if (instruction_view_cmp(&view, &expected, NULL)) {
+        printf("%s: failed on 'barrier'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+    qk_circuit_measure(qc, 0, 0);
+    qk_circuit_view_instruction(qc, 4, &view);
+    expected = (QkCircuitInstructionView){"measure", args, args, NULL, 7, 1, 1, 0};
+    if (instruction_view_cmp(&view, &expected, NULL)) {
+        printf("%s: failed on 'measure 0'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+    qk_circuit_measure(qc, 1, 1);
+    qk_circuit_view_instruction(qc, 5, &view);
+    expected = (QkCircuitInstructionView){"measure", &args[1], &args[1], NULL, 7, 1, 1, 0};
+    if (instruction_view_cmp(&view, &expected, NULL)) {
+        printf("%s: failed on 'measure 1'\n", __func__);
+        res = EqualityError;
+        goto cleanup;
+    }
+
+cleanup:
+    for (size_t i = 0; i < sizeof(params) / sizeof(params[0]); i++) {
+        qk_param_free(params[i]);
+    }
+    qk_circuit_free(qc);
+    return res;
+}
+
 /**
  * Test circuit to dag conversion.
  */
@@ -1674,6 +1778,7 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_instruction_params_ownership);
     num_failed += RUN_TEST(test_parameterized_circuit);
     num_failed += RUN_TEST(test_circuit_global_phase);
+    num_failed += RUN_TEST(test_circuit_view_instruction);
     num_failed += RUN_TEST(test_circuit_to_dag);
     num_failed += RUN_TEST(test_pbc_instructions);
     num_failed += RUN_TEST(test_estimate_fidelity);

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -509,6 +509,32 @@ cleanup:
     return result;
 }
 
+static int test_dag_view_instruction(void) {
+    // Mostly the combinations in the `QkInstructionView` logic is tested via `QkCircuit`, so this
+    // is just a simple smoke test.
+    int res = Ok;
+    QkCircuitInstructionView view;
+    uint32_t op_node;
+    uint32_t args[2] = {1, 0};
+    QkCircuit *qc = qk_circuit_new(2, 0);
+    qk_circuit_gate(qc, QkGate_CX, args, NULL);
+    QkDag *dag = qk_circuit_to_dag(qc);
+    qk_circuit_free(qc);
+
+    // There's only the one op node.
+    qk_dag_topological_op_nodes(dag, &op_node);
+
+    qk_dag_view_instruction(dag, op_node, &view);
+    if (view.name_len != 2 || view.num_qubits != 2 || view.num_clbits != 0 ||
+        view.num_params != 0 || strncmp(view.name, "cx", 2) ||
+        memcmp(view.qubits, args, sizeof(args))) {
+        res = EqualityError;
+    }
+
+    qk_dag_free(dag);
+    return res;
+}
+
 static int test_dag_topological_op_nodes(void) {
     int result = Ok;
     QkDag *dag = qk_dag_new();
@@ -1387,6 +1413,7 @@ int test_dag(void) {
     num_failed += RUN_TEST(test_dag_global_phase);
     num_failed += RUN_TEST(test_op_node_bits_explicit);
     num_failed += RUN_TEST(test_dag_get_instruction);
+    num_failed += RUN_TEST(test_dag_view_instruction);
     num_failed += RUN_TEST(test_dag_topological_op_nodes);
     num_failed += RUN_TEST(test_unitary_gates);
     num_failed += RUN_TEST(test_substitute_node_with_dag);


### PR DESCRIPTION
The previous `qk_circuit_get_instruction` method (and its DAG equivalent) always allocates and requires freeing, which can be a significant cost when iterating through circuits.  We store all the data in _some_ form cleanly in Rust, so can expose the pointers directly. It's more efficient, but C has to jump through a couple more hoops to access it safely, since it's either not in C-idiomatic forms (the `name`) or isn't fully specified in the compile-time API (`params`).

In order to offset the `params` field, we have to introduce a function (`qk_param_type_width`) to retrieve the size of `Param` at library load time, since we only expose it as an opaque/indirect struct and it may change between library versions.  I considered introducing a mechanism to get _all_ the type widths of the opaque object as a static array of lengths, but the additional build-system tooling and linting needed to do this automatically without forgetting things is complex and isn't immediately necessary.

cc: @mbhealy

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
