### PR TITLE
Add C API for accessing bigint values in classical expressions (Qiskit#16666)

### DIFF
--- a/crates/bindgen/src/lib.rs
+++ b/crates/bindgen/src/lib.rs
@@ -110,6 +110,7 @@ pub static EXPORT_RENAME: &[(&str, &str)] = &[
     ("CIndexExprInfo", "IndexExprInfo"),
     ("CExprType", "ExprType"),
     ("CExprTypeInfo", "ExprTypeInfo"),
+    ("CBigUint", "BigUint"),
     ("CDurationType", "DurationType"),
     ("CDurationInfo", "DurationInfo"),
     ("CDurationValue", "DurationValue"),

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -493,6 +493,8 @@ mod classical_expr {
             export_fn!(qk_var_name),
             export_fn!(qk_var_type_info),
             export_fn!(qk_stretch_name),
+            export_fn!(qk_value_biguint),
+            export_fn!(qk_biguint_clear),
         ]
     });
 }

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -12,7 +12,7 @@
 
 use std::ptr;
 
-use crate::pointers::{check_ptr, const_ptr_as_ref};
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 use qiskit_circuit::{
@@ -910,18 +910,15 @@ pub unsafe extern "C" fn qk_value_biguint(value: *const Value) -> CBigUint {
 /// Behavior is undefined if ``biguint`` is not a valid, non-null pointer to a `QkBigUint`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_biguint_clear(biguint: *mut CBigUint) {
-    check_ptr(biguint).unwrap();
     // SAFETY: Per documentation, `biguint` is a valid, non-null pointer.
-    unsafe {
-        ptr::drop_in_place(biguint);
-        ptr::write(
-            biguint,
-            CBigUint {
-                limbs: ptr::null(),
-                num_limbs: 0,
-            },
-        );
-    }
+    let biguint = unsafe { mut_ptr_as_ref(biguint) };
+    drop(std::mem::replace(
+        biguint,
+        CBigUint {
+            limbs: ptr::null(),
+            num_limbs: 0,
+        },
+    ))
 }
 
 /// @ingroup QkClassicalExpressions

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -12,7 +12,7 @@
 
 use std::ptr;
 
-use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
+use crate::pointers::{check_ptr, const_ptr_as_ref};
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 use qiskit_circuit::{
@@ -832,6 +832,32 @@ pub struct CBigUint {
     num_limbs: usize,
 }
 
+impl CBigUint {
+    /// Convert BigUint to an CBigUint that owns its allocation.
+    pub fn from_biguint(biguint: &BigUint) -> Self {
+        let biguint_slice = biguint
+            .iter_u64_digits()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let result = CBigUint {
+            limbs: biguint_slice.as_ptr(),
+            num_limbs: biguint_slice.len(),
+        };
+        std::mem::forget(biguint_slice);
+        result
+    }
+}
+
+impl Drop for CBigUint {
+    fn drop(&mut self) {
+        // SAFETY: We own the slice.
+        unsafe {
+            let slice = ptr::slice_from_raw_parts_mut(self.limbs as *mut u64, self.num_limbs);
+            drop(Box::from_raw(slice));
+        }
+    }
+}
+
 /// @ingroup QkClassicalExpressions
 /// Extract the unsigned bigint value from a ``QkValue``. The data is copied
 /// to a freshly allocated `QkBigUint` which the caller owns after calling
@@ -868,13 +894,7 @@ pub unsafe extern "C" fn qk_value_biguint(value: *const Value) -> CBigUint {
         panic!("qk_value_biguint called on non-uint value")
     };
 
-    let biguint_slice = raw.iter_u64_digits().collect::<Vec<_>>().into_boxed_slice();
-    let result = CBigUint {
-        limbs: biguint_slice.as_ptr(),
-        num_limbs: biguint_slice.len(),
-    };
-    std::mem::forget(biguint_slice);
-    result
+    CBigUint::from_biguint(raw)
 }
 
 /// @ingroup QkClassicalExpressions
@@ -890,14 +910,18 @@ pub unsafe extern "C" fn qk_value_biguint(value: *const Value) -> CBigUint {
 /// Behavior is undefined if ``biguint`` is not a valid, non-null pointer to a `QkBigUint`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_biguint_clear(biguint: *mut CBigUint) {
+    check_ptr(biguint).unwrap();
     // SAFETY: Per documentation, `biguint` is a valid, non-null pointer.
-    let biguint = unsafe { mut_ptr_as_ref(biguint) };
-    let slice = ptr::slice_from_raw_parts_mut(biguint.limbs as *mut u64, biguint.num_limbs);
-    // SAFETY: Per documentation, converting the value to an owned slice must be valid.
-    unsafe { drop(Box::from_raw(slice)) };
-
-    biguint.limbs = ptr::null();
-    biguint.num_limbs = 0;
+    unsafe {
+        ptr::drop_in_place(biguint);
+        ptr::write(
+            biguint,
+            CBigUint {
+                limbs: ptr::null(),
+                num_limbs: 0,
+            },
+        );
+    }
 }
 
 /// @ingroup QkClassicalExpressions

--- a/crates/cext/src/classical_expr.rs
+++ b/crates/cext/src/classical_expr.rs
@@ -12,7 +12,7 @@
 
 use std::ptr;
 
-use crate::pointers::const_ptr_as_ref;
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
 use qiskit_circuit::{
@@ -813,6 +813,93 @@ pub unsafe extern "C" fn qk_value_uint(value: *const Value) -> u64 {
         .expect("Integer value too large to fit in uint64_t")
 }
 
+/// Representation of big-integer data.
+///
+/// The slice ``self.limbs[0..self.num_limbs]`` holds the limbs (big-digits) of the unsigned bigint in
+/// little-endian order. Each limb itself is encoded native-endian.
+///
+/// Trailing limbs where the value is zero will not be included. Notice that this implies that the
+/// buffer may be smaller than what you expect by inspecting the bit-width from `QkExprTypeInfo`.
+///
+/// **Ownership**: When constructed by calling `qk_value_biguint`, the caller owns the memory, and
+/// is responsible for calling `qk_biguint_clear` to free it at the end of use.
+#[repr(C)]
+pub struct CBigUint {
+    /// A buffer containing the bigint data, where each ``uint64_t`` element represents a limb
+    /// (big-digit) of the bigint.
+    limbs: *const u64,
+    /// Number of limbs.
+    num_limbs: usize,
+}
+
+/// @ingroup QkClassicalExpressions
+/// Extract the unsigned bigint value from a ``QkValue``. The data is copied
+/// to a freshly allocated `QkBigUint` which the caller owns after calling
+/// this function.
+///
+/// @param value A pointer to a uint value.
+///
+/// @return A `QkBigUint` that contains a copy of the big-integer data. Value is owned by the caller
+///     and should be freed with `qk_biguint_clear` when no longer in use.
+///
+/// Panics if ``value`` does not point to a ``QkExprType_Uint`` value.
+///
+/// # Example
+/// ```c
+/// QkBigUint biguint = qk_value_biguint(value);
+/// for (size_t i = 0; i< biguint.num_limbs; i++)
+///     printf("biguint.limbs[i] = %lx\n", biguint.limbs[i]);
+/// qk_biguint_clear(&biguint);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkValue``.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_value_biguint(value: *const Value) -> CBigUint {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let value = unsafe { const_ptr_as_ref(value) };
+
+    let Value::Uint {
+        raw,
+        ty: Type::Uint(_),
+    } = value
+    else {
+        panic!("qk_value_biguint called on non-uint value")
+    };
+
+    let biguint_slice = raw.iter_u64_digits().collect::<Vec<_>>().into_boxed_slice();
+    let result = CBigUint {
+        limbs: biguint_slice.as_ptr(),
+        num_limbs: biguint_slice.len(),
+    };
+    std::mem::forget(biguint_slice);
+    result
+}
+
+/// @ingroup QkClassicalExpressions
+/// Clear a `QkBigUint`.
+///
+/// This function frees the buffer. The pointer is then set to null, and the length is
+/// set to zero.
+///
+/// @param biguint Pointer to `QkBigUint`.
+///
+/// # Safety
+///
+/// Behavior is undefined if ``biguint`` is not a valid, non-null pointer to a `QkBigUint`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_biguint_clear(biguint: *mut CBigUint) {
+    // SAFETY: Per documentation, `biguint` is a valid, non-null pointer.
+    let biguint = unsafe { mut_ptr_as_ref(biguint) };
+    let slice = ptr::slice_from_raw_parts_mut(biguint.limbs as *mut u64, biguint.num_limbs);
+    // SAFETY: Per documentation, converting the value to an owned slice must be valid.
+    unsafe { drop(Box::from_raw(slice)) };
+
+    biguint.limbs = ptr::null();
+    biguint.num_limbs = 0;
+}
+
 /// @ingroup QkClassicalExpressions
 /// Extract the value from a ``QkValue`` of type ``QkExprType_Bool``.
 ///
@@ -1149,6 +1236,43 @@ pub unsafe extern "C" fn inner_test_value(
 
 /// cbindgen:qk-vtable-rules=[no-export]
 /// cbindgen:no-export
+///
+/// Create [`Value::Uint`] with big values for testing.
+///
+/// Copies `buf[0..len]` to a new [`Value::Uint`]. Note that `buf: *const u8` is agnostic regarding
+/// endianness -- unlike the inner representation of [`Value::Uint`] and [`QkBigUint`].
+///
+/// If `bit_width_auto` is true, calculate the bit-width metadata in `value::uint { ty: uint(_), .. }`
+/// according to the buffer size `len`, and ignore the `bit_width` parameter. Otherwise, use the
+/// `bit_width` parameter. Note that this stored bit-width metadata is treated as a hint, and we
+/// avoid relying on it for operations where using a wrong value may cause memory-unsafety.
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_test_value_biguint(
+    buf: *const u8,
+    len: usize,
+    bit_width_auto: bool,
+    bit_width: u32,
+) -> *mut Value {
+    let bytes: &[u8] = unsafe { std::slice::from_raw_parts(buf, len) };
+    let raw = BigUint::from_bytes_le(bytes);
+
+    let bit_width = if bit_width_auto {
+        u32::try_from(len).unwrap() * u64::BITS
+    } else {
+        bit_width
+    };
+
+    let value = Value::Uint {
+        raw,
+        ty: Type::Uint(bit_width),
+    };
+
+    Box::into_raw(Box::new(value))
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn inned_test_old_style_vars(out_vars: *mut *mut Expr) {
@@ -1174,4 +1298,12 @@ pub unsafe extern "C" fn inned_test_old_style_vars(out_vars: *mut *mut Expr) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn inner_expr_free(expr: *mut Expr) {
     drop(unsafe { Box::from_raw(expr) })
+}
+
+/// cbindgen:qk-vtable-rules=[no-export]
+/// cbindgen:no-export
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn inner_value_free(value: *mut Value) {
+    drop(unsafe { Box::from_raw(value) })
 }

--- a/docs/cdoc/qk-classical-expressions.rst
+++ b/docs/cdoc/qk-classical-expressions.rst
@@ -45,6 +45,9 @@ Data Types
 .. doxygenstruct:: QkDurationInfo
     :members:
 
+.. doxygenstruct:: QkBigUint
+    :members:
+
 
 Functions
 =========

--- a/releasenotes/notes/c-api-value-biguint-fe8b283479d3d1ad.yaml
+++ b/releasenotes/notes/c-api-value-biguint-fe8b283479d3d1ad.yaml
@@ -1,0 +1,8 @@
+---
+features_c:
+  - |
+    Added C API for accessing ``QkValue`` of type ``QkExprType_Uint`` where the
+    underlying integer is bigger than 64 bits. The new function :c:func:`qk_value_biguint`
+    returns a :c:struct:`QkBigUint` that contains an owned copy of the bigint data.
+    The caller is responsible for calling :c:func:`qk_biguint_clear` when a c:struct:`QkBigUint`
+    is no longer used.

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -28,7 +28,7 @@ find_library (qiskit qiskit_cext PATHS ${CARGO_LIB_DIR} REQUIRED)
 
 # Convert warnings into errors. Note that MSVC and GCC/clang do not match here, and CI will
 # require all to pass without errors.
-if (MSVC) 
+if (MSVC)
     add_compile_options(/W3 /WX)
 else ()
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
@@ -50,7 +50,7 @@ file (
 # test file.
 create_test_sourcelist (source_files test_driver.c ${discovered_tests})
 
-add_library(common STATIC common.c)
+add_library(common STATIC common.c bigint.c)
 # Actually define the test driver program executable to be built...
 add_executable (test_driver ${source_files})
 # ...include the location of the header file...

--- a/test/c/bigint.c
+++ b/test/c/bigint.c
@@ -19,10 +19,10 @@
 #include <string.h>
 
 int biguint_cmp(const QkBigUint a, const QkBigUint b) {
-    ptrdiff_t limb_count_diff = (ptrdiff_t)a.num_limbs - (ptrdiff_t)b.num_limbs;
-    if (limb_count_diff != 0) {
-        return limb_count_diff;
-    }
+    if (a.num_limbs < b.num_limbs)
+        return -1;
+    if (a.num_limbs > b.num_limbs)
+        return 1;
     return memcmp(a.limbs, b.limbs, a.num_limbs * sizeof(uint64_t));
 }
 

--- a/test/c/bigint.c
+++ b/test/c/bigint.c
@@ -1,0 +1,47 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include <inttypes.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+int biguint_cmp(const QkBigUint a, const QkBigUint b) {
+    ptrdiff_t limb_count_diff = (ptrdiff_t)a.num_limbs - (ptrdiff_t)b.num_limbs;
+    if (limb_count_diff != 0) {
+        return limb_count_diff;
+    }
+    return memcmp(a.limbs, b.limbs, a.num_limbs * sizeof(uint64_t));
+}
+
+bool biguint_eq(const QkBigUint a, const QkBigUint b) { return biguint_cmp(a, b) == 0; }
+
+/*
+ * Print QkBigUint values (debug helper)
+ */
+void biguint_debug_print(const QkBigUint *biguint, const char *name) {
+    if (name == NULL)
+        name = "biguint";
+    printf("%s.num_limbs = %zu\n", name, biguint->num_limbs);
+    for (size_t limb_idx = 0; limb_idx < biguint->num_limbs; limb_idx++) {
+        printf("%s[%zu] = [", name, limb_idx);
+        for (size_t i = 0; i < sizeof(uint64_t); i++) {
+            printf("%02" PRIX8, ((uint8_t *)biguint->limbs)[sizeof(uint64_t) * limb_idx + i]);
+            if (i < sizeof(uint64_t) - 1)
+                printf(" ");
+        }
+        printf("]\n");
+    }
+}

--- a/test/c/bigint.h
+++ b/test/c/bigint.h
@@ -1,0 +1,23 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * BigInt helpers for testing.
+ */
+
+int biguint_cmp(const QkBigUint a, const QkBigUint b);
+bool biguint_eq(const QkBigUint a, const QkBigUint b);
+void biguint_debug_print(const QkBigUint *biguint, const char *name);

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -676,12 +676,12 @@ static int test_expr_value_biguint(void) {
 
     // Bigger BigUint
     {
-        const size_t BIG_LIMB_LEN = 2000;
-        uint8_t big_bytes[BIG_LIMB_LEN * sizeof(uint64_t)];
+        enum { BIG_LIMB_LEN = 2000 };
+        static uint8_t big_bytes[BIG_LIMB_LEN * sizeof(uint64_t)];
         for (size_t i = 0; i < sizeof(big_bytes); i++)
             big_bytes[i] = (uint8_t)i;
 
-        uint64_t big_expected[BIG_LIMB_LEN];
+        static uint64_t big_expected[BIG_LIMB_LEN];
         for (size_t limb_idx = 0; limb_idx < BIG_LIMB_LEN; limb_idx++) {
             for (size_t i = 0; i < sizeof(uint64_t); i++) {
                 big_expected[limb_idx] |= (uint64_t)big_bytes[limb_idx * sizeof(uint64_t) + i]

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -29,8 +29,28 @@ QkExprNode *inner_test_unary_expr_ops(QkUnaryOpType);
 QkExprNode *inner_test_binary_expr_ops(QkBinaryOpType);
 QkExprNode *inner_test_expr_kinds_and_types(QkExprNodeKind, QkExprTypeInfo);
 QkExprNode *inner_test_value(QkExprType, bool, QkDurationInfo, double, uint64_t);
+QkValue *inner_test_value_biguint(const uint8_t *, size_t, bool, uint32_t);
 void inned_test_old_style_vars(QkExprNode **);
 void *inner_expr_free(QkExprNode *);
+void *inner_value_free(QkValue *);
+
+/*
+ * Print QkBigUint values (debug helper)
+ */
+static void biguint_debug_print(const QkBigUint *biguint, const char *name) {
+    if (name == NULL)
+        name = "biguint";
+    printf("%s.num_limbs = %zu\n", name, biguint->num_limbs);
+    for (size_t limb_idx = 0; limb_idx < biguint->num_limbs; limb_idx++) {
+        printf("%s[%zu] = [", name, limb_idx);
+        for (size_t i = 0; i < sizeof(uint64_t); i++) {
+            printf("%02" PRIX8, ((uint8_t *)biguint->limbs)[sizeof(uint64_t) * limb_idx + i]);
+            if (i < sizeof(uint64_t) - 1)
+                printf(" ");
+        }
+        printf("]\n");
+    }
+}
 
 /*
  * Test that expression tree structure is captured correctly via the information structs
@@ -437,6 +457,7 @@ static int test_expr_value(void) {
     int result = Ok;
     QkDurationInfo duration_info = {QkDurationType_Dt, {.dt = 12345}};
     QkExprNode *expr = NULL;
+    QkBigUint biguint_val = {0};
 
     for (uint8_t ty = QkExprType_Bool; ty <= QkExprType_Uint; ty++) {
         expr = inner_test_value((QkExprType)ty, true, duration_info, 3.14, 12345);
@@ -525,6 +546,20 @@ static int test_expr_value(void) {
                 result = EqualityError;
                 goto cleanup;
             }
+
+            biguint_val = qk_value_biguint(value);
+
+            if (biguint_val.num_limbs != 1) {
+                printf("Expected biguint value length 1 (one limb), got %" PRIu64 "\n",
+                       biguint_val.num_limbs);
+                result = EqualityError;
+                goto cleanup;
+            }
+            if (biguint_val.limbs[0] != 12345) {
+                printf("Expected biguint value 12345, got %" PRIu64 "\n", biguint_val.limbs[0]);
+                result = EqualityError;
+                goto cleanup;
+            }
         }
 
         inner_expr_free(expr);
@@ -536,7 +571,156 @@ cleanup:
     if (expr)
         inner_expr_free(expr);
 
+    if (biguint_val.limbs)
+        qk_biguint_clear(&biguint_val);
+
     return result;
+}
+
+typedef struct {
+    const char *label;
+
+    const uint8_t *bytes;
+    size_t bytes_len;
+    bool bit_width_auto;
+    uint32_t bit_width;
+
+    QkBigUint expected;
+} BigUint_TestCase;
+
+static enum TestResult check_biguint_value(const BigUint_TestCase *tc) {
+    enum TestResult result = Ok;
+
+    // Create test QkValue:
+    QkValue *value =
+        inner_test_value_biguint(tc->bytes, tc->bytes_len, tc->bit_width_auto, tc->bit_width);
+
+    // Extract QkBigUint from QkValue (copy):
+    QkBigUint actual = qk_value_biguint(value);
+
+    // Check that actual and expected biguints are equal:
+    if (!(actual.num_limbs == tc->expected.num_limbs &&
+          memcmp(actual.limbs, tc->expected.limbs, tc->expected.num_limbs * sizeof(uint64_t)) ==
+              0)) {
+        printf("Unexpected QkBigUint value for '%s'\n", tc->label);
+        biguint_debug_print(&tc->expected, "expected");
+        biguint_debug_print(&actual, "actual");
+        result = EqualityError;
+    }
+
+    // Cleanup:
+    qk_biguint_clear(&actual);
+    inner_value_free(value);
+
+    return result;
+}
+
+/*
+ * Test construction of `QkBigUint` from `QkValue`.
+ */
+static int test_expr_value_biguint(void) {
+    enum TestResult result = Ok;
+
+    // Data for constructing a testing QkValue.
+    const uint8_t testdata[] = {
+        /*  0.. 8 */ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        /*  8..16 */ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        /* 16..24 */ 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77,
+    };
+    // Expected output data. Type is `uint64_t[]` so that comparison is endian-independent.
+    const uint64_t expected_limbs[] = {
+        0x0807060504030201,
+        0xFFFFFFFFFFFFFFFF,
+        0x778899AABBCCDDEE,
+    };
+
+    const BigUint_TestCase one_limb = {
+        .label = "one_limb",
+        .bytes = testdata,
+        .bytes_len = 1 * sizeof(uint64_t),
+        .bit_width_auto = true,
+        .bit_width = 0,
+        .expected = {.limbs = expected_limbs, .num_limbs = 1},
+    };
+    result = check_biguint_value(&one_limb);
+    if (result != Ok)
+        return result;
+
+    const BigUint_TestCase two_limbs = {
+        .label = "two_limbs",
+        .bytes = testdata,
+        .bytes_len = 2 * sizeof(uint64_t),
+        .bit_width_auto = true,
+        .bit_width = 0,
+        .expected = {.limbs = expected_limbs, .num_limbs = 2},
+    };
+    result = check_biguint_value(&two_limbs);
+    if (result != Ok)
+        return result;
+
+    const BigUint_TestCase three_limbs = {
+        .label = "three_limbs",
+        .bytes = testdata,
+        .bytes_len = 3 * sizeof(uint64_t),
+        .bit_width_auto = true,
+        .bit_width = 0,
+        .expected = {.limbs = expected_limbs, .num_limbs = 3},
+    };
+    result = check_biguint_value(&three_limbs);
+    if (result != Ok)
+        return result;
+
+    // `bit_width` should be ignored.
+    {
+        const BigUint_TestCase zero_bitwidth = {
+            .label = "zero_bitwidth",
+            .bytes = testdata + (2 * sizeof(uint64_t)),
+            .bytes_len = 1 * sizeof(uint64_t),
+            .bit_width_auto = false, // <- notice: `bit_width` not auto-calculated.
+            .bit_width = 0,
+            .expected = {.limbs = &expected_limbs[2], .num_limbs = 1},
+        };
+        result = check_biguint_value(&zero_bitwidth);
+        if (result != Ok)
+            return result;
+
+        BigUint_TestCase big_bitwidth = zero_bitwidth;
+        big_bitwidth.label = "big_bitwidth";
+        big_bitwidth.bit_width = 1000;
+        result = check_biguint_value(&big_bitwidth);
+        if (result != Ok)
+            return result;
+    }
+
+    // Bigger BigUint
+    {
+        const size_t BIG_LIMB_LEN = 2000;
+        uint8_t big_bytes[BIG_LIMB_LEN * sizeof(uint64_t)];
+        for (size_t i = 0; i < sizeof(big_bytes); i++)
+            big_bytes[i] = (uint8_t)i;
+
+        uint64_t big_expected[BIG_LIMB_LEN];
+        for (size_t limb_idx = 0; limb_idx < BIG_LIMB_LEN; limb_idx++) {
+            for (size_t i = 0; i < sizeof(uint64_t); i++) {
+                big_expected[limb_idx] |= (uint64_t)big_bytes[limb_idx * sizeof(uint64_t) + i]
+                                          << (8 * i);
+            }
+        }
+
+        const BigUint_TestCase big = {
+            .label = "big",
+            .bytes = big_bytes,
+            .bytes_len = BIG_LIMB_LEN * sizeof(uint64_t),
+            .bit_width_auto = true,
+            .bit_width = 0,
+            .expected = {.limbs = big_expected, .num_limbs = BIG_LIMB_LEN},
+        };
+        result = check_biguint_value(&big);
+        if (result != Ok)
+            return result;
+    }
+
+    return Ok;
 }
 
 int test_classical_expr(void) {
@@ -548,6 +732,7 @@ int test_classical_expr(void) {
     num_failed += RUN_TEST(test_expr_var);
     num_failed += RUN_TEST(test_expr_stretch);
     num_failed += RUN_TEST(test_expr_value);
+    num_failed += RUN_TEST(test_expr_value_biguint);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -10,10 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#include "bigint.h"
 #include "common.h"
 #include <complex.h>
 #include <inttypes.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -33,24 +33,6 @@ QkValue *inner_test_value_biguint(const uint8_t *, size_t, bool, uint32_t);
 void inned_test_old_style_vars(QkExprNode **);
 void *inner_expr_free(QkExprNode *);
 void *inner_value_free(QkValue *);
-
-/*
- * Print QkBigUint values (debug helper)
- */
-static void biguint_debug_print(const QkBigUint *biguint, const char *name) {
-    if (name == NULL)
-        name = "biguint";
-    printf("%s.num_limbs = %zu\n", name, biguint->num_limbs);
-    for (size_t limb_idx = 0; limb_idx < biguint->num_limbs; limb_idx++) {
-        printf("%s[%zu] = [", name, limb_idx);
-        for (size_t i = 0; i < sizeof(uint64_t); i++) {
-            printf("%02" PRIX8, ((uint8_t *)biguint->limbs)[sizeof(uint64_t) * limb_idx + i]);
-            if (i < sizeof(uint64_t) - 1)
-                printf(" ");
-        }
-        printf("]\n");
-    }
-}
 
 /*
  * Test that expression tree structure is captured correctly via the information structs
@@ -575,18 +557,6 @@ cleanup:
         qk_biguint_clear(&biguint_val);
 
     return result;
-}
-
-int biguint_cmp(const QkBigUint a, const QkBigUint b) {
-    ptrdiff_t limb_count_diff = (ptrdiff_t)a.num_limbs - (ptrdiff_t)b.num_limbs;
-    if (limb_count_diff != 0) {
-        return limb_count_diff;
-    }
-    return memcmp(a.limbs, b.limbs, a.num_limbs * sizeof(uint64_t));
-}
-
-bool biguint_eq(const QkBigUint a, const QkBigUint b) {
-    return biguint_cmp(a, b) == 0;
 }
 
 typedef struct {

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -577,6 +577,18 @@ cleanup:
     return result;
 }
 
+int biguint_cmp(const QkBigUint a, const QkBigUint b) {
+    ptrdiff_t limb_count_diff = (ptrdiff_t)a.num_limbs - (ptrdiff_t)b.num_limbs;
+    if (limb_count_diff != 0) {
+        return limb_count_diff;
+    }
+    return memcmp(a.limbs, b.limbs, a.num_limbs * sizeof(uint64_t));
+}
+
+bool biguint_eq(const QkBigUint a, const QkBigUint b) {
+    return biguint_cmp(a, b) == 0;
+}
+
 typedef struct {
     const char *label;
 
@@ -591,25 +603,25 @@ typedef struct {
 static enum TestResult check_biguint_value(const BigUint_TestCase *tc) {
     enum TestResult result = Ok;
 
-    // Create test QkValue:
     QkValue *value =
         inner_test_value_biguint(tc->bytes, tc->bytes_len, tc->bit_width_auto, tc->bit_width);
 
     // Extract QkBigUint from QkValue (copy):
     QkBigUint actual = qk_value_biguint(value);
 
-    // Check that actual and expected biguints are equal:
-    if (!(actual.num_limbs == tc->expected.num_limbs &&
-          memcmp(actual.limbs, tc->expected.limbs, tc->expected.num_limbs * sizeof(uint64_t)) ==
-              0)) {
+    if (!biguint_eq(actual, tc->expected)) {
         printf("Unexpected QkBigUint value for '%s'\n", tc->label);
         biguint_debug_print(&tc->expected, "expected");
         biguint_debug_print(&actual, "actual");
         result = EqualityError;
     }
 
-    // Cleanup:
     qk_biguint_clear(&actual);
+    if (!(actual.num_limbs == 0 && actual.limbs == NULL)) {
+        printf("Expected zeroed memory after calling 'qk_biguint_clear'\n");
+        result = RuntimeError;
+    }
+
     inner_value_free(value);
 
     return result;

--- a/test/c/test_classical_expr.c
+++ b/test/c/test_classical_expr.c
@@ -550,7 +550,7 @@ static int test_expr_value(void) {
             biguint_val = qk_value_biguint(value);
 
             if (biguint_val.num_limbs != 1) {
-                printf("Expected biguint value length 1 (one limb), got %" PRIu64 "\n",
+                printf("Expected biguint value length 1 (one limb), got %zu\n",
                        biguint_val.num_limbs);
                 result = EqualityError;
                 goto cleanup;


### PR DESCRIPTION
Add C API for accessing bigint values in classical expressions.

This PR Addresses part of #16666.

This is how you use the added API:

```c
    QkBigUint biguint = qk_value_biguint(value);
    // ... use `biguint` by accessing its fields: .limbs, .num_limbs ...
    qk_biguint_clear(&biguint);
```

`qk_value_biguint` does an allocation on the Rust side, which contains a copy of the bigint data from `QkValue`.

It would actually be preferable -- from a performance perspective -- to give the caller a borrowed pointer to the internal buffer of `num_bigint::BigUint`, and let the caller copy it and handle the allocation. Or alternatively, but similar: a function that fills a buffer the caller provides. Both of these are more fundamental for a low-level API and avoid forcing an allocation.

For the time being, @eliarbel and I agreed on the API design as it is in this PR.

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by: