### PR TITLE
rename rust synth_mcx_noaux_v24 to synth_mcx_mcp_noaux

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -406,14 +406,14 @@ pub fn synth_mcx_n_dirty_i15(
 
 /// Synthesize a multi-controlled X gate with :math:`k` controls using no auxiliary qubits via the relation
 /// MCX = H · MCP(π) · H.
+/// For details on MCP synthesis see Python's `synth_mcp_noaux_default` in `qiskit/synthesis/multi_controlled/mcp_synthesis.py`.
 ///
 /// # Arguments
 /// - num_controls: the number of control qubits.
 ///
 /// # Returns
 ///
-/// A quantum circuit with :math:`k + 1` qubits. The number of CX-gates is
-/// quadratic in :math:`k`.
+/// A quantum circuit with :math:`k + 1` qubits.
 ///
 #[allow(dead_code)]
 pub fn synth_mcx_mcp_noaux(

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -404,11 +404,8 @@ pub fn synth_mcx_n_dirty_i15(
     }
 }
 
-/// Synthesize a multi-controlled X gate with :math:`k` controls based on
-/// the implementation for `MCPhaseGate`.
-///
-/// In turn, the MCPhase gate uses the decomposition for multi-controlled
-/// special unitaries described in [1].
+/// Synthesize a multi-controlled X gate with :math:`k` using no auxiliary qubits via the relation
+/// MCX = H · MCP(π) · H.
 ///
 /// # Arguments
 /// - num_controls: the number of control qubits.
@@ -418,12 +415,7 @@ pub fn synth_mcx_n_dirty_i15(
 /// A quantum circuit with :math:`k + 1` qubits. The number of CX-gates is
 /// quadratic in :math:`k`.
 ///
-/// # References
-///
-/// 1. Vale et. al., *Circuit Decomposition of Multicontrolled Special Unitary
-///    Single-Qubit Gates*, IEEE TCAD 43(3) (2024),
-///    [arXiv:2302.06377] (https://arxiv.org/abs/2302.06377).
-pub fn synth_mcx_noaux_v24(
+pub fn synth_mcx_mcp_noaux(
     py: Python,
     num_controls: usize,
 ) -> Result<CircuitData, CircuitDataError> {

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -415,6 +415,7 @@ pub fn synth_mcx_n_dirty_i15(
 /// A quantum circuit with :math:`k + 1` qubits. The number of CX-gates is
 /// quadratic in :math:`k`.
 ///
+#[allow(dead_code)]
 pub fn synth_mcx_mcp_noaux(
     py: Python,
     num_controls: usize,

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -404,7 +404,7 @@ pub fn synth_mcx_n_dirty_i15(
     }
 }
 
-/// Synthesize a multi-controlled X gate with :math:`k` using no auxiliary qubits via the relation
+/// Synthesize a multi-controlled X gate with :math:`k` controls using no auxiliary qubits via the relation
 /// MCX = H · MCP(π) · H.
 ///
 /// # Arguments

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -12,7 +12,7 @@
 
 use mcx::{
     c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15,
-    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_v24,
+    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -30,12 +30,6 @@ fn py_synth_mcx_n_dirty_i15(
     action_only: bool,
 ) -> PyResult<PyCircuitData> {
     Ok(synth_mcx_n_dirty_i15(num_controls, relative_phase, action_only)?.into())
-}
-
-#[pyfunction]
-#[pyo3(name="synth_mcx_noaux_v24", signature = (num_controls))]
-fn py_synth_mcx_noaux_v24(py: Python, num_controls: usize) -> PyResult<PyCircuitData> {
-    Ok(synth_mcx_noaux_v24(py, num_controls)?.into())
 }
 
 #[pyfunction]
@@ -73,7 +67,6 @@ pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(c3x, m)?)?;
     m.add_function(wrap_pyfunction!(c4x, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_dirty_i15, m)?)?;
-    m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_v24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcp_noaux_sp22, m)?)?;


### PR DESCRIPTION
`synth_mcx_noaux_v24` in rust does `H-MCP-H`, it does not implement the v24 algorithm. Therefore it is renamed to `synth_mcx_mcp_noaux`.
Currently this method is not exported to python.
In python we have a `synth_mcx_noaux_v24` that calls `synth_mcp_noaux_v24` directly, that one stays unchanged.

See prev discussion in #16693 


### AI/LLM disclosure

- [ x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:
