### PR TITLE
speed up case of `BasePauli._evolve_clifford`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -295,7 +295,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self.copy()._append_circuit(other.inverse(), qargs=qargs)
 
     def _evolve_clifford(self, other, qargs=None, frame="h"):
-        """Heisenberg picture evolution of a Pauli by a Clifford."""
+        """Evolve a Pauli by a Clifford (default is Heisenberg frame)."""
 
         if frame == "s":
             adj = other
@@ -316,17 +316,19 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         ret._z[:, qargs_] = False
 
         idx = np.concatenate((self._x[:, qargs_], self._z[:, qargs_]), axis=1)
+        # Only iterate rows of `other` selected by at least one Pauli in `self`:
+        keep = np.nonzero(idx.any(axis=0))[0]
         for idx_, row in zip(
-            idx.T,
-            PauliList.from_symplectic(z=adj.z, x=adj.x, phase=2 * adj.phase),
+            idx[:, keep].T,
+            PauliList.from_symplectic(z=adj.z[keep], x=adj.x[keep], phase=2 * adj.phase[keep]),
+            strict=True,
         ):
             # most of the logic below is to properly index if self is a PauliList (2D),
             # while not trying to index if the object is just a Pauli (1D).
-            if idx_.any():
-                if np.sum(idx_) == num_paulis:
-                    ret.compose(row, qargs=qargs, inplace=True)
-                else:
-                    ret[idx_] = ret[idx_].compose(row, qargs=qargs)
+            if np.sum(idx_) == num_paulis:
+                ret.compose(row, qargs=qargs, inplace=True)
+            else:
+                ret[idx_] = ret[idx_].compose(row, qargs=qargs)
 
         return ret
 

--- a/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
@@ -1,0 +1,6 @@
+---
+performance:
+  - The methods :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are now significantly
+   faster in the specific case where 1) `other` is a :class:`.Clifford`, 2) `frame` is
+   `'s'` (Schrodinger), and 3) the object being evolved has non-identity support on only
+   a small fraction of its qubits.

--- a/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
@@ -1,6 +1,6 @@
 ---
 performance:
-  - The methods :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are now significantly
-   faster in the specific case where 1) `other` is a :class:`.Clifford`, 2) `frame` is
-   `'s'` (Schrodinger), and 3) the object being evolved has non-identity support on only
-   a small fraction of its qubits.
+  - |
+    The methods :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are now significantly
+    faster at Schrödinger-frame evolution by a :class:`.Clifford` when the Paulis have few
+    non-identity terms. See `#16835 <https://github.com/Qiskit/qiskit/pull/16835>`__.


### PR DESCRIPTION
This PR speeds up the existing `BasePauli._evolve_clifford` for the case of evolving a Pauli/PauliList with identity on most qubits, by a many-qubit Clifford.

This matters e.g. any time we want to evolve a few-qubit Pauli by a many-qubit Clifford, since we must first expand the Pauli with many identities before calling evolve. [Example](https://github.com/Qiskit/pauli-prop/blob/7074643b89c8c7ddb33e8ca8a43f2b10d4d092b7/python/pauli_prop/propagation.py#L111-L122).

Without this PR, the code loops in Python over all rows of the Clifford, building an individual `Pauli` object for each before checking whether that row should be applied ([idx_.any()](https://github.com/Qiskit/qiskit/blob/4e0f21adda3273ecc74807a51827da480220b230/qiskit/quantum_info/operators/symplectic/base_pauli.py#L325)). If `self` has support on only a few qubits, `idx_.any()` returns `False` most of the time, such that most of the python-loop iterations are no-ops, and the `Pauli` created by each `PauliList.__getitem__` is usually never used.

This PR moves the `any()` call outside of the loop (further vectorizing it), and then python-loops over only the necessary rows of `Clifford`, which can be significantly faster.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [X] Some submitted code was generated by: Claude Opus 4.8

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
