### PR TITLE
Fix spurious clone on `SparsePauliOp.to_matrix(sparse=False)`

### DIFF
--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -1022,7 +1022,7 @@ pub fn to_matrix_dense<'py>(
     paulis.combine();
     let parallel = !force_serial && qiskit_util::getenv_use_multiple_threads();
     let out = paulis.to_matrix_dense(parallel);
-    Ok(PyArray2::from_array(py, &out))
+    Ok(PyArray2::from_owned_array(py, out))
 }
 
 type CSRData<T> = (Vec<Complex64>, Vec<T>, Vec<T>);

--- a/releasenotes/notes/sparsepauliop-dense-matrix-b0f745b9c0e50e93.yaml
+++ b/releasenotes/notes/sparsepauliop-dense-matrix-b0f745b9c0e50e93.yaml
@@ -1,0 +1,5 @@
+---
+performance:
+  - |
+    :meth:`.SparsePauliOp.to_matrix` in dense mode no longer spuriously copies the output matrix on
+    return.

--- a/releasenotes/notes/sparsepauliop-dense-matrix-b0f745b9c0e50e93.yaml
+++ b/releasenotes/notes/sparsepauliop-dense-matrix-b0f745b9c0e50e93.yaml
@@ -1,5 +1,5 @@
 ---
-performance:
+fixes:
   - |
-    :meth:`.SparsePauliOp.to_matrix` in dense mode no longer spuriously copies the output matrix on
-    return.
+    Fix a performance regression in :meth:`.SparsePauliOp.to_matrix` for dense outputs introduced in
+    v2.5, where the output was copied unnecessarily.


### PR DESCRIPTION
We always own the array; there was never a need to clone out to Python space.  The actual performance improvement varies a lot depending on the workload, the parallelism in the algorithm, and performance of the memory allocator.  The clone was always done single-threaded previously, so speedups in excess of 2x are quite reasonable.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
