### PR TITLE
quantum_info: remove redundant non-zero computation in SparsePauliOp.simplify

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -491,7 +491,7 @@ class SparsePauliOp(LinearOp):
         coeffs = np.zeros(indexes.shape[0], dtype=self.coeffs.dtype)
         np.add.at(coeffs, inverses, nz_coeffs)
 
-        # Filter non-zero coefficients
+        # Delete zero coefficient rows
         if self.coeffs.dtype == object:
 
             def to_complex(coeff):
@@ -504,14 +504,6 @@ class SparsePauliOp(LinearOp):
                 except TypeError:
                     return np.nan
 
-            non_zero = np.logical_not(
-                np.isclose([to_complex(x) for x in self.coeffs], 0, atol=atol, rtol=rtol)
-            )
-        else:
-            non_zero = np.logical_not(np.isclose(self.coeffs, 0, atol=atol, rtol=rtol))
-
-        # Delete zero coefficient rows
-        if self.coeffs.dtype == object:
             is_zero = np.array(
                 [np.isclose(to_complex(coeff), 0, atol=atol, rtol=rtol) for coeff in coeffs]
             )

--- a/releasenotes/notes/clean-sparsepauliop-simplify-non-zero-16796.yaml
+++ b/releasenotes/notes/clean-sparsepauliop-simplify-non-zero-16796.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Removed an unused, redundant computation of non-zero coefficients
+    inside :meth:`.SparsePauliOp.simplify`.


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Title above -->
### Summary
In `SparsePauliOp.simplify()`, a chunk of code evaluated `np.isclose` on `self.coeffs` before accumulating duplicate rows, storing the boolean mask in `non_zero`. This variable was never used and was immediately overwritten later by `non_zero = np.logical_not(is_zero)` after duplicate row accumulation and zero checking.

This PR removes this redundant computation, eliminating dead code and avoiding duplicate work during `SparsePauliOp.simplify()`.

### Details and comments
Fixes #16796