### PR TITLE
circuit_drawer: avoid panic on empty circuit drawing

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1300,6 +1300,10 @@ impl TextDrawer {
     }
 
     fn draw(&self, mergewires: bool, fold: usize) -> String {
+        if self.wires.is_empty() || self.wires[0].is_empty() {
+            return String::new();
+        }
+
         // Calculate the layer ranges for each fold of the circuit
         let num_layers = self.wires[0].len();
         // We skip the first (inputs) layer since it's printed for each fold, regardless
@@ -1566,6 +1570,14 @@ mod tests {
             .unwrap();
 
         circuit
+    }
+
+    #[cfg(not(miri))]
+    #[test]
+    fn test_empty_circuit() {
+        let circuit = CircuitData::new(None, None, Param::Float(0.5)).unwrap();
+        let result = draw_circuit(&circuit, false, false, None).unwrap();
+        assert_eq!("global phase: 0.5\n", result);
     }
 
     #[cfg(not(miri))]


### PR DESCRIPTION
### Summary
Fixes #16723: When `TextDrawer::draw` was called on an empty circuit (i.e. one with zero qubits and zero clbits), attempting to index `self.wires[0].len()` panicked with an out-of-bounds error.

### Details and comments
- Checked `if self.wires.is_empty() || self.wires[0].is_empty()` in `TextDrawer::draw` to return an empty string immediately, allowing global phase and header output to render cleanly.
- Added unit test `test_empty_circuit` in `crates/circuit/src/circuit_drawer.rs`.

Signed-off-by: sundeep8967 <sundeep8967@gmail.com>