### PR TITLE
Fix `DAGCircuit.__eq__` with `Unitary`, `PPR`s and `PPM`s

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2516,67 +2516,86 @@ impl DAGCircuit {
                                     OperationRef::StandardInstruction(_),
                                 ] => Ok(other.unpack_py_op(py, inst2)?.eq(ob)? && check_args()),
                                 [OperationRef::Unitary(op_a), OperationRef::Unitary(op_b)] => {
-                                    match [&op_a.array, &op_b.array] {
-                                        [ArrayType::NDArray(a), ArrayType::NDArray(b)] => Ok(
-                                            relative_eq!(a, b, max_relative = 1e-5, epsilon = 1e-8),
-                                        ),
-                                        [ArrayType::OneQ(a), ArrayType::NDArray(b)]
-                                        | [ArrayType::NDArray(b), ArrayType::OneQ(a)] => {
-                                            if b.shape()[0] == 2 {
-                                                for i in 0..2 {
-                                                    for j in 0..2 {
-                                                        if !relative_eq!(
-                                                            b[[i, j]],
-                                                            a[(i, j)],
-                                                            max_relative = 1e-5,
-                                                            epsilon = 1e-8
-                                                        ) {
-                                                            return Ok(false);
+                                    if check_args() {
+                                        match [&op_a.array, &op_b.array] {
+                                            [ArrayType::NDArray(a), ArrayType::NDArray(b)] => {
+                                                Ok(relative_eq!(
+                                                    a,
+                                                    b,
+                                                    max_relative = 1e-5,
+                                                    epsilon = 1e-8
+                                                ))
+                                            }
+                                            [ArrayType::OneQ(a), ArrayType::NDArray(b)]
+                                            | [ArrayType::NDArray(b), ArrayType::OneQ(a)] => {
+                                                if b.shape()[0] == 2 {
+                                                    for i in 0..2 {
+                                                        for j in 0..2 {
+                                                            if !relative_eq!(
+                                                                b[[i, j]],
+                                                                a[(i, j)],
+                                                                max_relative = 1e-5,
+                                                                epsilon = 1e-8
+                                                            ) {
+                                                                return Ok(false);
+                                                            }
                                                         }
                                                     }
+                                                    Ok(true)
+                                                } else {
+                                                    Ok(false)
                                                 }
-                                                Ok(true)
-                                            } else {
-                                                Ok(false)
                                             }
-                                        }
-                                        [ArrayType::TwoQ(a), ArrayType::NDArray(b)]
-                                        | [ArrayType::NDArray(b), ArrayType::TwoQ(a)] => {
-                                            if b.shape()[0] == 4 {
-                                                for i in 0..4 {
-                                                    for j in 0..4 {
-                                                        if !relative_eq!(
-                                                            b[[i, j]],
-                                                            a[(i, j)],
-                                                            max_relative = 1e-5,
-                                                            epsilon = 1e-8
-                                                        ) {
-                                                            return Ok(false);
+                                            [ArrayType::TwoQ(a), ArrayType::NDArray(b)]
+                                            | [ArrayType::NDArray(b), ArrayType::TwoQ(a)] => {
+                                                if b.shape()[0] == 4 {
+                                                    for i in 0..4 {
+                                                        for j in 0..4 {
+                                                            if !relative_eq!(
+                                                                b[[i, j]],
+                                                                a[(i, j)],
+                                                                max_relative = 1e-5,
+                                                                epsilon = 1e-8
+                                                            ) {
+                                                                return Ok(false);
+                                                            }
                                                         }
                                                     }
+                                                    Ok(true)
+                                                } else {
+                                                    Ok(false)
                                                 }
-                                                Ok(true)
-                                            } else {
-                                                Ok(false)
                                             }
+                                            [ArrayType::OneQ(a), ArrayType::OneQ(b)] => {
+                                                Ok(relative_eq!(
+                                                    a,
+                                                    b,
+                                                    max_relative = 1e-5,
+                                                    epsilon = 1e-8
+                                                ))
+                                            }
+                                            [ArrayType::TwoQ(a), ArrayType::TwoQ(b)] => {
+                                                Ok(relative_eq!(
+                                                    a,
+                                                    b,
+                                                    max_relative = 1e-5,
+                                                    epsilon = 1e-8
+                                                ))
+                                            }
+                                            _ => Ok(false),
                                         }
-                                        [ArrayType::OneQ(a), ArrayType::OneQ(b)] => Ok(
-                                            relative_eq!(a, b, max_relative = 1e-5, epsilon = 1e-8),
-                                        ),
-                                        [ArrayType::TwoQ(a), ArrayType::TwoQ(b)] => Ok(
-                                            relative_eq!(a, b, max_relative = 1e-5, epsilon = 1e-8),
-                                        ),
-                                        _ => Ok(false),
+                                    } else {
+                                        Ok(false)
                                     }
                                 }
                                 [
                                     OperationRef::PauliProductMeasurement(op_a),
                                     OperationRef::PauliProductMeasurement(op_b),
-                                ] => Ok(op_a == op_b),
+                                ] => Ok((op_a == op_b) && check_args()),
                                 [
                                     OperationRef::PauliProductRotation(op_a),
                                     OperationRef::PauliProductRotation(op_b),
-                                ] => Ok(op_a == op_b),
+                                ] => Ok((op_a == op_b) && check_args()),
                                 _ => Ok(false),
                             }
                         }

--- a/releasenotes/notes/fix-dag-circuit-equality-c84ad3d15f613810.yaml
+++ b/releasenotes/notes/fix-dag-circuit-equality-c84ad3d15f613810.yaml
@@ -6,5 +6,3 @@ fixes:
     :class:`.PauliProductRotationGate`, or :class:`.PauliProductMeasurement`
     acting on the same qubits in different orders would incorrectly compare as
     equal.
-
-    See `#15019 <https://github.com/Qiskit/qiskit/issues/15019>`__.

--- a/releasenotes/notes/fix-dag-circuit-equality-c84ad3d15f613810.yaml
+++ b/releasenotes/notes/fix-dag-circuit-equality-c84ad3d15f613810.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`~.QuantumCircuit` and :class:`.DAGCircuit` equality
+    where circuits containing the same :class:`~.UnitaryGate`, 
+    :class:`.PauliProductRotationGate`, or :class:`.PauliProductMeasurement`
+    acting on the same qubits in different orders would incorrectly compare as
+    equal.
+
+    See `#15019 <https://github.com/Qiskit/qiskit/issues/15019>`__.

--- a/test/python/circuit/library/test_pauli_product_rotation.py
+++ b/test/python/circuit/library/test_pauli_product_rotation.py
@@ -91,12 +91,12 @@ class TestPauliProductRotationGate(QiskitTestCase):
         qc1.append(PauliProductRotationGate(Pauli("XX"), angle=1.2), [0, 1])
 
         qc2 = QuantumCircuit(2)
-        qc2.append(PauliProductRotationGate(Pauli("XX"), angle=1.2), [1, 0])
-        self.assertEqual(qc1, qc2)
+        qc2.append(PauliProductRotationGate(Pauli("XZ"), angle=1.2), [0, 1])
+        self.assertNotEqual(qc1, qc2)
 
         qc3 = QuantumCircuit(2)
-        qc3.append(PauliProductRotationGate(Pauli("XZ"), angle=1.2), [0, 1])
-        self.assertNotEqual(qc1, qc3)
+        qc3.append(PauliProductRotationGate(Pauli("XZ"), angle=1.2), [1, 0])
+        self.assertNotEqual(qc2, qc3)
 
     @data("iX", "-iX")
     def test_invalid_phase(self, pauli):

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -58,7 +58,12 @@ from qiskit.circuit.library import (
     U1Gate,
     RXGate,
     CSGate,
+    CHGate,
+    UnitaryGate,
+    PauliProductRotationGate,
+    PauliProductMeasurement,
 )
+from qiskit.quantum_info import Pauli
 from qiskit.converters import circuit_to_dag
 from test import QiskitTestCase
 
@@ -2036,6 +2041,47 @@ class TestDagEquivalence(DAGTest):
         dag2 = circuit_to_dag(circ2)
 
         self.assertNotEqual(self.dag1, dag2)
+
+    def test_dag_neq_reversed_unitary(self):
+        """Test that reversing the order of qubits of a unitary gate leads to a different circuit."""
+        unitary = UnitaryGate(CHGate())
+
+        qc1 = QuantumCircuit(4)
+        qc1.append(unitary, [0, 1])
+
+        qc2 = QuantumCircuit(4)
+        qc2.append(unitary, [1, 0])
+
+        self.assertNotEqual(qc1, qc2)
+        self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
+    def test_dag_neq_reversed_ppr(self):
+        """Test that reversing the order of qubits of a PPR gate leads to a different
+        circuit."""
+        ppr = PauliProductRotationGate(Pauli("ZX"), 0.1)
+
+        qc1 = QuantumCircuit(4)
+        qc1.append(ppr, [0, 1])
+
+        qc2 = QuantumCircuit(4)
+        qc2.append(ppr, [1, 0])
+
+        self.assertNotEqual(qc1, qc2)
+        self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
+    def test_dag_neq_reversed_ppm(self):
+        """Test that reversing the order of qubits of a PPM instruction leads to a different
+        circuit."""
+        ppm = PauliProductMeasurement(Pauli("ZX"))
+
+        qc1 = QuantumCircuit(4, 1)
+        qc1.append(ppm, [0, 1], [0])
+
+        qc2 = QuantumCircuit(4, 1)
+        qc2.append(ppm, [1, 0], [0])
+
+        self.assertNotEqual(qc1, qc2)
+        self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
 
     def test_node_params_equal_unequal(self):
         """Test node params are equal or unequal."""

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -813,59 +813,58 @@ class TestLitinskiTransformation(QiskitTestCase):
         circuit_target.compose(circuit, [0, 1], inplace=True)
         self.assertEqual(circuit_out, circuit_target)
 
-    @data("ppm", "ppr")
-    def test_litinski_with_ppr_ppm_input(self, pp_type):
+    @combine(pp_type=["ppm", "ppr"], seed=list(range(5678, 5688)))
+    def test_litinski_with_ppr_ppm_input(self, pp_type, seed):
         """Test that LitinskiTransformation is correct for PPR/PPM as input"""
         num_qubits = 5
         qarg_paulis = [1, 2, 4]
 
-        for seed in range(5678, 5688):
-            cliff = random_clifford_circuit(num_qubits, num_gates=20, seed=1234)
-            pauli = random_pauli(len(qarg_paulis), seed=5680)
+        cliff = random_clifford_circuit(num_qubits, num_gates=20, seed=1234)
+        pauli = random_pauli(len(qarg_paulis), seed=5680)
 
-            # pad the original pauli
-            p = pauli.to_label()
-            p_pad = Pauli(p[0] + "I" + p[1] + p[2] + "I")
+        # pad the original pauli
+        p = pauli.to_label()
+        p_pad = Pauli(p[0] + "I" + p[1] + p[2] + "I")
 
-            pauli_ev = p_pad.evolve(cliff)
-            # unpad the evolved pauli
-            q = pauli_ev.to_label()
-            phase = 0
-            if q[0] == "-":
-                q = q[1:]
-                phase = 2
-            out_str = ""
-            out_ind = []
-            for i in range(num_qubits):
-                j = num_qubits - i - 1
-                if q[j] != "I":
-                    out_str += q[j]
-                    out_ind.append(num_qubits - 1 - j)
-            out_ev = Pauli(out_str[::-1])
-            out_ev.phase = phase
+        pauli_ev = p_pad.evolve(cliff)
+        # unpad the evolved pauli
+        q = pauli_ev.to_label()
+        phase = 0
+        if q[0] == "-":
+            q = q[1:]
+            phase = 2
+        out_str = ""
+        out_ind = []
+        for i in range(num_qubits):
+            j = num_qubits - i - 1
+            if q[j] != "I":
+                out_str += q[j]
+                out_ind.append(num_qubits - 1 - j)
+        out_ev = Pauli(out_str[::-1])
+        out_ev.phase = phase
 
-            if pp_type == "ppr":
-                circuit = QuantumCircuit(num_qubits)
-                circuit.compose(cliff, range(num_qubits), inplace=True)
-                circuit.append(PauliProductRotationGate(pauli, angle=0.123), qarg_paulis)
-            else:  # pp_type == "ppm"
-                circuit = QuantumCircuit(num_qubits, 1)
-                circuit.compose(cliff, range(num_qubits), inplace=True)
-                circuit.append(PauliProductMeasurement(pauli), qarg_paulis, [0])
+        if pp_type == "ppr":
+            circuit = QuantumCircuit(num_qubits)
+            circuit.compose(cliff, range(num_qubits), inplace=True)
+            circuit.append(PauliProductRotationGate(pauli, angle=0.123), qarg_paulis)
+        else:  # pp_type == "ppm"
+            circuit = QuantumCircuit(num_qubits, 1)
+            circuit.compose(cliff, range(num_qubits), inplace=True)
+            circuit.append(PauliProductMeasurement(pauli), qarg_paulis, [0])
 
-            transform = LitinskiTransformation(fix_clifford=True, use_ppr=True)
-            circuit_out = transform(circuit)
+        transform = LitinskiTransformation(fix_clifford=True, use_ppr=True)
+        circuit_out = transform(circuit)
 
-            if pp_type == "ppr":
-                circuit_target = QuantumCircuit(num_qubits)
-                circuit_target.append(PauliProductRotationGate(out_ev, angle=0.123), out_ind)
-                circuit_target.compose(cliff, range(num_qubits), inplace=True)
-            else:  # pp_type == "ppm"
-                circuit_target = QuantumCircuit(num_qubits, 1)
-                circuit_target.append(PauliProductMeasurement(out_ev), out_ind, [0])
-                circuit_target.compose(cliff, range(num_qubits), inplace=True)
+        if pp_type == "ppr":
+            circuit_target = QuantumCircuit(num_qubits)
+            circuit_target.append(PauliProductRotationGate(out_ev, angle=0.123), out_ind)
+            circuit_target.compose(cliff, range(num_qubits), inplace=True)
+        else:  # pp_type == "ppm"
+            circuit_target = QuantumCircuit(num_qubits, 1)
+            circuit_target.append(PauliProductMeasurement(out_ev), out_ind, [0])
+            circuit_target.compose(cliff, range(num_qubits), inplace=True)
 
-            self.assertEqual(circuit_out, circuit_target)
+        self.assertEqual(circuit_out, circuit_target)
 
     def test_litinski_with_clifford_ppr_pi2_angle(self):
         """Test that LitinskiTransformation is does not change the gates for Clifford and PPR input with pi/2 angle"""

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -808,50 +808,54 @@ class TestLitinskiTransformation(QiskitTestCase):
         """Test that LitinskiTransformation is correct for PPR/PPM as input"""
         num_qubits = 5
         qarg_paulis = [1, 2, 4]
-        cliff = random_clifford_circuit(num_qubits, num_gates=20, seed=1234)
-        pauli = random_pauli(len(qarg_paulis), seed=5678)
 
-        # pad the original pauli
-        p = pauli.to_label()
-        p_pad = Pauli(p[0] + "I" + p[1] + p[2] + "I")
-        pauli_ev = p_pad.evolve(cliff)
-        # unpad the evolved pauli
-        q = pauli_ev.to_label()
-        phase = 0
-        if q[0] == "-":
-            q = q[1:]
-            phase = 2
-        out_str = ""
-        out_ind = []
-        for i in range(num_qubits):
-            if q[i] != "I":
-                out_str += q[i]
-                out_ind.append(num_qubits - i - 1)
-        out_ev = Pauli(out_str)
-        out_ev.phase = phase
+        for seed in range(5678, 5688):
+            cliff = random_clifford_circuit(num_qubits, num_gates=20, seed=1234)
+            pauli = random_pauli(len(qarg_paulis), seed=5680)
 
-        if pp_type == "ppr":
-            circuit = QuantumCircuit(num_qubits)
-            circuit.compose(cliff, range(num_qubits), inplace=True)
-            circuit.append(PauliProductRotationGate(pauli, angle=0.123), qarg_paulis)
-        else:  # pp_type == "ppm"
-            circuit = QuantumCircuit(num_qubits, 1)
-            circuit.compose(cliff, range(num_qubits), inplace=True)
-            circuit.append(PauliProductMeasurement(pauli), qarg_paulis, [0])
+            # pad the original pauli
+            p = pauli.to_label()
+            p_pad = Pauli(p[0] + "I" + p[1] + p[2] + "I")
 
-        transform = LitinskiTransformation(fix_clifford=True, use_ppr=True)
-        circuit_out = transform(circuit)
+            pauli_ev = p_pad.evolve(cliff)
+            # unpad the evolved pauli
+            q = pauli_ev.to_label()
+            phase = 0
+            if q[0] == "-":
+                q = q[1:]
+                phase = 2
+            out_str = ""
+            out_ind = []
+            for i in range(num_qubits):
+                j = num_qubits - i - 1
+                if q[j] != "I":
+                    out_str += q[j]
+                    out_ind.append(num_qubits - 1 - j)
+            out_ev = Pauli(out_str[::-1])
+            out_ev.phase = phase
 
-        if pp_type == "ppr":
-            circuit_target = QuantumCircuit(num_qubits)
-            circuit_target.append(PauliProductRotationGate(out_ev, angle=0.123), out_ind)
-            circuit_target.compose(cliff, range(num_qubits), inplace=True)
-        else:  # pp_type == "ppm"
-            circuit_target = QuantumCircuit(num_qubits, 1)
-            circuit_target.append(PauliProductMeasurement(out_ev), out_ind, [0])
-            circuit_target.compose(cliff, range(num_qubits), inplace=True)
+            if pp_type == "ppr":
+                circuit = QuantumCircuit(num_qubits)
+                circuit.compose(cliff, range(num_qubits), inplace=True)
+                circuit.append(PauliProductRotationGate(pauli, angle=0.123), qarg_paulis)
+            else:  # pp_type == "ppm"
+                circuit = QuantumCircuit(num_qubits, 1)
+                circuit.compose(cliff, range(num_qubits), inplace=True)
+                circuit.append(PauliProductMeasurement(pauli), qarg_paulis, [0])
 
-        self.assertEqual(circuit_out, circuit_target)
+            transform = LitinskiTransformation(fix_clifford=True, use_ppr=True)
+            circuit_out = transform(circuit)
+
+            if pp_type == "ppr":
+                circuit_target = QuantumCircuit(num_qubits)
+                circuit_target.append(PauliProductRotationGate(out_ev, angle=0.123), out_ind)
+                circuit_target.compose(cliff, range(num_qubits), inplace=True)
+            else:  # pp_type == "ppm"
+                circuit_target = QuantumCircuit(num_qubits, 1)
+                circuit_target.append(PauliProductMeasurement(out_ev), out_ind, [0])
+                circuit_target.compose(cliff, range(num_qubits), inplace=True)
+
+            self.assertEqual(circuit_out, circuit_target)
 
     def test_litinski_with_clifford_ppr_pi2_angle(self):
         """Test that LitinskiTransformation is does not change the gates for Clifford and PPR input with pi/2 angle"""

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -813,14 +813,14 @@ class TestLitinskiTransformation(QiskitTestCase):
         circuit_target.compose(circuit, [0, 1], inplace=True)
         self.assertEqual(circuit_out, circuit_target)
 
-    @combine(pp_type=["ppm", "ppr"], seed=list(range(5678, 5688)))
-    def test_litinski_with_ppr_ppm_input(self, pp_type, seed):
+    @combine(pp_type=["ppm", "ppr"], random_pauli_seed=list(range(5678, 5688)))
+    def test_litinski_with_ppr_ppm_input(self, pp_type, random_pauli_seed):
         """Test that LitinskiTransformation is correct for PPR/PPM as input"""
         num_qubits = 5
         qarg_paulis = [1, 2, 4]
 
         cliff = random_clifford_circuit(num_qubits, num_gates=20, seed=1234)
-        pauli = random_pauli(len(qarg_paulis), seed=5680)
+        pauli = random_pauli(len(qarg_paulis), seed=random_pauli_seed)
 
         # pad the original pauli
         p = pauli.to_label()


### PR DESCRIPTION

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Previously the `DAGCircuit.__eq__` did not take the qubit order when comparing `Unitary`, `PauliProductRotation` and `PauliProductMeasurement` variants. This led to circuits with such gates compare equal even when qubit orders are completely different. For example both code snippets below returns that the circuits are equal even if their operators are not:

```python
    unitary = UnitaryGate(CHGate())
    qc1 = QuantumCircuit(4)
    qc2 = QuantumCircuit(4)
    qc1.append(unitary, [0, 1])
    qc2.append(unitary, [1, 0])

    print(f"Circuits equal : {qc1 == qc2}")
    print(f"DAGs equal     : {circuit_to_dag(qc1) == circuit_to_dag(qc2)}")
    print(f"Operators equal: {Operator(qc1) == Operator(qc2)}")
```

or 

```python
    ppr1 = PauliProductRotationGate(Pauli("ZXY"), 0.1)
    qc1 = QuantumCircuit(4)
    qc1.append(ppr1, [0, 1, 2])
    qc2= QuantumCircuit(4)
    qc2.append(ppr1, [2, 0, 1])

    print(f"Circuits equal : {qc1 == qc2}")
    print(f"DAGs equal     : {circuit_to_dag(qc1) == circuit_to_dag(qc2)}")
    print(f"Operators equal: {Operator(qc1) == Operator(qc2)}")
```

This PR trivially fixes this by returning `True` only when `check_args` is true.

Though it is also worth noting that circuits containing `PPR("XY", [0, 1])` respectively `PPR("YX", [1, 0])` no longer compare as true, even if the two operators are equivalent. However, this is consistent with other gates, for instance circuits containing `CZ(0,1)` respectively `CZ(1, 0)` also no longer compare as equal.


### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
