### PR TITLE
[WIP] Add plot_barriers option to Rust circuit drawer

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -2481,7 +2481,7 @@ pub unsafe extern "C" fn qk_circuit_draw(
         (true, true, None)
     };
 
-    let circuit_str = draw_circuit(circuit, bundle_cregs, merge_wires, fold).unwrap();
+    let circuit_str = draw_circuit(circuit, bundle_cregs, true, merge_wires, fold).unwrap();
 
     CString::new(circuit_str).unwrap().into_raw()
 }

--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -34,6 +34,7 @@ use unicode_width::UnicodeWidthStr;
 ///
 /// * circuit: The CircuitData to draw.
 /// * cregbundle: If true, classical bits of classical registers are bundled into one wire.
+/// * plot_barriers: If true, barriers are included in the rendered circuit.
 /// * mergewires: If true, adjacent wires are merged when rendered.
 /// * fold: If not None, applies line wrapping using the specified amount.
 ///
@@ -43,10 +44,11 @@ use unicode_width::UnicodeWidthStr;
 pub fn draw_circuit(
     circuit: &CircuitData,
     cregbundle: bool,
+    plot_barriers: bool,
     mergewires: bool,
     fold: Option<usize>,
 ) -> PyResult<String> {
-    let vis_mat = VisualizationMatrix::from_circuit(circuit, cregbundle)?;
+    let vis_mat = VisualizationMatrix::from_circuit(circuit, cregbundle, plot_barriers)?;
 
     let text_drawer = TextDrawer::from_visualization_matrix(&vis_mat, cregbundle);
 
@@ -97,13 +99,21 @@ pub fn draw_circuit(
 /// Return a list of layers such that each layer contains a list of op node indices, representing instructions
 /// whose qubits/clbits indices do not overlap. The instruction are packed into each layer as long as there
 /// is no qubit/clbit overlap.
-fn build_layers(circ: &CircuitData) -> Vec<Vec<&PackedInstruction>> {
+fn build_layers(circ: &CircuitData, plot_barriers: bool) -> Vec<Vec<&PackedInstruction>> {
     let mut layers: Vec<Vec<&PackedInstruction>> = Vec::new();
     let num_qubits = circ.num_qubits();
     let num_clbits = circ.num_clbits();
     let mut layers_frontier = vec![0usize; num_qubits + num_clbits];
 
     for inst in circ.data() {
+        if !plot_barriers
+            && matches!(
+                inst.op.view(),
+                OperationRef::StandardInstruction(StandardInstruction::Barrier(_))
+            )
+        {
+            continue;
+        }
         if matches!(
             inst.op.view(),
             OperationRef::StandardGate(StandardGate::GlobalPhase)
@@ -539,8 +549,12 @@ struct VisualizationMatrix<'a> {
 }
 
 impl<'a> VisualizationMatrix<'a> {
-    fn from_circuit(circuit: &'a CircuitData, bundle_cregs: bool) -> PyResult<Self> {
-        let inst_layers = build_layers(circuit);
+    fn from_circuit(
+        circuit: &'a CircuitData,
+        bundle_cregs: bool,
+        plot_barriers: bool,
+    ) -> PyResult<Self> {
+        let inst_layers = build_layers(circuit, plot_barriers);
 
         let num_wires = circuit.num_qubits()
             + if !bundle_cregs {
@@ -1573,7 +1587,7 @@ mod tests {
     fn test_creg_bundle() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, true, false, None).unwrap();
 
         let expected = "
       ┌───┐
@@ -1596,7 +1610,7 @@ c2: 2/══════════
     fn test_merge_wires() {
         let circuit = basic_circuit();
 
-        let result = draw_circuit(&circuit, false, true, None).unwrap();
+        let result = draw_circuit(&circuit, false, true, true, None).unwrap();
         let expected = "
       ┌───┐
  q_0: ┤ H ├──■──
@@ -1646,7 +1660,7 @@ c2_1: ══════════
         };
         circuit.push(inst).unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
    ┌───┐┌─┐
 q: ┤ H ├┤M├
@@ -1689,7 +1703,7 @@ c: ══════╩═
             .push_standard_gate(StandardGate::H, &[], &[Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
       ┌───┐
    q: ┤ H ├
@@ -1724,7 +1738,7 @@ cr_1: ═════
             .push_standard_gate(StandardGate::CZ, &[], &[Qubit::new(0), Qubit::new(1)])
             .unwrap();
 
-        let result = draw_circuit(&circuit, false, false, Some(10)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(10)).unwrap();
         let expected = "
       ┌───┐     »
  q_0: ┤ H ├──■──»
@@ -1789,7 +1803,7 @@ c2_1: ══════════»
         let mut inst_clone = circuit.data()[0].clone();
         inst_clone.label = Some(Box::new("my_ch".to_string()));
         circuit.push(inst_clone).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(80)).unwrap();
         let expected = "
           ┌────────────┐┌───────────────┐
 q_0: ──■──┤0 Rxx(1.23) ├┤0 my_rxx(1.23) ├────■────
@@ -1918,7 +1932,7 @@ q_1: ┤ H ├┤1           ├┤1              ├┤ my_ch ├
             py_op: OnceLock::new(),
         };
         circuit.push(inst).unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(80)).unwrap();
         let expected = "
           ┌─────────┐                  ┌────────────────────┐┌──────────┐»
 q_0: ─────┤ Unitary ├──────────────────┤0                   ├┤2         ├»
@@ -1972,7 +1986,7 @@ q_3: ──────────────────────┤1     
                 .collect::<Vec<Param>>();
             circuit.push_standard_gate(op, &params, &qubits).unwrap();
         }
-        let result = draw_circuit(&circuit, false, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(80)).unwrap();
         let expected = "
      ┌───┐  ┌───────────┐      ┌─────┐   ┌─────┐ ┌───────────────────────┐          »
 q_0: ┤ Y ├──┤ Rx(3.141) ├──────┤ Sdg ├───┤ Tdg ├─┤ U3(3.141,3.141,3.141) ├──■───────»
@@ -2059,7 +2073,7 @@ q_4: ─────────────────────────
     fn test_global_phase() {
         let mut circuit = basic_circuit();
         circuit.set_global_phase_param(3.14.into()).unwrap();
-        let result = draw_circuit(&circuit, true, false, None).unwrap();
+        let result = draw_circuit(&circuit, true, true, false, None).unwrap();
 
         let expected = "
 global phase: 3.14
@@ -2086,7 +2100,7 @@ c2: 2/══════════
                 ParameterExpression::from_symbol(Symbol::standalone("ϕ".to_owned(), None)),
             )))
             .unwrap();
-        let result = draw_circuit(&circuit, true, false, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, false, Some(80)).unwrap();
 
         let expected = "
 global phase: ϕ
@@ -2128,7 +2142,7 @@ c2: 2/══════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
      ┌─────────┐┌────────────┐┌─────────┐
 q_0: ┤0 Rxx(a) ├┤0 my_rxx(a) ├┤0 Rzx(2) ├
@@ -2215,7 +2229,7 @@ q_1: ┤1        ├┤1           ├┤1        ├
             circuit.push(inst).unwrap();
         }
 
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
           ┌────────────────┐┌────────────────┐┌────────────────┐┌────────────────┐┌───────────────┐ ░  ░ »
 q_0: ─|0>─┤ Delay(2.1[ns]) ├┤ Delay(2.1[ps]) ├┤ Delay(2.1[us]) ├┤ Delay(2.1[ms]) ├┤ Delay(2.1[s]) ├─░──░─»
@@ -2267,6 +2281,11 @@ c_3: ═════════════════════════
 «
 ";
         assert_eq!(result, expected.trim_start_matches("\n"));
+        let result_without_barriers =
+            draw_circuit(&circuit, false, false, false, Some(100)).unwrap();
+        assert!(!result_without_barriers.contains(BARRIER));
+        assert!(result_without_barriers.contains("Delay"));
+        assert!(result_without_barriers.contains("M"));
     }
 
     #[test]
@@ -2292,7 +2311,7 @@ c_3: ═════════════════════════
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
      ┌─────────┐┌─────────────┐┌─────────┐
 q_0: ┤0 Rxx(ϕ) ├┤0 μου_rxx(ϕ) ├┤0 Rzx(2) ├
@@ -2333,7 +2352,7 @@ q_1: ┤1        ├┤1            ├┤1        ├
                 &[Qubit(0), Qubit(1)],
             )
             .unwrap();
-        let result = draw_circuit(&circuit, false, false, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, false, Some(100)).unwrap();
         let expected = "
                ┌───────────┐            ┌──────────────┐┌─────────┐
 q_0: ──────────┤0 Rxx(🎩)  ├────────────┤0  💶🔉(🎩)   ├┤0 Rzx(2) ├
@@ -2386,7 +2405,7 @@ q_1: ┤ Ry(🎩) ├┤1         ├─┤ 💶🔉(🎩) ├─┤1          �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, None).unwrap();
+        let result = draw_circuit(&circuit, true, true, true, None).unwrap();
         let expected = "
 global phase: 4π/5
       ┌────────────┐ ┌────────────┐ ┌───────────────┐
@@ -2550,7 +2569,7 @@ q_1: ┤ Rz(1.2346e8) ├┤ Rx(0.12346) ├┤ Rx(1.2346e-5) ├┤ Rx(2π/3) �
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, true, Some(80)).unwrap();
         let expected = "
                       ┌────────────┐┌──────────────┐
  q_0: ────────────────┤0 Z         ├┤0  Z          ├
@@ -2633,7 +2652,7 @@ q_10: ────────────────────────�
             )
             .unwrap();
 
-        let result = draw_circuit(&circuit, true, true, Some(80)).unwrap();
+        let result = draw_circuit(&circuit, true, true, true, Some(80)).unwrap();
         let expected = "
       ┌───────────┐
 qr_0: ┤0 I        ├───────────────────
@@ -2668,7 +2687,7 @@ cr: 3/══════╩══════════╩══════�
 
         build(&mut circuit);
 
-        let result = draw_circuit(&circuit, false, mergewires, Some(100)).unwrap();
+        let result = draw_circuit(&circuit, false, true, mergewires, Some(100)).unwrap();
         assert_eq!(result, expected);
     }
 


### PR DESCRIPTION
### Summary

This adds `plot_barriers` support to the Rust text circuit drawer.

The option is passed through `draw_circuit()` and `VisualizationMatrix::from_circuit()` to `build_layers()`. When disabled, barrier instructions are skipped before the visualization layers are constructed. Existing behavior is preserved by passing `true` from the C API.

Part of #16464.

### Testing

- `cargo fmt --all -- --check`
- `cargo test -p qiskit-circuit --lib`
- `cargo check -p qiskit-cext`

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: ChatGPT (OpenAI)
- [x] Some submitted code was generated by: ChatGPT (OpenAI)
