### PR TITLE
Added a note to SparsePauliOp docstring about qubit indexing

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -63,6 +63,12 @@ class SparsePauliOp(LinearOp):
     are stored as a complex Numpy array vector and can be accessed using
     the :attr:`~SparsePauliOp.coeffs` attribute.
 
+    .. note::
+
+        Pauli strings are read right-to-left: the rightmost character is qubit 0
+        and the leftmost is qubit :math:`N-1`.  For example, ``SparsePauliOp("ZII")``
+        applies ``Z`` to qubit 2, not qubit 0.
+
     .. rubric:: Data type of coefficients
 
     The default ``dtype`` of the internal ``coeffs`` Numpy array is ``complex128``.  Users can


### PR DESCRIPTION
Added note in the docstring of SparsePauliOp about the reversed indexing used there . Makes it easier for users to interpret.

closes #16780


### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
