### PR TITLE
QPY 18: store each ParameterVector once and reference it by index

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -37,7 +37,7 @@ use qiskit_circuit::operations::{
     StandardInstruction, StandardInstructionType, SwitchTarget, UnitaryGate,
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
-use qiskit_circuit::parameter::parameter_expression::{ParameterExpression, PyParameter};
+use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::SymbolVector;
 use qiskit_circuit::var_stretch_container::{StretchType, VarType};
 use qiskit_circuit::{Block, classical, imports};

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -41,6 +41,7 @@ use qiskit_circuit::operations::{
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 use qiskit_circuit::parameter::parameter_expression::{ParameterExpression, PyParameter};
+use qiskit_circuit::parameter::symbol_expr::SymbolVector;
 use qiskit_circuit::var_stretch_container::{StretchType, VarType};
 use qiskit_circuit::{Block, classical, imports};
 use qiskit_circuit::{Clbit, Qubit};
@@ -48,6 +49,7 @@ use qiskit_quantum_info::sparse_observable::BitTerm;
 use qiskit_quantum_info::sparse_observable::SparseObservable;
 use std::str::FromStr;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use smallvec::SmallVec;
 
@@ -1702,6 +1704,24 @@ pub(crate) fn unpack_circuit(
         standalone_vars: HashMap::new(),
         standalone_stretches: HashMap::new(),
         vectors: HashMap::new(),
+        // From QPY 18 the payload declares its vectors up front
+        parameter_vectors: packed_circuit
+            .parameter_vectors
+            .as_ref()
+            .map(|table| {
+                table
+                    .vectors
+                    .iter()
+                    .map(|vector| {
+                        Arc::new(SymbolVector {
+                            name: vector.name.clone(),
+                            uuid: Uuid::from_bytes(vector.uuid),
+                            len: (vector.vector_size as usize).into(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
         annotation_handler,
     };
     if let Some(annotation_headers) = &packed_circuit.annotation_headers {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -138,7 +138,7 @@ pub(crate) fn pack_annotations(
 
 fn pack_condition(
     condition: Condition,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::ConditionPack, QpyError> {
     match condition {
         Condition::Expr(exp) => {
@@ -337,7 +337,7 @@ pub fn standard_instruction_class_name(inst: &StandardInstruction) -> &str {
 fn pack_pauli_product_measurement(
     ppm: &PauliProductMeasurement,
     instruction: &PackedInstruction,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
     // since we won't recreate this gate via python, it's not important to verify the python name is identical to the one we use here
     // so we simply hard-code it instead of going through python
@@ -371,7 +371,7 @@ fn pack_pauli_product_measurement(
 fn pack_pauli_product_rotation(
     rotation: &PauliProductRotation,
     instruction: &PackedInstruction,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
     // since we won't recreate this gate via python, it's not important to verify the python name is identical to the one we use here
     // so we simply hard-code it instead of going through python
@@ -570,7 +570,7 @@ fn pack_control_flow_inst(
 }
 fn pack_unitary_gate(
     unitary_gate: &UnitaryGate,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
     // unitary gates are special since they are uniquely determined by a matrix, which is not
     // a "parameter", strictly speaking, but is treated as such when serializing
@@ -850,7 +850,7 @@ fn pack_classical_register(
 fn pack_circuit_header(
     circuit_name: Option<String>,
     metadata: Bytes,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitHeaderV12Pack, QpyError> {
     let global_phase_data = pack_param_obj(
         qpy_data.circuit_data.global_phase(),
@@ -1332,10 +1332,11 @@ pub(crate) fn pack_circuit(
         circuit_data,
         version,
         standalone_var_indices: HashMap::new(),
+        parameter_vectors: Default::default(),
         annotation_handler,
     };
     let standalone_vars = pack_standalone_vars(&mut qpy_data)?;
-    let header = pack_circuit_header(extra.name, extra.metadata, &qpy_data)?;
+    let header = pack_circuit_header(extra.name, extra.metadata, &mut qpy_data)?;
     // CalibrationsPack was dropped in v18; for v13-17 write an empty block (pulse
     // gates were removed in Qiskit 2.0 but older format versions require the field)
     let calibrations = if version < 18 {
@@ -1364,10 +1365,14 @@ pub(crate) fn pack_circuit(
         .map(|(namespace, state)| formats::AnnotationStateHeaderPack { namespace, state })
         .collect();
     let annotation_headers = Some(formats::AnnotationHeaderStaticPack { state_headers });
+    // Built only now that packing is done, since that is what discovered which vectors the circuit
+    // refers to -- even though the table is serialized ahead of the instructions that point into it.
+    let parameter_vectors = (version >= 18).then(|| qpy_data.parameter_vectors.to_pack());
     Ok(formats::QPYCircuit {
         header,
         standalone_vars,
         annotation_headers,
+        parameter_vectors,
         custom_instructions,
         instructions,
         calibrations,

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -52,10 +52,11 @@ pub struct QPYFileHeader {
 // 1) Header: Contains the global data such as name, number of qubits etc.
 // 2) Standalone vars: Contains the qiskit_circuit::Var elements used in expressions
 // 3) Annotation Headers: The annotation-related global data.
-// 4) Custom instructions: List of custom gates used in the circuits, e.g. gate with nonstandard control
-// 5) Instruction: The sequential list of gates in the circuit.
-// 6) Calibrations: Obsolete; this was pulse-related data. Here for backwards compatibility.
-// 7) Layout: The transpilation layout, if one exists (otherwise a dummy is used).
+// 4) Parameter vectors (QPY 18+): the `ParameterVector`s that elements in this circuit belong to.
+// 5) Custom instructions: List of custom gates used in the circuits, e.g. gate with nonstandard control
+// 6) Instruction: The sequential list of gates in the circuit.
+// 7) Calibrations: Obsolete; this was pulse-related data. Here for backwards compatibility.
+// 8) Layout: The transpilation layout, if one exists (otherwise a dummy is used).
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
@@ -67,6 +68,8 @@ pub struct QPYCircuit {
     pub standalone_vars: Vec<ExpressionVarDeclarationPack>,
     #[br(if(version >= 15))]
     pub annotation_headers: Option<AnnotationHeaderStaticPack>,
+    #[br(if(version >= 18))]
+    pub parameter_vectors: Option<ParameterVectorTablePack>,
     pub custom_instructions: CustomCircuitInstructionsPack,
     #[br(count = header.num_instructions, args { inner: (true,) })]
     pub instructions: Vec<CircuitInstructionV2Pack>,
@@ -656,13 +659,51 @@ pub struct ParameterSymbolPack {
     pub name: String,
 }
 
-// A single parameter vector element. Since vectors has no standalone representation in QPY
-// the vector data (name and size) is stored along with the element-specific data (uuid and index in the vector)
-// This is obviously not optimal compared to storing a list of vector and keeping a pointer in each element so TODO: improve in QPY18?
+// A `ParameterVector`, stored once per circuit payload and referred to by index from each of its
+// elements.
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
-pub struct ParameterVectorElementPack {
+pub struct ParameterVectorPack {
+    #[bw(calc = name.len() as u16)]
+    pub name_size: u16,
+    pub vector_size: u64,
+    pub uuid: [u8; 16],
+    #[br(count = name_size as usize, try_map = String::from_utf8)]
+    #[bw(map = |s| s.as_bytes())]
+    pub name: String,
+}
+
+// The parameter vectors referenced by this circuit payload, in index order.  Nested payloads (a
+// control-flow block, or a custom instruction definition) carry their own table, so that a circuit
+// remains decodable on its own.
+#[binrw]
+#[brw(big)]
+#[derive(Debug)]
+pub struct ParameterVectorTablePack {
+    #[bw(calc = vectors.len() as u16)]
+    pub num_vectors: u16,
+    #[br(count = num_vectors)]
+    pub vectors: Vec<ParameterVectorPack>,
+}
+
+// A single parameter vector element.
+// From QPY 18 the vector lives once in `ParameterVectorTablePack` and the element only points at it.
+#[binrw]
+#[brw(big)]
+#[derive(Debug)]
+#[brw(import(version: u8))]
+pub enum ParameterVectorElementPack {
+    #[br(pre_assert(version < 18))]
+    V17(ParameterVectorElementV17Pack),
+    #[br(pre_assert(version >= 18))]
+    V18(ParameterVectorElementV18Pack),
+}
+
+#[binrw]
+#[brw(big)]
+#[derive(Debug)]
+pub struct ParameterVectorElementV17Pack {
     #[bw(calc = name.len() as u16)]
     pub name_size: u16,
     pub vector_size: u64,
@@ -671,6 +712,17 @@ pub struct ParameterVectorElementPack {
     #[br(count = name_size as usize, try_map = String::from_utf8)]
     #[bw(map = |s| s.as_bytes())]
     pub name: String,
+}
+
+// The QPY 18 element encoding: a pointer into the payload's parameter vector table.
+#[binrw]
+#[brw(big)]
+#[derive(Debug)]
+pub struct ParameterVectorElementV18Pack {
+    /// Index into this payload's `ParameterVectorTablePack`.
+    pub vector_index: u16,
+    /// Index of this element within that vector.
+    pub index: u64,
 }
 
 // The various types of components available in a parameter expression
@@ -775,6 +827,7 @@ pub struct ParameterExpressionSubsOpPack {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import(version: u8))]
 pub struct ParameterExpressionPack {
     #[bw(calc = symbol_table_data.len() as u64)]
     pub symbol_tables_length: u64,
@@ -782,7 +835,8 @@ pub struct ParameterExpressionPack {
     pub expression_data_length: u64,
     #[br(count = expression_data_length)]
     pub expression_data: Bytes,
-    #[br(count = symbol_tables_length)]
+    #[br(count = symbol_tables_length, args { inner: (version,) })]
+    #[bw(args(version))]
     pub symbol_table_data: Vec<ParameterExpressionSymbolPack>,
 }
 
@@ -793,18 +847,19 @@ pub struct ParameterExpressionPack {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import(version: u8))]
 pub enum ParameterExpressionSymbolPack {
     #[brw(magic = b'p')]
     Parameter(ParameterExpressionParameterSymbolPack),
     #[brw(magic = b'v')]
-    ParameterVector(ParameterExpressionParameterVectorSymbolPack),
+    ParameterVector(#[brw(args(version))] ParameterExpressionParameterVectorSymbolPack),
     /// This variant _should not_ exist; it is counter to the QPY spec, and has no semantic meaning.
     /// However, Qiskit 2.0 (with QPY 13 non-symengine serialisation but before Rust-space
     /// `ParameterExpression` or QPY) would populate the "symbol map" with the raw dictionaries
     /// given to `ParameterExpression.subs` calls, which include expressions.  The equivalent "read"
     /// code would load up the entries, then immediately filter them out to make the symbol map.
     #[brw(magic = b'e')]
-    ParameterExpression(ParameterExpressionParameterExpressionSymbolPack),
+    ParameterExpression(#[brw(args(version))] ParameterExpressionParameterExpressionSymbolPack),
 }
 
 // symbol->value mapping for parameter expressions
@@ -824,10 +879,12 @@ pub struct ParameterExpressionParameterSymbolPack {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import(version: u8))]
 pub struct ParameterExpressionParameterVectorSymbolPack {
     pub value_key: ValueType,
     #[bw(calc = value_data.len() as u64)]
     pub value_data_len: u64,
+    #[brw(args(version))]
     pub symbol_data: ParameterVectorElementPack,
     #[br(count = value_data_len)]
     pub value_data: Bytes,
@@ -837,10 +894,12 @@ pub struct ParameterExpressionParameterVectorSymbolPack {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
+#[brw(import(version: u8))]
 pub struct ParameterExpressionParameterExpressionSymbolPack {
     pub value_key: u8,
     #[bw(calc = value_data.len() as u64)]
     pub value_data_len: u64,
+    #[brw(args(version))]
     pub symbol_data: ParameterExpressionPack,
     #[br(count = value_data_len)]
     pub value_data: Bytes,

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -667,6 +667,7 @@ mod tests {
                 .map(|index| SymbolVector::new(format!("v{index}"), 2))
                 .collect(),
             annotation_handler: AnnotationHandler::native(),
+            caller: QpyCaller::Native,
         }
     }
 

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -137,12 +137,13 @@ pub(crate) fn pack_parameter_expression_by_op(
 // this is no longer used in the rust-based parameter expressions, so we do not fully utilize the formats
 pub(crate) fn pack_parameter_expression(
     exp: &ParameterExpression,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::ParameterExpressionPack, QpyError> {
     let packed_expression_data = pack_parameter_expression_elements(exp)?;
     let expression_data = serialize(&packed_expression_data)?;
     let symbol_table_data: Vec<formats::ParameterExpressionSymbolPack> = exp
         .iter_symbols()
-        .map(pack_symbol_table_element)
+        .map(|symbol| pack_symbol_table_element(symbol, qpy_data))
         .collect::<Result<_, QpyError>>()?;
     Ok(formats::ParameterExpressionPack {
         expression_data,
@@ -152,6 +153,7 @@ pub(crate) fn pack_parameter_expression(
 
 fn pack_symbol_table_element(
     symbol: &Symbol,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::ParameterExpressionSymbolPack, QpyError> {
     // The `value_data` part in the QPY format is only used for "substitute" commands in the replay,
     // but the Rust-space writer has no need to output those, so it's always empty for us.
@@ -169,7 +171,7 @@ fn pack_symbol_table_element(
             let pack = formats::ParameterExpressionParameterVectorSymbolPack {
                 value_key: ValueType::ParameterVector,
                 value_data,
-                symbol_data: pack_parameter_vector(symbol)?,
+                symbol_data: pack_parameter_vector(symbol, qpy_data)?,
             };
             Ok(formats::ParameterExpressionSymbolPack::ParameterVector(
                 pack,
@@ -485,6 +487,7 @@ pub(crate) fn unpack_symbol(parameter_pack: &formats::ParameterSymbolPack) -> Sy
 
 pub(crate) fn pack_parameter_vector(
     symbol: &Symbol,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::ParameterVectorElementPack, QpyError> {
     let Symbol::Element { index, base } = symbol else {
         return Err(QpyError::ConversionError(
@@ -492,22 +495,63 @@ pub(crate) fn pack_parameter_vector(
                 .to_owned(),
         ));
     };
-    Ok(formats::ParameterVectorElementPack {
-        vector_size: base.len.load(atomic::Ordering::Relaxed) as u64,
-        uuid: *symbol.uuid().as_bytes(),
-        index: *index as u64,
-        name: base.name.clone(),
-    })
+    if qpy_data.version >= 18 {
+        // The vector itself goes in this payload's table; the element only points at it.  Its UUID is
+        // not stored, being the vector's plus the index.
+        let vector_index = qpy_data.parameter_vectors.index_of(base)?;
+        return Ok(formats::ParameterVectorElementPack::V18(
+            formats::ParameterVectorElementV18Pack {
+                vector_index,
+                index: *index as u64,
+            },
+        ));
+    }
+    Ok(formats::ParameterVectorElementPack::V17(
+        formats::ParameterVectorElementV17Pack {
+            vector_size: base.len.load(atomic::Ordering::Relaxed) as u64,
+            uuid: *symbol.uuid().as_bytes(),
+            index: *index as u64,
+            name: base.name.clone(),
+        },
+    ))
 }
 
 /// Unpack a `ParameterVectorElement` into a `Symbol`.
 ///
-/// Actually, the majority of the work we have to do here is unpacking the underlying _vector_ and
-/// ensuring it is consistent with any other definitions of this vector that we've seen.
+/// From QPY 18 the element just names its vector's index in the
+/// payload's table, so there is nothing to reconstruct or reconcile.  Before that, the majority of
+/// the work is unpacking the underlying _vector_ and ensuring it is consistent with any other
+/// definitions of this vector that we've seen.
 pub(crate) fn unpack_parameter_vector(
     pack: &formats::ParameterVectorElementPack,
     qpy_data: &mut QPYReadData,
 ) -> Result<Symbol, QpyError> {
+    let pack = match pack {
+        formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {
+            vector_index,
+            index,
+        }) => {
+            let vector = qpy_data
+                .parameter_vectors
+                .get(*vector_index as usize)
+                .ok_or_else(|| {
+                    QpyError::InvalidParameter(format!(
+                        "parameter vector index {} is out of range; the circuit declares {}",
+                        vector_index,
+                        qpy_data.parameter_vectors.len()
+                    ))
+                })?;
+            return vector.get(*index as usize).ok_or_else(|| {
+                QpyError::InvalidParameter(format!(
+                    "index {} is out of range for vector '{}[{}]'",
+                    index,
+                    vector.name,
+                    vector.len.load(atomic::Ordering::Relaxed)
+                ))
+            });
+        }
+        formats::ParameterVectorElementPack::V17(pack) => pack,
+    };
     // Historical versions of Qiskit assigned independent UUIDs to every element of a vector.
     // Modern Qiskit doesn't even permit this representation; elements' UUIDs are offset from the
     // base vector's.  With certain payloads from very old Qiskit versions (pre Terra 0.25), this
@@ -539,7 +583,7 @@ pub(crate) fn unpack_parameter_vector(
 
 pub(crate) fn pack_param_expression(
     exp: &ParameterExpression,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::GenericDataPack, QpyError> {
     // if the parameter expression is a single symbol, we should treat it like a parameter
     // or a parameter vector, depending on whether the `vector` field exists
@@ -563,7 +607,7 @@ pub(crate) fn pack_param_expression(
 
 pub(crate) fn pack_param_obj(
     param: &Param,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
     endian: ValueEndian,
 ) -> Result<formats::GenericDataPack, QpyError> {
     let resolved = endian.resolve(qpy_data.version);
@@ -598,5 +642,85 @@ pub(crate) fn generic_value_to_param(value: &GenericValue) -> Result<Param, QpyE
         }
         GenericValue::ParameterExpression(exp) => Ok(Param::ParameterExpression(exp.clone())),
         _ => Ok(Param::Obj(py_convert_from_generic_value(value)?)),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::annotations::AnnotationHandler;
+    use qiskit_circuit::circuit_data::CircuitData;
+    use qiskit_circuit::operations::Param;
+
+    /// A reader whose payload declares `num_vectors` parameter vectors, each of length 2.
+    fn read_data(num_vectors: usize) -> QPYReadData {
+        QPYReadData {
+            circuit_data: CircuitData::new(None, None, Param::Float(0.0)).unwrap(),
+            version: 18,
+            use_symengine: false,
+            standalone_vars: HashMap::new(),
+            standalone_stretches: HashMap::new(),
+            vectors: HashMap::new(),
+            parameter_vectors: (0..num_vectors)
+                .map(|index| SymbolVector::new(format!("v{index}"), 2))
+                .collect(),
+            annotation_handler: AnnotationHandler::native(),
+        }
+    }
+
+    #[test]
+    fn indexed_element_resolves_through_the_table() {
+        let mut qpy_data = read_data(2);
+        let symbol = unpack_parameter_vector(
+            &formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {
+                vector_index: 1,
+                index: 1,
+            }),
+            &mut qpy_data,
+        )
+        .unwrap();
+        let Symbol::Element { index, base } = &symbol else {
+            panic!("expected a vector element, got {symbol:?}");
+        };
+        assert_eq!(*index, 1);
+        assert_eq!(base.name, "v1");
+        // The element's UUID is not stored; it is the vector's offset by the index.
+        assert_eq!(symbol.uuid(), Uuid::from_u128(base.uuid.as_u128() + 1u128));
+    }
+
+    #[test]
+    fn vector_index_past_the_table_is_an_error() {
+        let mut qpy_data = read_data(1);
+        let result = unpack_parameter_vector(
+            &formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {
+                vector_index: 7,
+                index: 0,
+            }),
+            &mut qpy_data,
+        );
+        let Err(error) = result else {
+            panic!("an index past the end of the table must not resolve: {result:?}");
+        };
+        assert!(
+            format!("{error}").contains("out of range"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn element_index_past_the_vector_length_is_an_error() {
+        let mut qpy_data = read_data(1);
+        let result = unpack_parameter_vector(
+            &formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {
+                vector_index: 0,
+                index: 99,
+            }),
+            &mut qpy_data,
+        );
+        assert!(
+            result.is_err(),
+            "an index past the end of the vector must not resolve: {result:?}"
+        );
     }
 }

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -185,7 +185,7 @@ pub(crate) fn py_deserialize_numpy_object(data: &Bytes) -> Result<Py<PyAny>, Qpy
 
 fn pack_sparse_pauli_op(
     operator: &Bound<PyAny>,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::PauliDataPack, QpyError> {
     if operator.is_instance_of::<PySparseObservable>() {
         let py_sparse_observable: PyRef<PySparseObservable> = operator
@@ -235,7 +235,7 @@ fn pack_sparse_pauli_op(
 
 pub(crate) fn py_pack_pauli_evolution_gate(
     evolution_gate: &Bound<PyAny>,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<formats::PauliEvolutionDefPack, QpyError> {
     let py = evolution_gate.py();
     let operators = evolution_gate.getattr("operator")?;
@@ -479,7 +479,7 @@ pub(crate) fn py_convert_from_generic_value(value: &GenericValue) -> Result<Py<P
 // Not to be confused with Parameter, which is an atom of ParameterExpression
 pub(crate) fn py_pack_param(
     py_object: &Bound<PyAny>,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
     endian: ValueEndian,
 ) -> Result<formats::GenericDataPack, QpyError> {
     let value = py_convert_to_generic_value(py_object)?;

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -184,9 +184,13 @@ impl ParameterVectorTableBuilder {
         if let Some(index) = self.indices.get(&vector.uuid.as_u128()) {
             return Ok(*index);
         }
-        let index = u16::try_from(self.vectors.len()).map_err(|_| {
-            QpyError::ConversionError("too many parameter vectors in one circuit".to_string())
-        })?;
+        if self.vectors.len() >= u16::MAX as usize {
+            return Err(QpyError::ConversionError(format!(
+                "too many parameter vectors in one circuit: QPY stores at most {}",
+                u16::MAX as usize
+            )));
+        }
+        let index = self.vectors.len() as u16;
         self.indices.insert(vector.uuid.as_u128(), index);
         self.vectors.push(Arc::clone(vector));
         Ok(index)

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -12,6 +12,7 @@
 
 use std::num::NonZero;
 use std::sync::Arc;
+use std::sync::atomic;
 
 use binrw::meta::{ReadEndian, WriteEndian};
 use binrw::{BinRead, BinWrite, Endian, binrw};
@@ -170,6 +171,42 @@ pub(crate) fn pack_biguint(bigint: &BigUint) -> BigIntPack {
 pub(crate) fn unpack_biguint(big_int_pack: BigIntPack) -> BigUint {
     BigUint::from_bytes_be(&big_int_pack.bytes)
 }
+#[derive(Debug, Default)]
+pub struct ParameterVectorTableBuilder {
+    /// Vector root UUID to its index in `vectors`.
+    indices: HashMap<u128, u16>,
+    vectors: Vec<Arc<SymbolVector>>,
+}
+
+impl ParameterVectorTableBuilder {
+    /// The index of `vector` in the table, adding it if this is the first element to reference it.
+    pub fn index_of(&mut self, vector: &Arc<SymbolVector>) -> Result<u16, QpyError> {
+        if let Some(index) = self.indices.get(&vector.uuid.as_u128()) {
+            return Ok(*index);
+        }
+        let index = u16::try_from(self.vectors.len()).map_err(|_| {
+            QpyError::ConversionError("too many parameter vectors in one circuit".to_string())
+        })?;
+        self.indices.insert(vector.uuid.as_u128(), index);
+        self.vectors.push(Arc::clone(vector));
+        Ok(index)
+    }
+
+    /// The collected vectors, in index order.
+    pub fn to_pack(&self) -> formats::ParameterVectorTablePack {
+        formats::ParameterVectorTablePack {
+            vectors: self
+                .vectors
+                .iter()
+                .map(|vector| formats::ParameterVectorPack {
+                    vector_size: vector.len.load(atomic::Ordering::Relaxed) as u64,
+                    uuid: *vector.uuid.as_bytes(),
+                    name: vector.name.clone(),
+                })
+                .collect(),
+        }
+    }
+}
 
 // Data that is needed globally while writing the circuit
 #[derive(Debug)]
@@ -177,6 +214,7 @@ pub struct QPYWriteData<'a> {
     pub circuit_data: &'a CircuitData,
     pub version: u8,
     pub standalone_var_indices: HashMap<u128, u16>, // mapping from the variable's UUID to its index in the standalone variables list
+    pub parameter_vectors: ParameterVectorTableBuilder,
     pub annotation_handler: AnnotationHandler,
 }
 
@@ -189,6 +227,7 @@ pub struct QPYReadData {
     pub standalone_vars: HashMap<u16, qiskit_circuit::Var>,
     pub standalone_stretches: HashMap<u16, qiskit_circuit::Stretch>,
     pub vectors: HashMap<Uuid, Arc<SymbolVector>>,
+    pub parameter_vectors: Vec<Arc<SymbolVector>>,
     pub annotation_handler: AnnotationHandler,
 }
 
@@ -588,14 +627,18 @@ pub(crate) fn load_value(
             Ok(GenericValue::ParameterExpressionSymbol(symbol.into()))
         }
         ValueType::ParameterVector => {
-            let (parameter_vector_element_pack, _) =
-                deserialize::<formats::ParameterVectorElementPack>(bytes)?;
+            let (parameter_vector_element_pack, _) = deserialize_with_args::<
+                formats::ParameterVectorElementPack,
+                _,
+            >(bytes, (qpy_data.version,))?;
             let symbol = unpack_parameter_vector(&parameter_vector_element_pack, qpy_data)?;
             Ok(GenericValue::ParameterExpressionVectorSymbol(symbol.into()))
         }
         ValueType::ParameterExpression => {
-            let (parameter_expression_pack, _) =
-                deserialize::<formats::ParameterExpressionPack>(bytes)?;
+            let (parameter_expression_pack, _) = deserialize_with_args::<
+                formats::ParameterExpressionPack,
+                _,
+            >(bytes, (qpy_data.version,))?;
             let exp = unpack_parameter_expression(&parameter_expression_pack, qpy_data)?;
             Ok(GenericValue::ParameterExpression(Arc::new(exp)))
         }
@@ -645,7 +688,7 @@ pub(crate) fn load_biguint_value(bytes: &Bytes) -> Result<GenericValue, QpyError
 /// serializes the generic value into bytes and also returns the identifying tag
 pub(crate) fn serialize_generic_value(
     value: &GenericValue,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<(ValueType, Bytes), QpyError> {
     Ok(match value {
         GenericValue::Bool(value) => (ValueType::Bool, value.into()),
@@ -660,11 +703,17 @@ pub(crate) fn serialize_generic_value(
         }
         GenericValue::ParameterExpressionVectorSymbol(symbol) => (
             ValueType::ParameterVector,
-            serialize(&pack_parameter_vector(symbol)?)?,
+            serialize_with_args(
+                &pack_parameter_vector(symbol, qpy_data)?,
+                (qpy_data.version,),
+            )?,
         ),
         GenericValue::ParameterExpression(exp) => (
             ValueType::ParameterExpression,
-            serialize(&pack_parameter_expression(exp)?)?,
+            serialize_with_args(
+                &pack_parameter_expression(exp, qpy_data)?,
+                (qpy_data.version,),
+            )?,
         ),
         GenericValue::Tuple(values) => (
             ValueType::Tuple,
@@ -731,7 +780,7 @@ pub(crate) fn serialize_generic_value(
 // but since that's the format currently in place in QPY we don't try to optimize
 pub(crate) fn pack_generic_value(
     value: &GenericValue,
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<GenericDataPack, QpyError> {
     let (type_key, data) = serialize_generic_value(value, qpy_data)?;
     Ok(GenericDataPack { type_key, data })
@@ -800,7 +849,7 @@ pub(crate) fn unpack_for_collection(value: &GenericValue) -> Result<ForCollectio
 
 pub(crate) fn pack_generic_value_sequence(
     values: &[GenericValue],
-    qpy_data: &QPYWriteData,
+    qpy_data: &mut QPYWriteData,
 ) -> Result<GenericDataSequencePack, QpyError> {
     let elements = values
         .iter()

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -490,8 +490,7 @@ PARAMETER_VECTOR_TABLE
 Version 18 stores each :class:`.ParameterVector` once per circuit payload and has its elements refer
 to it by index, instead of repeating the vector's identity in every element.
 
-The circuit payload gains a ``PARAMETER_VECTOR_TABLE`` immediately after the annotation headers (see
-:ref:`qpy_circuit`), before the custom instruction definitions:
+The circuit payload gains a ``PARAMETER_VECTOR_TABLE`` immediately after the annotation headers, before the custom instruction definitions:
 
 .. code-block:: c
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -485,6 +485,49 @@ Version 18 also corrects the encoding of integer and float ``INSTRUCTION_PARAM``
 to big-endian byte order, consistent with the rest of the QPY specification. In versions
 1–17 these were mistakenly written in little-endian.
 
+PARAMETER_VECTOR_TABLE
+~~~~~~~~~~~~~~~~~~~~~~
+Version 18 stores each :class:`.ParameterVector` once per circuit payload and has its elements refer
+to it by index, instead of repeating the vector's identity in every element.
+
+The circuit payload gains a ``PARAMETER_VECTOR_TABLE`` immediately after the annotation headers (see
+:ref:`qpy_circuit`), before the custom instruction definitions:
+
+.. code-block:: c
+
+    struct {
+        uint16_t num_vectors;
+    }
+
+followed by ``num_vectors`` entries of
+
+.. code-block:: c
+
+    struct {
+        uint16_t vector_name_size;
+        uint64_t vector_size;
+        char     uuid[16];        // the vector's root UUID
+    }
+
+each immediately followed by ``vector_name_size`` utf8 bytes of the vector's name.
+
+A :ref:`PARAMETER_VECTOR_ELEMENT <qpy_param_vector>` is correspondingly reduced to a reference:
+
+.. code-block:: c
+
+    struct {
+        uint16_t vector_index;    // index into PARAMETER_VECTOR_TABLE
+        uint64_t index;           // index of this element within that vector
+    }
+
+The element's own UUID is no longer stored, because it is the vector's root UUID plus the element's
+index -- the relationship the reader has always used to recover the owning vector.  An element
+therefore costs 10 bytes rather than 34 plus the length of the vector name, at the cost of two bytes
+per circuit for the count when a circuit uses no parameter vectors at all.
+
+A nested payload -- a control-flow block, or a custom instruction definition -- carries its own
+table, so that each circuit remains decodable on its own.
+
 New ParamRegisterPack
 ~~~~~~~~~~~~~~~~~~~~~
 Version 18 replaces the encoding of a `Register` payload, which stores either a whole
@@ -1953,6 +1996,12 @@ defined as:
 
 which is immediately followed by ``vector_name_size`` utf8 bytes representing
 the parameter's vector name.
+
+.. versionchanged:: QPY 18
+
+    The vector is stored once in the circuit's ``PARAMETER_VECTOR_TABLE`` and this payload became a
+    reference to it, ``uint16_t vector_index`` followed by ``uint64_t index``, with no name, size or
+    UUID of its own.  See :ref:`qpy_version_18`.
 
 .. _qpy_param_expr_v3:
 

--- a/releasenotes/notes/qpy-18-parameter-vector-table-3f8c21d90ab4e657.yaml
+++ b/releasenotes/notes/qpy-18-parameter-vector-table-3f8c21d90ab4e657.yaml
@@ -1,0 +1,11 @@
+---
+upgrade_qpy:
+  - |
+    QPY version 18 now stores each :class:`.ParameterVector` once per circuit payload, in a new
+    ``PARAMETER_VECTOR_TABLE``, and has each of its elements refer to it by index.  Up to version 17
+    every element repeated its vector's name and size, along with a UUID that is derivable from the
+    vector's own, so a vector of :math:`n` elements stored its identity :math:`n` times.  An element
+    now occupies 10 bytes instead of 34 plus the length of the vector's name: a circuit using a
+    100-element vector is around 29% smaller.  A circuit that uses no parameter vectors grows by the
+    two bytes of the table's count.  Payloads of version 17 and earlier are unaffected, and are read
+    exactly as before.  See :mod:`qiskit.qpy` for the format description.

--- a/test/python/qpy/test_v18.py
+++ b/test/python/qpy/test_v18.py
@@ -15,7 +15,14 @@
 import io
 import struct
 
-from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister, Qubit
+from qiskit.circuit import (
+    Qubit,
+    ClassicalRegister,
+    Parameter,
+    ParameterVector,
+    QuantumCircuit,
+    QuantumRegister,
+)
 from qiskit.circuit.classical import expr
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.qpy import dump, load
@@ -45,11 +52,13 @@ class TestV17VsV18(QiskitTestCase):
         size17 = len(_dump(qc, 17))
         size18 = len(_dump(qc, 18))
         cal_header_size = struct.calcsize(formats.CALIBRATION_PACK)  # 2 bytes
+        empty_vector_table_size = struct.calcsize("!H")  # the num_vectors count alone
 
         self.assertEqual(
             size17 - size18,
-            cal_header_size,
-            f"Expected v18 to be {cal_header_size} bytes smaller than v17, "
+            cal_header_size - empty_vector_table_size,
+            f"Expected v18 to differ from v17 by "
+            f"{cal_header_size - empty_vector_table_size} bytes, "
             f"got v17={size17} v18={size18} diff={size17 - size18}",
         )
 
@@ -231,3 +240,79 @@ class TestV18SparseObservable(QiskitTestCase):
         qc = QuantumCircuit(evo.num_qubits)
         qc.append(evo, qc.qubits)
         self._assert_roundtrips(qc)
+
+
+class TestV18ParameterVectorTable(QiskitTestCase):
+    """From v18 a ``ParameterVector`` is stored once per payload and its elements point at it.
+
+    Up to v17 every element repeated the vector's name and size, plus a UUID that is the vector's own
+    offset by the element index.
+    """
+
+    @staticmethod
+    def _vector_circuit(name="v", length=3):
+        """A circuit applying one rotation per element of a single vector."""
+        vector = ParameterVector(name, length)
+        circuit = QuantumCircuit(1, name="vector_circuit")
+        for parameter in vector:
+            circuit.rx(parameter, 0)
+        return circuit, vector
+
+    def test_element_shrinks_by_expected_amount(self):
+        """An element costs 10 bytes at v18 against 34 plus the vector name at v17.
+
+        Measured by differencing twice: once between v17 and v18 for a given circuit, then between two
+        vector lengths.  Everything that does not scale with the number of elements -- the gate that
+        carries each one, the table, the calibration header -- cancels out.
+        """
+        extra = 10
+        short, _ = self._vector_circuit(length=1)
+        long, _ = self._vector_circuit(length=1 + extra)
+
+        saving = (len(_dump(long, 17)) - len(_dump(long, 18))) - (
+            len(_dump(short, 17)) - len(_dump(short, 18))
+        )
+        self.assertEqual(saving, extra * ((34 + len("v")) - 10))
+
+    def test_roundtrip_preserves_vector_identity(self):
+        """Reloaded elements belong to one vector, with the original name, length and UUIDs."""
+        circuit, vector = self._vector_circuit(length=4)
+        reloaded = load(io.BytesIO(_dump(circuit, 18)))[0]
+        self.assertEqual(reloaded, circuit)
+
+        elements = [instruction.operation.params[0] for instruction in reloaded.data]
+        vectors = {element.vector for element in elements}
+        self.assertEqual(len(vectors), 1)
+        reloaded_vector = vectors.pop()
+        self.assertEqual(reloaded_vector.name, vector.name)
+        self.assertEqual(len(reloaded_vector), len(vector))
+        self.assertEqual([element.uuid for element in elements], [p.uuid for p in vector])
+
+    def test_two_vectors_stay_distinct(self):
+        """Two vectors get separate table entries and do not collapse into one."""
+        first, second = ParameterVector("a", 2), ParameterVector("b", 2)
+        circuit = QuantumCircuit(1)
+        for parameter in list(first) + list(second):
+            circuit.rx(parameter, 0)
+
+        reloaded = load(io.BytesIO(_dump(circuit, 18)))[0]
+        self.assertEqual(reloaded, circuit)
+        names = {instruction.operation.params[0].vector.name for instruction in reloaded.data}
+        self.assertEqual(names, {"a", "b"})
+
+    def test_element_inside_an_expression_roundtrips(self):
+        """A vector element reached through a parameter expression uses the table too."""
+        vector, theta = ParameterVector("w", 2), Parameter("theta")
+        circuit = QuantumCircuit(2)
+        circuit.rx(vector[0] + theta, 0)
+        circuit.ry(vector[1] * 2, 1)
+        self.assertEqual(load(io.BytesIO(_dump(circuit, 18)))[0], circuit)
+
+    def test_element_inside_a_control_flow_block_roundtrips(self):
+        """A nested payload carries its own table, so a block's elements resolve independently."""
+        vector = ParameterVector("n", 2)
+        circuit = QuantumCircuit(1, 1)
+        circuit.rx(vector[0], 0)
+        with circuit.if_test((circuit.clbits[0], True)):
+            circuit.rx(vector[1], 0)
+        self.assertEqual(load(io.BytesIO(_dump(circuit, 18)))[0], circuit)


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
## Summary

Until QPY 17, each `ParameterVectorElementPack` included both the vector name and vector length, as well as the UUID that can be derived from the vector itself.
meaning that an `n`-length vector repeats its UUUID `n` times.

QPY 18 introduces a `ParameterVectorTablePack` in the circuit payload, where each vector appears once and the elements has references to it — `uint16_t vector_index` and `uint64_t index`. 
Each element thus requires 10 bytes rather than 34 plus the length of the vector name, which reduces the size of the circuit.
for example-  using 100 elements in a  vector reduces the size of the circuit by about 29%. 

The nested payloads such as a control flow block or a custom instruction definition include their own table, which ensures that each circuit is decodable individually.

## Notes for review

* Reading version ≤ 17 is untouched. The element pack is version-gated
  (`ParameterVectorElementV17Pack` / `...V18Pack`), the same shape as the existing `RegisterPack` and `PauliDataPack` enums.
* had to change some functions definitions to allow mutability in QPYWriteData.
* The element UUID is not stored because it is the vector's root UUID plus the index — the
  relationship both the reader and the writer already relied on to recover the vector.


### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
