### PR TITLE
[WIP] Port `QFTGate` to Rust.

### DIFF
--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -23,6 +23,7 @@ use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::{PyResult, intern};
 
 use crate::circuit_data::{CircuitData, PyCircuitData};
+use crate::custom_operations::QFTGate;
 use crate::dag_circuit::DAGCircuit;
 use crate::duration::Duration;
 use crate::imports::{CONTROLLED_GATE, WARNINGS_WARN};
@@ -849,6 +850,20 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
                         label: extract_label()?,
                     });
                 };
+            }
+        } else if ob_name == "qft" {
+            // ToDo:
+            // 1. How should we check that this is a real QFTGate and not just some other gate also called "QFT"?
+            // 2. How should we handle subclasses of QFTGate gates (coming from Python)?
+            if extract_label()?.is_none() {
+                let num_qubits = ob.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+                return Ok(OperationFromPython {
+                    operation: PackedOperation::from_custom_operation(Box::new(QFTGate::new(
+                        num_qubits,
+                    ))),
+                    params: None,
+                    label: None,
+                });
             }
         } else if ob_name == "pauli_product_measurement" {
             let z = ob

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -815,118 +815,136 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
 
         // We need to check by name here to avoid a circular import during initial loading
         let ob_name = ob.getattr(intern!(py, "name"))?.extract::<String>()?;
-        if ob_name == "unitary" {
-            let params: SmallVec<[Param; 3]> = get_params()?.extract()?;
-            if let Some(Param::Obj(data)) = params.first() {
-                let py_matrix: PyReadonlyArray2<Complex64> = data.extract(py)?;
-                let matrix: Option<MatrixView2<Complex64, Dyn, Dyn>> = py_matrix.try_as_matrix();
-                if let Some(x) = matrix {
-                    let unitary_gate = Box::new(UnitaryGate {
-                        array: ArrayType::OneQ(x.into_owned()),
-                    });
+        match ob_name.as_str() {
+            "unitary" => {
+                let params: SmallVec<[Param; 3]> = get_params()?.extract()?;
+                if let Some(Param::Obj(data)) = params.first() {
+                    let py_matrix: PyReadonlyArray2<Complex64> = data.extract(py)?;
+                    let matrix: Option<MatrixView2<Complex64, Dyn, Dyn>> =
+                        py_matrix.try_as_matrix();
+                    if let Some(x) = matrix {
+                        let unitary_gate = Box::new(UnitaryGate {
+                            array: ArrayType::OneQ(x.into_owned()),
+                        });
+                        return Ok(OperationFromPython {
+                            operation: PackedOperation::from_unitary(unitary_gate),
+                            params: None,
+                            label: extract_label()?,
+                        });
+                    }
+                    let matrix: Option<MatrixView4<Complex64, Dyn, Dyn>> =
+                        py_matrix.try_as_matrix();
+                    if let Some(x) = matrix {
+                        let unitary_gate = Box::new(UnitaryGate {
+                            array: ArrayType::TwoQ(x.into_owned()),
+                        });
+                        return Ok(OperationFromPython {
+                            operation: PackedOperation::from_unitary(unitary_gate),
+                            params: None,
+                            label: extract_label()?,
+                        });
+                    } else {
+                        let unitary_gate = Box::new(UnitaryGate {
+                            array: ArrayType::NDArray(py_matrix.as_array().to_owned()),
+                        });
+                        return Ok(OperationFromPython {
+                            operation: PackedOperation::from_unitary(unitary_gate),
+                            params: None,
+                            label: extract_label()?,
+                        });
+                    };
+                }
+            }
+            "qft" => 'qft: {
+                // ToDo: should we handle subclasses of QFTGate gates (coming from Python)?
+
+                // To ensure that this is a real QFT gate from Python and not some other custom gate also named "qft",
+                // the Python QFT gates have a `_is_rust_custom_operation` field at the class level so we can
+                // quickly identify them here without an `isinstance` check.
+                let is_qft = ob_type
+                    .getattr(intern!(py, "_is_rust_custom_operation"))
+                    .ok()
+                    .and_then(|marker| marker.extract::<bool>().ok())
+                    .unwrap_or(false);
+                if !is_qft {
+                    break 'qft;
+                }
+                if extract_label()?.is_none() {
+                    let num_qubits = ob.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
                     return Ok(OperationFromPython {
-                        operation: PackedOperation::from_unitary(unitary_gate),
+                        operation: PackedOperation::from_custom_operation(Box::new(QFTGate::new(
+                            num_qubits,
+                        ))),
                         params: None,
-                        label: extract_label()?,
+                        label: None,
                     });
                 }
-                let matrix: Option<MatrixView4<Complex64, Dyn, Dyn>> = py_matrix.try_as_matrix();
-                if let Some(x) = matrix {
-                    let unitary_gate = Box::new(UnitaryGate {
-                        array: ArrayType::TwoQ(x.into_owned()),
-                    });
-                    return Ok(OperationFromPython {
-                        operation: PackedOperation::from_unitary(unitary_gate),
-                        params: None,
-                        label: extract_label()?,
-                    });
-                } else {
-                    let unitary_gate = Box::new(UnitaryGate {
-                        array: ArrayType::NDArray(py_matrix.as_array().to_owned()),
-                    });
-                    return Ok(OperationFromPython {
-                        operation: PackedOperation::from_unitary(unitary_gate),
-                        params: None,
-                        label: extract_label()?,
-                    });
-                };
             }
-        } else if ob_name == "qft" {
-            // ToDo:
-            // 1. How should we check that this is a real QFTGate and not just some other gate also called "QFT"?
-            // 2. How should we handle subclasses of QFTGate gates (coming from Python)?
-            if extract_label()?.is_none() {
-                let num_qubits = ob.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+            "pauli_product_measurement" => {
+                let z = ob
+                    .getattr(intern!(py, "_pauli_z"))?
+                    .extract::<PyReadonlyArray1<bool>>()?
+                    .as_slice()?
+                    .to_vec();
+
+                let x = ob
+                    .getattr(intern!(py, "_pauli_x"))?
+                    .extract::<PyReadonlyArray1<bool>>()?
+                    .as_slice()?
+                    .to_vec();
+
+                let phase = ob.getattr(intern!(py, "_pauli_phase"))?.extract::<u8>()?;
+
+                let pauli_product_measurement = PauliProductMeasurement {
+                    z: z.to_owned(),
+                    x: x.to_owned(),
+                    neg: phase == 2, // phase is only 0 (represents 1) or 2 (represents -1)
+                };
+                let pbc = Box::new(PauliBased::PauliProductMeasurement(
+                    pauli_product_measurement,
+                ));
+
                 return Ok(OperationFromPython {
-                    operation: PackedOperation::from_custom_operation(Box::new(QFTGate::new(
-                        num_qubits,
-                    ))),
+                    operation: PackedOperation::from_pauli_based(pbc),
                     params: None,
-                    label: None,
+                    label: extract_label()?,
                 });
             }
-        } else if ob_name == "pauli_product_measurement" {
-            let z = ob
-                .getattr(intern!(py, "_pauli_z"))?
-                .extract::<PyReadonlyArray1<bool>>()?
-                .as_slice()?
-                .to_vec();
+            "pauli_product_rotation" => {
+                let z = ob
+                    .getattr(intern!(py, "_pauli_z"))?
+                    .extract::<PyReadonlyArray1<bool>>()?
+                    .as_slice()?
+                    .to_vec();
 
-            let x = ob
-                .getattr(intern!(py, "_pauli_x"))?
-                .extract::<PyReadonlyArray1<bool>>()?
-                .as_slice()?
-                .to_vec();
+                let x = ob
+                    .getattr(intern!(py, "_pauli_x"))?
+                    .extract::<PyReadonlyArray1<bool>>()?
+                    .as_slice()?
+                    .to_vec();
 
-            let phase = ob.getattr(intern!(py, "_pauli_phase"))?.extract::<u8>()?;
+                let py_angle = get_params()?.get_item(0)?;
+                let angle = Param::extract(py_angle.as_borrowed())?;
+                if matches!(angle, Param::Obj(_)) {
+                    return Err(PyTypeError::new_err(
+                        "invalid type for angle in PauliProductRotation",
+                    ));
+                }
 
-            let pauli_product_measurement = PauliProductMeasurement {
-                z: z.to_owned(),
-                x: x.to_owned(),
-                neg: phase == 2, // phase is only 0 (represents 1) or 2 (represents -1)
-            };
-            let pbc = Box::new(PauliBased::PauliProductMeasurement(
-                pauli_product_measurement,
-            ));
+                let pauli_rotation = PauliProductRotation {
+                    z: z.to_owned(),
+                    x: x.to_owned(),
+                    angle: angle.clone(),
+                };
+                let pbc = Box::new(PauliBased::PauliProductRotation(pauli_rotation));
 
-            return Ok(OperationFromPython {
-                operation: PackedOperation::from_pauli_based(pbc),
-                params: None,
-                label: extract_label()?,
-            });
-        } else if ob_name == "pauli_product_rotation" {
-            let z = ob
-                .getattr(intern!(py, "_pauli_z"))?
-                .extract::<PyReadonlyArray1<bool>>()?
-                .as_slice()?
-                .to_vec();
-
-            let x = ob
-                .getattr(intern!(py, "_pauli_x"))?
-                .extract::<PyReadonlyArray1<bool>>()?
-                .as_slice()?
-                .to_vec();
-
-            let py_angle = get_params()?.get_item(0)?;
-            let angle = Param::extract(py_angle.as_borrowed())?;
-            if matches!(angle, Param::Obj(_)) {
-                return Err(PyTypeError::new_err(
-                    "invalid type for angle in PauliProductRotation",
-                ));
+                return Ok(OperationFromPython {
+                    operation: PackedOperation::from_pauli_based(pbc),
+                    params: Some(Parameters::Params(smallvec![angle])),
+                    label: extract_label()?,
+                });
             }
-
-            let pauli_rotation = PauliProductRotation {
-                z: z.to_owned(),
-                x: x.to_owned(),
-                angle: angle.clone(),
-            };
-            let pbc = Box::new(PauliBased::PauliProductRotation(pauli_rotation));
-
-            return Ok(OperationFromPython {
-                operation: PackedOperation::from_pauli_based(pbc),
-                params: Some(Parameters::Params(smallvec![angle])),
-                label: extract_label()?,
-            });
+            _ => {}
         }
 
         let Some(kind) = PyOpKind::from_type(ob_type.as_borrowed())? else {

--- a/crates/circuit/src/custom_operations.rs
+++ b/crates/circuit/src/custom_operations.rs
@@ -1,0 +1,98 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use ndarray::Array2;
+use num_complex::Complex64;
+use pyo3::prelude::*;
+use smallvec::SmallVec;
+use std::f64::consts::PI;
+
+use crate::imports;
+use crate::operations::{CustomOperation, Operation, Param};
+
+/// The Quantum Fourier Transform Gate.
+///
+/// On `n` qubits this is the operation
+///
+/// ```text
+/// |j> -> 1/sqrt(2^n) * sum_k exp(2 pi i j k / 2^n) |k>
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QFTGate {
+    num_qubits: u32,
+}
+
+impl QFTGate {
+    pub fn new(num_qubits: u32) -> Self {
+        Self { num_qubits }
+    }
+
+    /// The number of qubits the QFT acts on.
+    pub fn num_qubits(&self) -> u32 {
+        self.num_qubits
+    }
+}
+
+impl Operation for QFTGate {
+    fn name(&self) -> &str {
+        "qft"
+    }
+
+    fn num_qubits(&self) -> u32 {
+        self.num_qubits
+    }
+
+    fn num_clbits(&self) -> u32 {
+        0
+    }
+
+    fn num_params(&self) -> u32 {
+        0
+    }
+
+    fn directive(&self) -> bool {
+        false
+    }
+}
+
+impl CustomOperation for QFTGate {
+    fn is_unitary(&self) -> bool {
+        true
+    }
+
+    fn matrix(&self, _params: &[Param]) -> Option<Array2<Complex64>> {
+        // ToDo: should we return `None` if the number of qubits is too large?
+        // This would also prevent overflow errors when computing 1 << num_qubits.
+        let size = 1usize << self.num_qubits;
+        let norm = 0.5_f64.powi(size as i32);
+        Some(Array2::from_shape_fn((size, size), |(i, j)| {
+            let phase = 2.0 * PI * (i * j) as f64 / (size as f64);
+            Complex64::from_polar(norm, phase)
+        }))
+    }
+
+    fn create_py_op(
+        &self,
+        py: Python,
+        _params: Option<SmallVec<[Param; 3]>>,
+        _label: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        Ok(imports::QFT_GATE
+            .get_bound(py)
+            .call1((self.num_qubits,))?
+            .unbind())
+    }
+
+    // ToDo:
+    // Due to dependency between rust packages, we cannot take the definition from the synthesis
+    // crate. Should we implement the textbook synthesis method here or leave it as None?
+}

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2577,6 +2577,10 @@ impl DAGCircuit {
                                     OperationRef::PauliProductRotation(op_a),
                                     OperationRef::PauliProductRotation(op_b),
                                 ] => Ok(op_a == op_b),
+                                [
+                                    OperationRef::CustomOperation(op_a),
+                                    OperationRef::CustomOperation(op_b),
+                                ] => Ok((op_a == op_b) && check_args()),
                                 _ => Ok(false),
                             }
                         }
@@ -2744,6 +2748,9 @@ impl DAGCircuit {
                 (OperationRef::Unitary(left), OperationRef::Unitary(right)) => Ok(left == right),
                 (OperationRef::PyCustom(left), OperationRef::PyCustom(right)) => {
                     Python::attach(|py| left.ob.bind(py).eq(&right.ob))
+                }
+                (OperationRef::CustomOperation(left), OperationRef::CustomOperation(right)) => {
+                    Ok(left == right)
                 }
                 _ => Ok(false),
             }

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -92,6 +92,8 @@ pub static UNITARY_GATE: ImportOnceCell = ImportOnceCell::new(
     "qiskit.circuit.library.generalized_gates.unitary",
     "UnitaryGate",
 );
+pub static QFT_GATE: ImportOnceCell =
+    ImportOnceCell::new("qiskit.circuit.library.basis_change.qft", "QFTGate");
 pub static PAULI_PRODUCT_ROTATION_GATE: ImportOnceCell = ImportOnceCell::new(
     "qiskit.circuit.library.generalized_gates.pauli_product_rotation",
     "PauliProductRotationGate",

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -14,7 +14,6 @@ use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
 use ndarray::Array2;
 use num_complex::Complex64;
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use smallvec::SmallVec;
 
@@ -166,6 +165,7 @@ pub trait Instruction {
             OperationRef::PyCustom(i) => i.matrix(),
             OperationRef::Unitary(u) => u.matrix(),
             OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
+            OperationRef::CustomOperation(custom) => custom.matrix(self.params_view()),
             _ => None,
         }
     }
@@ -191,8 +191,8 @@ pub fn create_py_op(
         }
         OperationRef::PyCustom(inst) => Ok(inst.ob.clone_ref(py)),
         OperationRef::Unitary(unitary) => unitary.create_py_op(py, label),
-        OperationRef::CustomOperation(_) => Err(PyNotImplementedError::new_err(
-            "Custom operations from Rust cannot be exposed to Python",
-        )),
+        OperationRef::CustomOperation(custom) => {
+            custom.create_py_op(py, params.map(|p| p.unwrap_params()), label)
+        }
     }
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -19,6 +19,7 @@ pub mod circuit_drawer;
 pub mod circuit_instruction;
 pub mod classical;
 pub mod converters;
+pub mod custom_operations;
 pub mod dag_circuit;
 pub mod dag_node;
 mod dot_utils;

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -41,7 +41,7 @@ use num_complex::{Complex64, c64};
 use smallvec::SmallVec;
 
 use numpy::{PyArray1, PyReadonlyArray2, ToPyArray};
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyTuple, PyType};
 use pyo3::{IntoPyObjectExt, Python, intern};
@@ -2021,6 +2021,18 @@ pub trait CustomOperation:
 
     /// Returns whether the operation is based on a unitary matrix.
     fn is_unitary(&self) -> bool;
+
+    fn create_py_op(
+        &self,
+        _py: Python,
+        _params: Option<SmallVec<[Param; 3]>>,
+        _label: Option<&str>,
+    ) -> PyResult<Py<PyAny>> {
+        Err(PyNotImplementedError::new_err(format!(
+            "custom operation '{}' cannot be exposed to Python",
+            self.name()
+        )))
+    }
 }
 
 impl PartialEq for dyn CustomOperation {
@@ -2096,11 +2108,10 @@ impl From<Box<dyn CustomOperation>> for BoxedCustomOperation {
 
 #[cfg(test)]
 mod test {
+    use crate::operations::{Param, PauliProductRotation};
     use approx::assert_abs_diff_eq;
     use ndarray::{Array2, arr2, linalg::kron};
     use qiskit_util::complex::{C_ONE, C_ZERO, IM};
-
-    use crate::operations::{Param, PauliProductRotation};
 
     #[test]
     fn test_ppr_matrix() {
@@ -2140,6 +2151,7 @@ mod test {
 #[cfg(test)]
 mod test_custom_operations {
     use crate::circuit_data::CircuitData;
+    use crate::custom_operations::QFTGate;
     use crate::gate_matrix::{H_GATE, rz_gate};
     use crate::instruction::Parameters;
     use crate::operations::{CustomOperation, Operation, OperationRef, Param, StandardGate};
@@ -2577,5 +2589,46 @@ mod test_custom_operations {
             assert_eq!(op.num_params(), view.num_params());
             assert_eq!(op.directive(), view.directive());
         }
+    }
+
+    // Tests basic QFT gate properties
+    #[test]
+    fn test_qft() {
+        let qft3 = QFTGate::new(3);
+        let another_qft3 = QFTGate::new(3);
+        assert_eq!(qft3, another_qft3);
+
+        let qft4 = QFTGate::new(4);
+        assert_ne!(qft3, qft4);
+
+        let mat = qft3.matrix(&[]);
+        assert!(mat.is_some());
+    }
+
+    // Tests putting QFT gates in a circuit and retrieving them back
+    #[test]
+    fn test_qft_rountrip() {
+        let qft = QFTGate::new(4);
+
+        // Add a QFT gate to a circuit
+        let mut qc = CircuitData::with_capacity(1, 0, 1, 0.0.into())
+            .expect("Circuit with small capacity should be built.");
+        let qft_op = PackedOperation::from_custom_operation(Box::new(qft));
+        qc.push_packed_operation(qft_op, None, &[Qubit(0)], &[])
+            .expect("Instruction should be added to the circuit.");
+
+        let retrieved_op = &qc.data()[0];
+
+        let OperationRef::CustomOperation(dyn_cast_op) = retrieved_op.op.view() else {
+            panic!("Gate should be a custom operation");
+        };
+
+        let Some(downcast_op) = dyn_cast_op.downcast_ref::<QFTGate>() else {
+            panic!("Gate should be a custom gate of type QFTGate");
+        };
+
+        assert!(downcast_op.is_unitary());
+        assert_eq!(downcast_op.num_qubits(), 4);
+        assert_eq!(downcast_op, &qft);
     }
 }

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -32,6 +32,7 @@ use qiskit_circuit::bit::{
 };
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
+use qiskit_circuit::custom_operations;
 use qiskit_circuit::instruction::{Parameters, create_py_op};
 use qiskit_circuit::interner::Interned;
 use qiskit_circuit::operations::{
@@ -97,6 +98,8 @@ pub enum InstructionType {
     PauliProductRotation,
     Unitary,
     ControlFlow,
+    // covers Rust based CusomOperations
+    CustomOperation,
     // covers instruction types require resorting to python space
     Custom,
     Python,
@@ -198,6 +201,8 @@ fn recognize_instruction_type(
         || ["Barrier", "Delay", "Measure", "Reset"].contains(&name)
     {
         InstructionType::StandardInstruction
+    } else if is_custom_operation(name) {
+        InstructionType::CustomOperation
     } else if custom_instructions.get(name).is_some() {
         InstructionType::Custom
     } else {
@@ -214,6 +219,13 @@ fn recognize_instruction_type(
             InstructionType::Python
         }
     }
+}
+
+fn is_custom_operation(name: &str) -> bool {
+    // This is a placeholder function; we'll need either a list of CustomOperation names
+    // Or a better mechanism to iterate over all CustomOperations defined in qiskit.
+    // For now, compare against a hard coded list
+    ["qft"].contains(&name)
 }
 
 type InstructionBits = (Interned<[Qubit]>, Interned<[Clbit]>);
@@ -364,6 +376,7 @@ fn unpack_instruction(
         }
         InstructionType::Unitary => unpack_unitary(instruction, qpy_data)?,
         InstructionType::ControlFlow => unpack_control_flow(instruction, qpy_data)?,
+        InstructionType::CustomOperation => unpack_custom_operation(instruction, qpy_data)?,
         InstructionType::Custom => {
             unpack_custom_instruction(instruction, label.as_deref(), qpy_data, custom_instructions)?
         }
@@ -430,6 +443,27 @@ fn unpack_standard_instruction(
     Ok((op, param_values))
 }
 
+fn unpack_custom_operation(
+    instruction: &formats::CircuitInstructionV2Pack,
+    qpy_data: &mut QPYReadData,
+) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
+    // This is a placeholder implementation; in a real implementation, you would deserialize the custom operation properly.
+    // let op = PackedOperation::from_custom_operation_name(&instruction.gate_class_name);
+    let op = match instruction.gate_class_name.as_str() {
+        "qft" => PackedOperation::from_custom_operation(Box::new(custom_operations::QFTGate::new(
+            instruction.num_qargs,
+        ))),
+        _ => {
+            return Err(QpyError::InvalidInstruction(format!(
+                "Unrecognized custom operation {}",
+                instruction.gate_class_name
+            )));
+        }
+    };
+    let param_values =
+        get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
+    Ok((op, param_values))
+}
 fn unpack_pauli_product_measurement(
     instruction: &formats::CircuitInstructionV2Pack,
     qpy_data: &mut QPYReadData,

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -36,9 +36,9 @@ use qiskit_circuit::duration::Duration;
 use qiskit_circuit::imports;
 use qiskit_circuit::instruction::Parameters;
 use qiskit_circuit::operations::{
-    BoxDuration, CaseSpecifier, Condition, ControlFlow, ControlFlowInstruction, LoopParam,
-    Operation, OperationRef, Param, PauliProductMeasurement, PauliProductRotation, PyInstruction,
-    PyOpKind, StandardGate, StandardInstruction, SwitchTarget, UnitaryGate,
+    BoxDuration, CaseSpecifier, Condition, ControlFlow, ControlFlowInstruction, CustomOperation,
+    LoopParam, Operation, OperationRef, Param, PauliProductMeasurement, PauliProductRotation,
+    PyInstruction, PyOpKind, StandardGate, StandardInstruction, SwitchTarget, UnitaryGate,
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 
@@ -261,11 +261,7 @@ fn pack_instruction(
         OperationRef::ControlFlow(control_flow_inst) => {
             pack_control_flow_inst(control_flow_inst, instruction, qpy_data)?
         }
-        OperationRef::CustomOperation(_) => {
-            return Err(QpyError::SerializationError(
-                "compiled custom operations are not yet supported in QPY".to_owned(),
-            ));
-        }
+        OperationRef::CustomOperation(op) => pack_custom_operation(op, instruction, qpy_data)?,
     };
 
     // common data extraction for all instruction types
@@ -273,13 +269,15 @@ fn pack_instruction(
         instruction_pack.label = label.clone();
     }
     instruction_pack.bit_data = get_packed_bit_list(instruction, qpy_data.circuit_data);
-    if let Some(new_name) =
-        recognize_custom_operation(&instruction.op, &gate_class_name(&instruction.op)?)?
+    if !matches!(instruction.op.view(), OperationRef::CustomOperation(_))
+        && let Some(new_name) =
+            recognize_custom_operation(&instruction.op, &gate_class_name(&instruction.op)?)?
     {
         instruction_pack.gate_class_name = new_name.clone();
         new_custom_operations.push(new_name.clone());
         custom_operations.insert(new_name.clone(), instruction.op.clone());
     };
+
     Ok(instruction_pack)
 }
 
@@ -332,6 +330,30 @@ pub fn standard_instruction_class_name(inst: &StandardInstruction) -> &str {
         StandardInstruction::Measure => "Measure",
         StandardInstruction::Reset => "Reset",
     }
+}
+
+fn pack_custom_operation(
+    op: &dyn CustomOperation,
+    instruction: &PackedInstruction,
+    qpy_data: &mut QPYWriteData,
+) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
+    // This is a placeholder method; when we add more complex CustomOperations
+    // we'll need to have better handling here.
+    let params = pack_instruction_params(instruction, qpy_data)?;
+    let name = op.name().to_string();
+    Ok(formats::CircuitInstructionV2Pack {
+        num_qargs: instruction.op.num_qubits(),
+        num_cargs: instruction.op.num_clbits(),
+        extras_key: 0,
+        num_ctrl_qubits: 0,
+        ctrl_state: 0,
+        gate_class_name: name,
+        label: Default::default(),
+        condition: Default::default(),
+        bit_data: Default::default(),
+        params,
+        annotations: None,
+    })
 }
 
 fn pack_pauli_product_measurement(

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -15,7 +15,6 @@ use hashbrown::HashSet;
 use ndarray::prelude::*;
 use pyo3::Bound;
 use pyo3::IntoPyObjectExt;
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use qiskit_circuit::bit::ShareableQubit;
@@ -958,11 +957,9 @@ fn synthesize_op_using_plugins(
         OperationRef::PauliProductRotation(rotation) => {
             rotation.create_py_op(py, label)?.into_any()
         }
-        OperationRef::CustomOperation(_) => {
-            return Err(PyNotImplementedError::new_err(
-                "Custom Operations from Rust cannot be exposed to Python.",
-            ));
-        }
+        OperationRef::CustomOperation(custom) => custom
+            .create_py_op(py, Some(params.iter().cloned().collect()), label)?
+            .into_any(),
     };
 
     let res = HLS_SYNTHESIZE_OP_USING_PLUGINS

--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -290,6 +290,9 @@ class QFTGate(Gate):
 
     """
 
+    # Used from Rust to recognize that this is a QFTGate and not some other custom gate named "qft".
+    _is_rust_custom_operation = True
+
     def __init__(
         self,
         num_qubits: int,

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -269,7 +269,7 @@ class TestQFTGate(QiskitTestCase):
         qc = QuantumCircuit(5)
         qc.append(QFTGate(4), [1, 2, 0, 4])
         self.assertIsInstance(qc.data[0].operation, QFTGate)
-        self.assertEq(qc.data[0].operation, QFTGate(4))
+        self.assertEqual(qc.data[0].operation, QFTGate(4))
 
     @data(2, 3, 4, 5, 6)
     def test_circuit_with_gate_equivalent_to_original(self, num_qubits):

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -269,6 +269,7 @@ class TestQFTGate(QiskitTestCase):
         qc = QuantumCircuit(5)
         qc.append(QFTGate(4), [1, 2, 0, 4])
         self.assertIsInstance(qc.data[0].operation, QFTGate)
+        self.assertEq(qc.data[0].operation, QFTGate(4))
 
     @data(2, 3, 4, 5, 6)
     def test_circuit_with_gate_equivalent_to_original(self, num_qubits):


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

(Updated on 09/14)

This PR aims to start a discussion on how generalized operation (`QFTGate`, `MCXGate`, etc.) should be ported from Python to Rust. For simplicity I decided to start with the `QFTGate` which is only defined by its number of qubits.

The current implementation is similar to the handling of Pauli product rotations: we define a Rust variant of the QFT gate which gets stored on the `CircuitData` (instead of `PyCustom`), and where we implement translations from Rust QFT gates to Python QFT gates and vice versa.

An alternative implementation using encapsulation is given in #16991.

Some changes worth discussing:

* To identify that the Python gate is a true `QFTGate` and not just some custom gate that happens to be named "qft", I added a Python class-level field `_is_rust_custom_operation`. This is inspired by similar fields for standard gates and standard instructions, except that it can only be `True` or `False` when it exists.

* A related question to the above: how should we handle custom subclasses of `QFTGate`?


Resolved:

* No longer adding `create_py_op` to `CustomOperation` trait: as discussed, this was not the right approach.
* @gadial added an initial version of the code that supports QFTGates in QPY. We might want to rethink this with the ideas of #16793.

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
