### PR TITLE
visualization: fix Bloch vector_style line plot TypeError

### DIFF
--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -639,7 +639,7 @@ class Bloch:
             if self.vector_style == "":
                 # simple line style
                 self.axes.plot(
-                    xs3d, ys3d, zs3d, zs=0, zdir="z", label="Z", lw=self.vector_width, color=color
+                    xs3d, ys3d, zs3d, zdir="z", label="Z", lw=self.vector_width, color=color
                 )
             else:
                 # decorated style, with arrow heads

--- a/test/python/visualization/test_state_plot_tools.py
+++ b/test/python/visualization/test_state_plot_tools.py
@@ -50,6 +50,17 @@ class TestStatePlotTools(QiskitTestCase):
         self.assertEqual(output[0], labels)
         self.assertTrue(np.allclose(output[1], values))
 
+    def test_bloch_vector_style_line(self):
+        """Test Bloch render with vector_style='' simple line style."""
+        from qiskit.visualization.bloch import Bloch
+        import matplotlib.pyplot as plt
+
+        b = Bloch()
+        b.vector_style = ""
+        b.add_vectors([0, 1, 0])
+        b.render()
+        plt.close(b.fig)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### Summary
Fixes an issue where setting `Bloch.vector_style = ""` (the documented simple line style) raises `TypeError: plot() for multiple values for argument 'zs'` when rendering.

### Details and Explanation
In `qiskit/visualization/bloch.py`, `zs3d` is passed positionally as the 3rd argument to `Axes3D.plot()`, and `zs=0` was also passed as a keyword argument. Matplotlib explicitly forbids providing `zs` both positionally and by keyword.

Fix: Removed the redundant `zs=0` keyword argument.

Fixes #16740

### Testing
- Added regression test `test_bloch_vector_style_line` in `test/python/visualization/test_state_plot_tools.py`.