### PR TITLE
Add a C API to query the unbound Parameter names in a QkCircuit

### DIFF
--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -140,6 +140,7 @@ mod circuit {
             export_fn!(qk_control_flow_switch_case_labels_bit_width),
             export_fn!(qk_control_flow_switch_case_labels_uint),
             export_fn!(qk_control_flow_switch_case_labels_clear),
+            export_fn!(qk_circuit_get_param_symbols),
         ]
     });
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -12,6 +12,7 @@
 
 use std::ffi::{CStr, CString, c_char};
 use std::ptr;
+use std::str::FromStr;
 
 use crate::circuit_library::pbc::{CPauliProductMeasurement, CPauliProductRotation};
 use crate::control_flow::CControlFlowInstruction;
@@ -767,6 +768,74 @@ pub unsafe extern "C" fn qk_circuit_num_param_symbols(circuit: *const CircuitDat
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 
     circuit.num_parameters()
+}
+
+/// Iterate over all the unbound parameter symbols in the circuit
+///
+/// The parameter symbols returned by this function represent unbound parameters used in a circuit's
+/// parameters (represented by ``QkParam``). These could be standalone parameters or part of a
+/// larger parametric expression. The parameter symbols returned by this function are symbol strings tied to this
+/// circuit. There could be name conflicts with other circuits but they should not be considered
+/// the same symbols. The iteration order of this function is in alphabetical order, and in circuits
+/// from Python with the Python ``ParameterVector`` type the vector elements are in numeric order
+/// (this matches the order from Python's ``QuantumCircuit.parameters``)
+///
+/// @param circuit A pointer to the circuit.
+/// @param callback A function pointer to the callback. This function will be called once for each
+/// unbound parameter in the circuit. It takes a single argument a char pointer to the nul
+/// terminated string representating an unbound parameter symbol in the circuit. If the function
+/// returns False this will break the iteration and the function will return.
+///
+/// # Example
+///
+/// ```c
+/// #include <string.h>
+/// #include <stdlib.h>
+///
+/// char **parameters = malloc(sizeof(char*) * 10);
+/// int count = 0;
+///
+/// bool callback_fn(const char *symbol) {
+///     parameters[count] = malloc(strlen(symbol) + 1);
+///     strcpy(parameters[count], symbol);
+///     count++;
+///     return true;
+/// }
+///
+/// qk_circuit_get_param_symbols(circuit, &callback_fn);
+/// for (int i = 0; i < count; i++) {
+///     free(parameters[i]);
+/// }
+/// free(parameters);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, aligned, non-null pointer to a ``QkCircuit`` or
+/// ``callback`` is not a valid, aligned, non-null function pointer that matches the signature in
+/// the header. It is undefined behavior to write to the string passed to the ``callback`` function, the string
+/// is read-only and also only lives for the duration of a single call. Once the callback returns
+/// the address passed to ``callback`` will be freed. If you need the data to persist past a single
+/// call you must copy the data. This function will panic if a circuit contains an unbound parameter
+/// symbol's string contains a nul character in it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_circuit_get_param_symbols(
+    circuit: *const CircuitData,
+    callback: unsafe extern "C" fn(symbol: *const c_char) -> bool,
+) {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    for param in circuit.parameters() {
+        let out_str = CString::from_str(param.fullname().as_ref())
+            .expect("A parameter contains a nul character");
+        // SAFETY: Per documentation the pointer is matches the expected
+        // signature and conforms to the runtime expectations.
+        unsafe {
+            if !callback(out_str.as_ptr()) {
+                break;
+            }
+        }
+    }
 }
 
 /// @ingroup QkCircuit

--- a/releasenotes/notes/qk_circuit_get_param_symbols-3b43dd27680360ae.yaml
+++ b/releasenotes/notes/qk_circuit_get_param_symbols-3b43dd27680360ae.yaml
@@ -1,0 +1,6 @@
+---
+features_c:
+  - Added a new function :c:func:`qk_circuit_get_param_symbols` that is used
+    to get the unbound parameter symbol names in a :c:type:`QkCircuit`
+    object.
+

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -1677,6 +1677,134 @@ cleanup:
     return result;
 }
 
+static int test_get_circuit_params(void) {
+    QkCircuit *qc = qk_circuit_new(2, 0);
+    QkParam *x = qk_param_new_symbol("x");
+    QkParam *y = qk_param_new_symbol("somey longery namey");
+
+    uint32_t q0[1] = {0};
+    uint32_t q1[1] = {1};
+    uint32_t q01[2] = {0, 1};
+    const QkParam *rx_param[1] = {x};
+    const QkParam *rzz_param[1] = {y};
+
+    int result = Ok;
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q0, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q1, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (qk_circuit_parameterized_gate(qc, QkGate_RZZ, q01, rzz_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    // check the number of parameters
+    size_t num_symbols = qk_circuit_num_param_symbols(qc);
+    if (num_symbols != 2) {
+        result = EqualityError;
+        printf("Expected 2 symbols, found %zu\n", num_symbols);
+        goto cleanup;
+    }
+    char **parameters = malloc(sizeof(char *) * num_symbols);
+    size_t count = 0;
+    bool callback_fn(const char *symbol) {
+        parameters[count] = malloc(strlen(symbol) + 1);
+        strcpy(parameters[count], symbol);
+        count++;
+        return true;
+    }
+    qk_circuit_get_param_symbols(qc, &callback_fn);
+    if (count != num_symbols) {
+        result = EqualityError;
+        printf("Expected 2 symbols in the output parameters list, found: %zu\n", count);
+        goto result_cleanup;
+    }
+    if (strcmp(parameters[0], "somey longery namey") != 0) {
+        result = EqualityError;
+        printf("Expected second symbol returned to be 'somey longery namey', found: %s\n",
+               parameters[0]);
+        goto result_cleanup;
+    }
+    if (strcmp(parameters[1], "x") != 0) {
+        result = EqualityError;
+        printf("Expected first symbol returned to be 'x', found: %s\n", parameters[1]);
+    }
+result_cleanup:
+    for (size_t i = 0; i < count; i++) {
+        free(parameters[i]);
+    }
+    free(parameters);
+cleanup:
+    qk_param_free(x);
+    qk_param_free(y);
+    qk_circuit_free(qc);
+    return result;
+}
+
+static int test_get_circuit_params_iter_break(void) {
+    QkCircuit *qc = qk_circuit_new(2, 0);
+    QkParam *x = qk_param_new_symbol("x");
+    QkParam *y = qk_param_new_symbol("somey longery namey");
+
+    uint32_t q0[1] = {0};
+    uint32_t q1[1] = {1};
+    uint32_t q01[2] = {0, 1};
+    const QkParam *rx_param[1] = {x};
+    const QkParam *rzz_param[1] = {y};
+
+    int result = Ok;
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q0, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (qk_circuit_parameterized_gate(qc, QkGate_RX, q1, rx_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+    if (qk_circuit_parameterized_gate(qc, QkGate_RZZ, q01, rzz_param) != QkExitCode_Success) {
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    // check the number of parameters
+    size_t num_symbols = qk_circuit_num_param_symbols(qc);
+    if (num_symbols != 2) {
+        result = EqualityError;
+        printf("Expected 2 symbols, found %zu\n", num_symbols);
+        goto cleanup;
+    }
+    char *parameter;
+    size_t count = 0;
+    bool callback_fn(const char *symbol) {
+        parameter = malloc(strlen(symbol) + 1);
+        strcpy(parameter, symbol);
+        count++;
+        return false;
+    }
+    qk_circuit_get_param_symbols(qc, &callback_fn);
+    if (count != 1) {
+        result = EqualityError;
+        printf("Expected 1 symbols in the output parameters list, found: %zu\n", count);
+        goto result_cleanup;
+    }
+    if (strcmp(parameter, "somey longery namey") != 0) {
+        result = EqualityError;
+        printf("Expected second symbol returned to be 'somey longery namey', found: %s\n",
+               parameter);
+    }
+result_cleanup:
+    free(parameter);
+cleanup:
+    qk_param_free(x);
+    qk_param_free(y);
+    qk_circuit_free(qc);
+    return result;
+}
+
 int test_circuit(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
@@ -1710,6 +1838,8 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_estimate_fidelity_non_physical);
     num_failed += RUN_TEST(test_basic_register_queries);
     num_failed += RUN_TEST(test_register_bits);
+    num_failed += RUN_TEST(test_get_circuit_params);
+    num_failed += RUN_TEST(test_get_circuit_params_iter_break);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
This commit adds a new C API qk_circuit_get_param_symbols which is used to get the unbound parameter names in the C API. It works via a user provided callback function pointer so the user can control the memory usage. This is an alternative approach to what was attempt in the draft PR #16794 which attempted to return an array of QkParam. This should both be more ergonomic for the C API because the callback gives users tighter control over the usage, but also works with raw strings instead of the opaque QkParam. The only realistic thing to do with a QkParam is to call ``qk_param_str`` to get the string anyway so returning a string just skips a step and if a QkParam is needed for some other context it can be created easily by just passing the string to ``qk_param_new_symbol``. This also is significantly simpler to return in the implementation because we're directly returning a copy of the inner type instead of having to wrap that copy in a complex type that is required to have a QkParam exposed to C.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
