### PR TITLE
Port synth_mcx_noaux_sp22 to Rust

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1171,8 +1171,10 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
         )?;
         circuit.h(num_ctrl_qubits as u32)?;
         let pi_phase = Param::Float(PI);
-        // Inline MCP(π) steps — same as synth_mcp_noaux_sp22 but directly
-        // on `circuit` which has target qubit at index `num_ctrl_qubits`
+        // Inline MCP(π) steps — same as ;synth_mcp_noaux_sp22; but emitted directly
+        // into `circuit` which has target qubit at index `num_ctrl_qubits`.
+        // This avoids allocating and copying an intermediate circuit and is ~2x faster than calling 
+        // `synth_mcp_noaux_sp22`.
         sp22::step_1(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_2(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_3(&mut circuit, num_ctrl_qubits)?;

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1171,10 +1171,9 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
         )?;
         circuit.h(num_ctrl_qubits as u32)?;
         let pi_phase = Param::Float(PI);
-        // Inline MCP(π) steps — same as ;synth_mcp_noaux_sp22; but emitted directly
-        // into `circuit` which has target qubit at index `num_ctrl_qubits`.
-        // This avoids allocating and copying an intermediate circuit and is ~2x faster than calling
-        // `synth_mcp_noaux_sp22`.
+        // Adding MCP(π) on `circuit` which has target qubit at index `num_ctrl_qubits`.
+        // Instead of calling `synth_mcp_noaux_sp22` we call it's step functions directly. This avoids
+        // allocating and copying an intermediate circuit and is ~2x faster.
         sp22::step_1(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_2(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_3(&mut circuit, num_ctrl_qubits)?;
@@ -1189,6 +1188,8 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
 /// # Arguments
 ///
 /// - num_ctrl_qubits: The number of control qubits.
+///
+/// Panics if called with more than 4 control qubits.
 ///
 /// # Returns
 ///

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1173,7 +1173,7 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
         let pi_phase = Param::Float(PI);
         // Inline MCP(π) steps — same as ;synth_mcp_noaux_sp22; but emitted directly
         // into `circuit` which has target qubit at index `num_ctrl_qubits`.
-        // This avoids allocating and copying an intermediate circuit and is ~2x faster than calling 
+        // This avoids allocating and copying an intermediate circuit and is ~2x faster than calling
         // `synth_mcp_noaux_sp22`.
         sp22::step_1(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_2(&mut circuit, &pi_phase, num_ctrl_qubits)?;

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1158,20 +1158,8 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
 ///
 /// 2. <https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>
 pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
-    if num_ctrl_qubits == 0 {
-        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
-        circuit.x(0)?;
-        Ok(circuit)
-    } else if num_ctrl_qubits == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
-        circuit.cx(0, 1)?;
-        Ok(circuit)
-    } else if num_ctrl_qubits == 2 {
-        Ok(ccx())
-    } else if num_ctrl_qubits == 3 {
-        Ok(c3x().into())
-    } else if num_ctrl_qubits == 4 {
-        Ok(c4x()?.into())
+    if num_ctrl_qubits <= 4 {
+        synth_mcx_explicit(num_ctrl_qubits)
     } else {
         // 2n^2-2n+1 instructions from synth_mcp_noaux_sp22, plus 2 H gates wrapping it.
         let num_instructions = 2 * num_ctrl_qubits * num_ctrl_qubits - 2 * num_ctrl_qubits + 3;
@@ -1187,6 +1175,38 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
         circuit.compose(&mcp, &qubits, &[])?;
         circuit.h(num_ctrl_qubits as u32)?;
         Ok(circuit)
+    }
+}
+
+/// Synthesize multi-controlled X explicit gates with up to 4 control qubits.
+///
+/// # Arguments
+///
+/// - num_ctrl_qubits: The number of control qubits.
+///
+/// # Returns
+///
+/// The synthesized quantum circuit.
+fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
+    assert!(
+        num_ctrl_qubits <= 4,
+        "synth_basic_mcx_gates called with num_ctrl_qubits = {num_ctrl_qubits}, expected <= 4"
+    );
+    match num_ctrl_qubits {
+        0 => {
+            let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
+            circuit.x(0)?;
+            Ok(circuit)
+        }
+        1 => {
+            let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
+            circuit.cx(0, 1)?;
+            Ok(circuit)
+        }
+        2 => Ok(ccx()),
+        3 => Ok(c3x().into()),
+        4 => Ok(c4x()?.into()),
+        _ => unreachable!(),
     }
 }
 

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1138,6 +1138,58 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     Ok(circuit)
 }
 
+/// Synthesize a multi-controlled X gate with :math:`k` controls using the relation
+/// MCX = H · MCP(π) · H, where MCP is synthesized via `synth_mcp_noaux_sp22` [1][2].
+///
+/// Produces a quantum circuit with :math:`k + 1` qubits.
+/// The number of CX-gates is quadratic in :math:`k`.
+///
+/// # Arguments
+///
+/// - num_ctrl_qubits: The number of control qubits.
+///
+/// # Returns
+///
+/// The synthesized quantum circuit.
+///
+/// # References
+/// 1. A. J. da Silva and D. K. Park, *Linear-depth quantum circuits for multiqubit controlled gates*,
+///    [Phys. Rev. A 106, 042602](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.106.042602).
+///
+/// 2. <https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py>
+pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
+    if num_ctrl_qubits == 0 {
+        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
+        circuit.x(0)?;
+        Ok(circuit)
+    } else if num_ctrl_qubits == 1 {
+        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
+        circuit.cx(0, 1)?;
+        Ok(circuit)
+    } else if num_ctrl_qubits == 2 {
+        Ok(ccx())
+    } else if num_ctrl_qubits == 3 {
+        Ok(c3x().into())
+    } else if num_ctrl_qubits == 4 {
+        Ok(c4x()?.into())
+    } else {
+        // 2n^2-2n+1 instructions from synth_mcp_noaux_sp22, plus 2 H gates wrapping it.
+        let num_instructions = 2 * num_ctrl_qubits * num_ctrl_qubits - 2 * num_ctrl_qubits + 3;
+        let mut circuit = CircuitData::with_capacity(
+            (num_ctrl_qubits + 1) as u32,
+            0,
+            num_instructions,
+            Param::Float(0.0),
+        )?;
+        let mcp = synth_mcp_noaux_sp22(num_ctrl_qubits, Param::Float(PI))?;
+        let qubits: Vec<Qubit> = (0..=(num_ctrl_qubits as u32)).map(Qubit).collect();
+        circuit.h(num_ctrl_qubits as u32)?;
+        circuit.compose(&mcp, &qubits, &[])?;
+        circuit.h(num_ctrl_qubits as u32)?;
+        Ok(circuit)
+    }
+}
+
 // The following code (synth_mcp_noaux_sp22 and mod sp22) is a derivative work of qclib
 // (https://github.com/qclib/qclib/blob/master/qclib/gates/ldmcu.py).
 // Copyright 2021 qclib project. Licensed under the Apache License, Version 2.0.

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1169,10 +1169,14 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
             num_instructions,
             Param::Float(0.0),
         )?;
-        let mcp = synth_mcp_noaux_sp22(num_ctrl_qubits, Param::Float(PI))?;
-        let qubits: Vec<Qubit> = (0..=(num_ctrl_qubits as u32)).map(Qubit).collect();
         circuit.h(num_ctrl_qubits as u32)?;
-        circuit.compose(&mcp, &qubits, &[])?;
+        let pi_phase = Param::Float(PI);
+        // Inline MCP(π) steps — same as synth_mcp_noaux_sp22 but directly
+        // on `circuit` which has target qubit at index `num_ctrl_qubits`
+        sp22::step_1(&mut circuit, &pi_phase, num_ctrl_qubits)?;
+        sp22::step_2(&mut circuit, &pi_phase, num_ctrl_qubits)?;
+        sp22::step_3(&mut circuit, num_ctrl_qubits)?;
+        sp22::step_4(&mut circuit, num_ctrl_qubits)?;
         circuit.h(num_ctrl_qubits as u32)?;
         Ok(circuit)
     }
@@ -1190,7 +1194,7 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
 fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
     assert!(
         num_ctrl_qubits <= 4,
-        "synth_basic_mcx_gates called with num_ctrl_qubits = {num_ctrl_qubits}, expected <= 4"
+        "synth_mcx_explicit called with num_ctrl_qubits = {num_ctrl_qubits}, expected <= 4"
     );
     match num_ctrl_qubits {
         0 => {

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1172,7 +1172,7 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
         circuit.h(num_ctrl_qubits as u32)?;
         let pi_phase = Param::Float(PI);
         // Adding MCP(π) on `circuit` which has target qubit at index `num_ctrl_qubits`.
-        // Instead of calling `synth_mcp_noaux_sp22` we call it's step functions directly. This avoids
+        // Instead of calling `synth_mcp_noaux_sp22`, we call its step functions directly. This avoids
         // allocating and copying an intermediate circuit and is ~2x faster.
         sp22::step_1(&mut circuit, &pi_phase, num_ctrl_qubits)?;
         sp22::step_2(&mut circuit, &pi_phase, num_ctrl_qubits)?;

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -12,7 +12,7 @@
 
 use mcx::{
     c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15,
-    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24,
+    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_sp22,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -63,6 +63,12 @@ fn py_synth_mcp_noaux_sp22(num_controls: usize, phase: Param) -> PyResult<PyCirc
     Ok(synth_mcp_noaux_sp22(num_controls, phase)?.into())
 }
 
+#[pyfunction]
+#[pyo3(name = "synth_mcx_noaux_sp22")]
+fn py_synth_mcx_noaux_sp22(num_controls: usize) -> PyResult<PyCircuitData> {
+    Ok(synth_mcx_noaux_sp22(num_controls)?.into())
+}
+
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c3x, m)?)?;
     m.add_function(wrap_pyfunction!(c4x, m)?)?;
@@ -70,6 +76,7 @@ pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcp_noaux_sp22, m)?)?;
+    m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_sp22, m)?)?;
     m.add_function(wrap_pyfunction!(mcmt::mcmt_v_chain, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_clean_m15, m)?)?;
     Ok(())

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -233,7 +233,9 @@ def synth_mcx_noaux_sp22(num_ctrl_qubits: int) -> QuantumCircuit:
             "synth_mcx_noaux_sp22 cannot be called with a negative number of control qubits."
         )
 
-    return QuantumCircuit._from_circuit_data(synth_mcx_noaux_sp22_rs(num_ctrl_qubits),  legacy_qubits=True)
+    return QuantumCircuit._from_circuit_data(
+        synth_mcx_noaux_sp22_rs(num_ctrl_qubits), legacy_qubits=True
+    )
 
 
 def synth_mcx_noaux_v24(num_ctrl_qubits: int) -> QuantumCircuit:

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -233,7 +233,7 @@ def synth_mcx_noaux_sp22(num_ctrl_qubits: int) -> QuantumCircuit:
             "synth_mcx_noaux_sp22 cannot be called with a negative number of control qubits."
         )
 
-    return QuantumCircuit._from_circuit_data(synth_mcx_noaux_sp22_rs(num_ctrl_qubits))
+    return QuantumCircuit._from_circuit_data(synth_mcx_noaux_sp22_rs(num_ctrl_qubits),  legacy_qubits=True)
 
 
 def synth_mcx_noaux_v24(num_ctrl_qubits: int) -> QuantumCircuit:

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -25,10 +25,10 @@ from qiskit._accelerate.synthesis.multi_controlled import (
     synth_mcx_noaux_hp24 as synth_mcx_noaux_hp24_rs,
     synth_mcx_n_clean_m15 as synth_mcx_n_clean_m15_rs,
     synth_mcx_1_clean_b95 as synth_mcx_1_clean_b95_rs,
+    synth_mcx_noaux_sp22 as synth_mcx_noaux_sp22_rs,
 )
 from .gray_code import gray_code_chain
 from qiskit.synthesis.multi_controlled.mcp_synthesis import (
-    synth_mcp_noaux_sp22,
     synth_mcp_noaux_v24,
 )
 
@@ -232,22 +232,8 @@ def synth_mcx_noaux_sp22(num_ctrl_qubits: int) -> QuantumCircuit:
         raise QiskitError(
             "synth_mcx_noaux_sp22 cannot be called with a negative number of control qubits."
         )
-    circ = QuantumCircuit(num_ctrl_qubits + 1)
-    if num_ctrl_qubits <= 2:
-        return _synth_mcx_special_cases(num_ctrl_qubits)
-    elif num_ctrl_qubits == 3:
-        circ = synth_c3x()
-    elif num_ctrl_qubits == 4:
-        circ = synth_c4x()
-    else:
-        circ.h(num_ctrl_qubits)
-        circ.compose(
-            synth_mcp_noaux_sp22(num_ctrl_qubits, phase=np.pi),
-            range(num_ctrl_qubits + 1),
-            inplace=True,
-        )
-        circ.h(num_ctrl_qubits)
-    return circ
+
+    return QuantumCircuit._from_circuit_data(synth_mcx_noaux_sp22_rs(num_ctrl_qubits))
 
 
 def synth_mcx_noaux_v24(num_ctrl_qubits: int) -> QuantumCircuit:

--- a/releasenotes/notes/synth-mcx-noaux-sp22-rust-a628eb25345c97fc.yaml
+++ b/releasenotes/notes/synth-mcx-noaux-sp22-rust-a628eb25345c97fc.yaml
@@ -1,0 +1,7 @@
+---
+performance:
+  - |
+    Improved runtime of :func:`~qiskit.synthesis.synth_mcx_noaux_sp22` synthesis function by migrating implementation to Rust,
+    resulting in approximately 2x-2.6x speedup across circuit sizes (n=50 to n=1000).   
+    See `#16755 <https://github.com/Qiskit/qiskit/pull/16818>`__ for more details.
+

--- a/releasenotes/notes/synth-mcx-noaux-sp22-rust-a628eb25345c97fc.yaml
+++ b/releasenotes/notes/synth-mcx-noaux-sp22-rust-a628eb25345c97fc.yaml
@@ -3,5 +3,5 @@ performance:
   - |
     Improved runtime of :func:`~qiskit.synthesis.synth_mcx_noaux_sp22` synthesis function by migrating implementation to Rust,
     resulting in approximately 2x-2.6x speedup across circuit sizes (n=50 to n=1000).   
-    See `#16755 <https://github.com/Qiskit/qiskit/pull/16818>`__ for more details.
+    See `#16818 <https://github.com/Qiskit/qiskit/pull/16818>`__ for more details.
 


### PR DESCRIPTION
`synth_mcx_noaux_sp22` is now a thin wrapper calling to rust implementation, which uses `MCX = H · MCP(π) · H` . Rust version calls the internal step functions of `synth_mcp_noaux_sp22` to skip creating the MCP circuit then copying it.

CX count for k ≥ 5 is `4k²−4k+2` (same as MCP SP22).

Performance improvement is ~x2.1 - x2.6 

| n | Python (µs) | Rust (µs) | Speedup |
|---:|---:|---:|---:|
| 50 | 1,306 | 496 | 2.63× |
| 100 | 4,806 | 2,086 | 2.30× |
| 200 | 19,096 | 8,021 | 2.38× |
| 500 | 128,664 | 60,143 | 2.14× |
| 1,000 | 613,014 | 284,803 | 2.15× |

performance script:
```python
KS = [50, 100, 200, 500, 1000]
REPS = 5
print(f"{'n':>6}  {'mean (µs)':>12}")
print(f"{'------':>6}  {'------------':>12}")

for k in KS:
    times = timeit.repeat(
        lambda k=k: synth_mcx_noaux_sp22(k),
        number=1,
        repeat=REPS,
    )
    mean_us = sum(times) / REPS * 1e6
    print(f"{k:>6}  {mean_us:>12.1f}")

```

Note:
I added a new function `synth_mcx_explicit`  for the basic MCX cases (`k<=4`). This function can be called by the other MCX synthesis functions as well and prevent code duplication. I suggest to do it in a separate PR.

### AI/LLM disclosure

- [x] Some submitted text was generated by: IBM Bob  2.0.3
