### PR TITLE
Fix split_layers description in CollectCliffords

### DIFF
--- a/qiskit/transpiler/passes/optimization/collect_cliffords.py
+++ b/qiskit/transpiler/passes/optimization/collect_cliffords.py
@@ -50,8 +50,8 @@ class CollectCliffords(CollectAndCollapse):
                 over disjoint qubit subsets.
             min_block_size (int): specifies the minimum number of gates in the block
                 for the block to be collected.
-            split_layers (bool): if True, splits collected blocks into sub-blocks
-                over disjoint qubit subsets.
+            split_layers (bool): if True, splits collected blocks into layers of
+                non-overlapping instructions (depth-1 sub-blocks).
             collect_from_back (bool): specifies if blocks should be collected started
                 from the end of the circuit.
             matrix_based (bool): specifies whether to collect unitary gates


### PR DESCRIPTION
Fix #16833

It uupdates the `split_layers` argument description in `CollectCliffords` to clarify that collected blocks are split into layers of non-overlapping instructions, in other words, depth-1 sub-blocks.

Validation:
- `python -m compileall qiskit/transpiler/passes/optimization/collect_cliffords.py`

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [X] Some written text was generated by: Claude
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
