### PR TITLE
Faster Heisenberg-frame evolution of Paulis by `Clifford`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -297,11 +297,26 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
     def _evolve_clifford(self, other, qargs=None, frame="h"):
         """Evolve a Pauli by a Clifford (default is Heisenberg frame)."""
 
-        if frame == "s":
-            adj = other
-        else:
-            adj = other.adjoint()
-
+        if frame == "h":
+            # Heisenberg evolution C^dg.P.C.
+            # Naively, would evolve by C^dg in Schrodinger frame, but getting the
+            # phase of C^dg (in `adjoint`) is expensive (N^3). Skip it for now:
+            inv = other.copy()
+            tmp = inv.destab_x.copy()
+            inv.destab_x = inv.stab_z.T
+            inv.destab_z = inv.destab_z.T
+            inv.stab_x = inv.stab_x.T
+            inv.stab_z = tmp.T
+            # We have z and x of C^dg, but not the phase.
+            ret = self._evolve_clifford(inv, qargs=qargs, frame="s")
+            # This evolution yields z, x of desired result but wrong phase.
+            # Fix answer by evolving this forward by C; excess phase after
+            # the round-trip should be subtracted from ret:
+            fwd = ret._evolve_clifford(other, qargs=qargs, frame="s")
+            ret.phase -= (fwd.phase - self.phase)
+            return ret
+        
+        # Schrodinger evolution C.P.C^dg.
         if qargs is None:
             qargs_ = slice(None)
         else:
@@ -320,7 +335,9 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         keep = np.nonzero(idx.any(axis=0))[0]
         for idx_, row in zip(
             idx[:, keep].T,
-            PauliList.from_symplectic(z=adj.z[keep], x=adj.x[keep], phase=2 * adj.phase[keep]),
+            PauliList.from_symplectic(
+                z=other.z[keep], x=other.x[keep], phase=2 * other.phase[keep]
+            ),
             strict=True,
         ):
             # most of the logic below is to properly index if self is a PauliList (2D),

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -300,7 +300,15 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         if frame == "h":
             # Heisenberg evolution C^dg.P.C.
             # Naively, would evolve by C^dg in Schrodinger frame, but getting the
-            # phase of C^dg (in `adjoint`) is expensive (N^3). Skip it for now:
+            # phase of C^dg (in `adjoint`) is expensive (N^3). Alternatively,
+            # it can be faster to compute phase via a second Schrodinger evolution,
+            # at a cost L*N^2, where L is number of Paulis in `self`. Empirically,
+            # thresholding on N <= L gave near-optimal performance across benchmarks
+            # that went up to 250 qubits.
+            if other.num_qubits <= self.z.shape[0]:
+                other = other.adjoint()
+                return self._evolve_clifford(other, qargs=qargs, frame="s")
+
             inv = other.copy()
             tmp = inv.destab_x.copy()
             inv.destab_x = inv.stab_z.T

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -295,7 +295,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self.copy()._append_circuit(other.inverse(), qargs=qargs)
 
     def _evolve_clifford(self, other, qargs=None, frame="h"):
-        """Heisenberg picture evolution of a Pauli by a Clifford."""
+        """Evolve a Pauli by a Clifford (default is Heisenberg frame)."""
 
         if frame == "s":
             adj = other
@@ -316,17 +316,19 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         ret._z[:, qargs_] = False
 
         idx = np.concatenate((self._x[:, qargs_], self._z[:, qargs_]), axis=1)
+        # Only iterate rows of `other` selected by at least one Pauli in `self`:
+        keep = np.nonzero(idx.any(axis=0))[0]
         for idx_, row in zip(
-            idx.T,
-            PauliList.from_symplectic(z=adj.z, x=adj.x, phase=2 * adj.phase),
+            idx[:, keep].T,
+            PauliList.from_symplectic(z=adj.z[keep], x=adj.x[keep], phase=2 * adj.phase[keep]),
+            strict=True,
         ):
             # most of the logic below is to properly index if self is a PauliList (2D),
             # while not trying to index if the object is just a Pauli (1D).
-            if idx_.any():
-                if np.sum(idx_) == num_paulis:
-                    ret.compose(row, qargs=qargs, inplace=True)
-                else:
-                    ret[idx_] = ret[idx_].compose(row, qargs=qargs)
+            if np.sum(idx_) == num_paulis:
+                ret.compose(row, qargs=qargs, inplace=True)
+            else:
+                ret[idx_] = ret[idx_].compose(row, qargs=qargs)
 
         return ret
 

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -305,7 +305,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
             # at a cost L*N^2, where L is number of Paulis in `self`. Empirically,
             # thresholding on N <= L gave near-optimal performance across benchmarks
             # that went up to 250 qubits.
-            if other.num_qubits <= self.z.shape[0]:
+            if other.num_qubits <= self._x.shape[0]:
                 other = other.adjoint()
                 return self._evolve_clifford(other, qargs=qargs, frame="s")
 

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -321,9 +321,9 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
             # Fix answer by evolving this forward by C; excess phase after
             # the round-trip should be subtracted from ret:
             fwd = ret._evolve_clifford(other, qargs=qargs, frame="s")
-            ret.phase -= (fwd.phase - self.phase)
+            ret.phase -= fwd.phase - self.phase
             return ret
-        
+
         # Schrodinger evolution C.P.C^dg.
         if qargs is None:
             qargs_ = slice(None)

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -299,28 +299,32 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         if frame == "h":
             # Heisenberg evolution C^dg.P.C.
-            # Naively, would evolve by C^dg in Schrodinger frame, but getting the
-            # phase of C^dg (in `adjoint`) is expensive (N^3). Alternatively,
-            # it can be faster to compute phase via a second Schrodinger evolution,
-            # at a cost L*N^2, where L is number of Paulis in `self`. Empirically,
-            # thresholding on N <= L gave near-optimal performance across benchmarks
-            # that went up to 250 qubits.
-            if other.num_qubits <= self._x.shape[0]:
-                other = other.adjoint()
+
+            # Pinning signs (phases) is expensive. We can pin the 2N signs of `C^dg`'s rows, or
+            # just the L signs of the result `(C^dg.P.C)`; pin whichever set is smaller. This
+            # simple threshold (2N vs L) was near-optimal for benchmarks up to 250 qubits.
+            if 2 * other.num_qubits <= self._x.shape[0]:
+                # Few qubits, many Paulis: Compute C^dg (pins signs) and evolve by it
+                other = other.adjoint()  # O(N^3)
                 return self._evolve_clifford(other, qargs=qargs, frame="s")
 
+            # Many qubits, few Paulis: Get result's signs by enforcing round-trip signs are +1,
+            # never paying for C^dg's signs. Build `inv` with ZX tableau of C^dg but wrong signs
+            # via the cheap part of `Clifford._conjugate_transpose` (at time of writing):
             inv = other.copy()
             tmp = inv.destab_x.copy()
             inv.destab_x = inv.stab_z.T
             inv.destab_z = inv.destab_z.T
             inv.stab_x = inv.stab_x.T
             inv.stab_z = tmp.T
-            # We have z and x of C^dg, but not the phase.
+            # Evolving by `inv` gives the correct ZX content of C^dg.P.C but wrong signs:
             ret = self._evolve_clifford(inv, qargs=qargs, frame="s")
-            # This evolution yields z, x of desired result but wrong phase.
-            # Fix answer by evolving this forward by C; excess phase after
-            # the round-trip should be subtracted from ret:
+            # Recover the signs by evolving back: C.(C^dg.P.C).C^dg = P. Since `ret`
+            # already has the right ZX content, evolving it forward reproduces P's ZX content
+            # exactly; only the signs can differ.
             fwd = ret._evolve_clifford(other, qargs=qargs, frame="s")
+            # Evolution merely adds to the phase (is linear), so `ret`'s phase error passes
+            # unchanged into `fwd`; read it off as `fwd.phase - self.phase` and subtract it:
             ret.phase -= fwd.phase - self.phase
             return ret
 

--- a/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
@@ -1,0 +1,7 @@
+---
+performance:
+  - |
+    :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are faster in the case where ``other``
+    is a :class:`.Clifford` and ``frame`` is ``'h'`` (Heisenberg). Previously this first called
+    :meth:`.Clifford.adjoint`, which is :math:`O(n^3)` in qubit number. Now the phase is instead
+    obtained via two Schrodinger-frame evolutions, which is :math:`O(n^2)`.

--- a/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
@@ -1,7 +1,9 @@
 ---
 performance:
   - |
-    :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are faster in the case where ``other``
-    is a :class:`.Clifford` and ``frame`` is ``'h'`` (Heisenberg). Previously this first called
-    :meth:`.Clifford.adjoint`, which is :math:`O(n^3)` in qubit number. Now the phase is instead
-    obtained via two Schrodinger-frame evolutions, which is :math:`O(n^2)`.
+    :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are faster for most cases where 1) ``other``
+    is a :class:`.Clifford`, 2) ``frame`` is ``'h'`` (Heisenberg), and 3) the number of qubits N in
+    the :class:`.Clifford` is smaller than the number of Paulis L being evolved. Previously this would
+    always call :meth:`.Clifford.adjoint`, which is :math:`O(N^3)`. Now when these 3 conditions are met,
+    the phase is instead obtained via a second Schrodinger-frame evolution, which is :math:`O(L N^2)`.
+    For example, this makes Heisenberg evolution of a single many-qubit Pauli much faster.

--- a/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-heis-3d2b6c1f0a4e5d7c.yaml
@@ -1,9 +1,5 @@
 ---
 performance:
   - |
-    :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are faster for most cases where 1) ``other``
-    is a :class:`.Clifford`, 2) ``frame`` is ``'h'`` (Heisenberg), and 3) the number of qubits N in
-    the :class:`.Clifford` is smaller than the number of Paulis L being evolved. Previously this would
-    always call :meth:`.Clifford.adjoint`, which is :math:`O(N^3)`. Now when these 3 conditions are met,
-    the phase is instead obtained via a second Schrodinger-frame evolution, which is :math:`O(L N^2)`.
-    For example, this makes Heisenberg evolution of a single many-qubit Pauli much faster.
+    :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are faster in many cases where ``other`` is
+    a :class:`.Clifford` and ``frame`` is ``'h'`` (Heisenberg).

--- a/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
+++ b/releasenotes/notes/perf-pauli-evolve-cliff-sch-a85e724989fa878c.yaml
@@ -1,0 +1,6 @@
+---
+performance:
+  - The methods :meth:`.Pauli.evolve` and :meth:`.PauliList.evolve` are now significantly
+   faster in the specific case where 1) `other` is a :class:`.Clifford`, 2) `frame` is
+   `'s'` (Schrodinger), and 3) the object being evolved has non-identity support on only
+   a small fraction of its qubits.


### PR DESCRIPTION
This PR speeds up typical performance of `Pauli.evolve` and `PauliList.evolve` when 1) ``other`` is a `Clifford`, 2) ``frame`` is ``'h'`` (Heisenberg), and 3) the number of qubits in the ``Clifford`` is larger than the number of Paulis being evolved.

This should be based on PR #16835 (I'm not sure how best to set this up on my fork).

Previously, Heisenberg evolution first called `Clifford.adjoint`, which is `O(N^3)` in the number of qubits in the Clifford. The phase can alternatively be obtained via a second Schrodinger-frame evolution, which is `O(L N^2)`, where L is the number of Paulis being evolved. For L << N, this alternative approach becomes much faster. For L >> N, the original approach of calling `adjoint` becomes much faster.

The comments below include benchmarking that mainly looks for a reasonable threshold at which to switch between these two procedures. Per these tests, the PR simply thresholds on the condition that N <= L, which gave near-optimal performance, albeit with some exceptions (i.e. regressions vs PR 16835).

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [X] Some submitted code was generated by: Claude Opus 4.8

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
