### PR TITLE
Add modulus parameter to ModularAdderGate (API only, synthesis follow-up) < Issue: Modular Arithmetic Libraries  #13608

### DIFF
--- a/qiskit/circuit/library/arithmetic/adders/adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/adder.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit, Gate
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_func
 
 
@@ -131,14 +132,14 @@ class HalfAdderGate(Gate):
 
 
 class ModularAdderGate(Gate):
-    r"""Compute the sum modulo :math:`2^n` of two :math:`n`-sized qubit registers.
+    r"""Compute the sum modulo an integer :math:`N` of two :math:`n`-sized qubit registers.
 
     For two registers :math:`|a\rangle_n` and :math:`|b\rangle_n` with :math:`n` qubits each, an
     adder performs the following operation
 
     .. math::
 
-        |a\rangle_n |b\rangle_n \mapsto |a\rangle_n |a + b \text{ mod } 2^n\rangle_n.
+        |a\rangle_n |b\rangle_n \mapsto |a\rangle_n |a + b \text{ mod } N\rangle_n.
 
     The quantum register :math:`|a\rangle_n` (and analogously :math:`|b\rangle_n`)
 
@@ -152,19 +153,44 @@ class ModularAdderGate(Gate):
 
         a = 2^{0}a_{0} + 2^{1}a_{1} + \cdots + 2^{n - 1}a_{n - 1}.
 
+    If ``modulus`` is not given (or equals :math:`2^n`), :math:`N = 2^n` and the operation is
+    simply addition modulo the full range representable on :math:`n` qubits, as above. For a
+    smaller modulus :math:`N < 2^n`, the map :math:`b \mapsto (a + b) \text{ mod } N` is only
+    well-defined -- and therefore the action of this gate is only specified -- on inputs with
+    :math:`a, b < N`. Applying the gate to a state with :math:`a \geq N` or :math:`b \geq N` is
+    undefined behaviour and is left to the chosen synthesis method.
+
     """
 
-    def __init__(self, num_state_qubits: int, label: str | None = None) -> None:
-        """
+    def __init__(
+        self, num_state_qubits: int, label: str | None = None, modulus: int | None = None
+    ) -> None:
+        r"""
         Args:
             num_state_qubits: The number of qubits in each of the registers.
             label: An optional label for identifying the instruction.
+            modulus: The modulus :math:`N` of the modular addition. Must satisfy
+                :math:`1 \leq N \leq 2^n`, where :math:`n` is ``num_state_qubits``. Defaults to
+                :math:`2^n`, in which case this gate is addition modulo the full range of
+                ``num_state_qubits`` qubits, and is identical to the behaviour before this
+                argument was introduced.
+
+        Raises:
+            ValueError: If ``num_state_qubits`` is smaller than 1, or if ``modulus`` is given
+                and is not in the range :math:`[1, 2^n]`.
         """
         if num_state_qubits < 1:
             raise ValueError("Need at least 1 state qubit.")
 
+        if modulus is not None and not 1 <= modulus <= 2**num_state_qubits:
+            raise ValueError(
+                "modulus must satisfy 1 <= modulus <= 2 ** num_state_qubits "
+                f"(2 ** {num_state_qubits} = {2**num_state_qubits}), got {modulus}."
+            )
+
         super().__init__("ModularAdder", 2 * num_state_qubits, [], label=label)
         self._num_state_qubits = num_state_qubits
+        self.modulus = modulus
 
     @property
     def num_state_qubits(self) -> int:
@@ -178,6 +204,18 @@ class ModularAdderGate(Gate):
     def _define(self):
         """Populates self.definition with some decomposition of this gate."""
         from qiskit.synthesis.arithmetic import adder_modular_v17
+
+        if self.modulus not in (None, 2**self.num_state_qubits):
+            # No ancilla-free (or otherwise) synthesis method is registered yet for an
+            # arbitrary modulus; see https://github.com/Qiskit/qiskit/issues/13608.
+            raise CircuitError(
+                "No default synthesis method is available for a ModularAdderGate with "
+                f"modulus={self.modulus}. A synthesis method for this gate is only "
+                "available when modulus is None or equal to 2 ** num_state_qubits. "
+                "Use qiskit.transpiler.passes.HighLevelSynthesis with a plugin that "
+                "supports this modulus, once one is registered for the 'ModularAdder' "
+                "high-level-synthesis key."
+            )
 
         # This particular decomposition does not use any ancilla qubits.
         # Note that the transpiler may choose a different decomposition

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1781,7 +1781,8 @@ class ModularAdderSynthesisV17(HighLevelSynthesisPlugin):
     The plugin name is :``ModularAdder.v17`` which can be used as the key on
     an :class:`~.HLSConfig` object to use this method with :class:`~.HighLevelSynthesis`.
 
-    This plugin requires no auxiliary qubits.
+    This plugin requires no auxiliary qubits, and only supports the default modulus
+    (``None``, i.e. :math:`2^n`).
 
     """
 
@@ -1790,6 +1791,10 @@ class ModularAdderSynthesisV17(HighLevelSynthesisPlugin):
             return None
 
         num_state_qubits = high_level_object.num_state_qubits
+
+        # this method only implements modular addition modulo 2 ** num_state_qubits
+        if high_level_object.modulus not in (None, 2**num_state_qubits):
+            return None
 
         return adder_modular_v17(num_state_qubits)
 
@@ -1800,33 +1805,8 @@ class ModularAdderSynthesisC04(HighLevelSynthesisPlugin):
     This plugin name is:``ModularAdder.ripple_c04`` which can be used as the key on
     an :class:`~.HLSConfig` object to use this method with :class:`~.HighLevelSynthesis`.
 
-    This plugin requires at least one clean auxiliary qubit.
-
-    The plugin supports the following plugin-specific options:
-
-    * ``num_clean_ancillas``: The number of clean auxiliary qubits available.
-
-    """
-
-    def run(self, high_level_object, coupling_map=None, target=None, qubits=None, **options):
-        if not isinstance(high_level_object, ModularAdderGate):
-            return None
-
-        # unless we implement the full adder, this implementation needs an ancilla qubit
-        if options.get("num_clean_ancillas", 0) < 1:
-            return None
-
-        return adder_ripple_c04(high_level_object.num_state_qubits, kind="fixed")
-
-
-class ModularAdderSynthesisV95(HighLevelSynthesisPlugin):
-    r"""A ripple-carry adder, modulo :math:`2^n`.
-
-    This plugin name is:``ModularAdder.ripple_v95`` which can be used as the key on
-    an :class:`~.HLSConfig` object to use this method with :class:`~.HighLevelSynthesis`.
-
-    For an adder on 2 registers with :math:`n` qubits each, this plugin requires at
-    least :math:`n-1` clean auxiliary qubit.
+    This plugin requires at least one clean auxiliary qubit, and only supports the
+    default modulus (``None``, i.e. :math:`2^n`).
 
     The plugin supports the following plugin-specific options:
 
@@ -1839,6 +1819,43 @@ class ModularAdderSynthesisV95(HighLevelSynthesisPlugin):
             return None
 
         num_state_qubits = high_level_object.num_state_qubits
+
+        # this method only implements modular addition modulo 2 ** num_state_qubits
+        if high_level_object.modulus not in (None, 2**num_state_qubits):
+            return None
+
+        # unless we implement the full adder, this implementation needs an ancilla qubit
+        if options.get("num_clean_ancillas", 0) < 1:
+            return None
+
+        return adder_ripple_c04(num_state_qubits, kind="fixed")
+
+
+class ModularAdderSynthesisV95(HighLevelSynthesisPlugin):
+    r"""A ripple-carry adder, modulo :math:`2^n`.
+
+    This plugin name is:``ModularAdder.ripple_v95`` which can be used as the key on
+    an :class:`~.HLSConfig` object to use this method with :class:`~.HighLevelSynthesis`.
+
+    For an adder on 2 registers with :math:`n` qubits each, this plugin requires at
+    least :math:`n-1` clean auxiliary qubit. It only supports the default modulus
+    (``None``, i.e. :math:`2^n`).
+
+    The plugin supports the following plugin-specific options:
+
+    * ``num_clean_ancillas``: The number of clean auxiliary qubits available.
+
+    """
+
+    def run(self, high_level_object, coupling_map=None, target=None, qubits=None, **options):
+        if not isinstance(high_level_object, ModularAdderGate):
+            return None
+
+        num_state_qubits = high_level_object.num_state_qubits
+
+        # this method only implements modular addition modulo 2 ** num_state_qubits
+        if high_level_object.modulus not in (None, 2**num_state_qubits):
+            return None
 
         # The synthesis method needs n-1 clean ancilla qubits
         if num_state_qubits - 1 > options.get("num_clean_ancillas", 0):
@@ -1852,13 +1869,21 @@ class ModularAdderSynthesisD00(HighLevelSynthesisPlugin):
 
     This plugin name is:``ModularAdder.qft_d00`` which can be used as the key on
     an :class:`~.HLSConfig` object to use this method with :class:`~.HighLevelSynthesis`.
+
+    This plugin only supports the default modulus (``None``, i.e. :math:`2^n`).
     """
 
     def run(self, high_level_object, coupling_map=None, target=None, qubits=None, **options):
         if not isinstance(high_level_object, ModularAdderGate):
             return None
 
-        return adder_qft_d00(high_level_object.num_state_qubits, kind="fixed", annotated=True)
+        num_state_qubits = high_level_object.num_state_qubits
+
+        # this method only implements modular addition modulo 2 ** num_state_qubits
+        if high_level_object.modulus not in (None, 2**num_state_qubits):
+            return None
+
+        return adder_qft_d00(num_state_qubits, kind="fixed", annotated=True)
 
 
 class HalfAdderSynthesisDefault(HighLevelSynthesisPlugin):

--- a/releasenotes/notes/modular-adder-gate-modulus-param-8f6b6f0d6d8c1a2e.yaml
+++ b/releasenotes/notes/modular-adder-gate-modulus-param-8f6b6f0d6d8c1a2e.yaml
@@ -1,0 +1,26 @@
+---
+features_circuits:
+  - |
+    :class:`.ModularAdderGate` now accepts a ``modulus`` argument, allowing the gate to
+    represent modular addition with respect to an arbitrary modulus :math:`N`, rather than
+    only the full range :math:`2^n` representable on its ``num_state_qubits`` qubits::
+
+        from qiskit.circuit.library import ModularAdderGate
+
+        # addition modulo 2 ** num_state_qubits, as before
+        gate = ModularAdderGate(3)
+
+        # addition modulo 5, restricted to inputs a, b < 5
+        gate = ModularAdderGate(3, modulus=5)
+
+    ``modulus`` defaults to ``None``, which is equivalent to :math:`2^n` and reproduces the
+    previous behaviour exactly. This is the API proposed in
+    `#13608 (comment) <https://github.com/Qiskit/qiskit/issues/13608#issuecomment-2859127930>`__.
+
+    No synthesis method is available yet for a modulus that is not a power of two (or
+    ``None``); constructing the gate's definition, or requesting its high-level synthesis,
+    for such a modulus currently raises an error. The existing
+    :class:`.ModularAdderSynthesisV17`, :class:`.ModularAdderSynthesisC04`,
+    :class:`.ModularAdderSynthesisV95` and :class:`.ModularAdderSynthesisD00` plugins are
+    unaffected and continue to apply only to the default modulus. Support for arbitrary
+    moduli is tracked in `#13608 <https://github.com/Qiskit/qiskit/issues/13608>`__.

--- a/test/python/circuit/library/test_adders.py
+++ b/test/python/circuit/library/test_adders.py
@@ -19,6 +19,7 @@ import numpy as np
 from ddt import ddt, data, unpack
 
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.quantum_info import Statevector
 from qiskit.circuit.library import (
     CDKMRippleCarryAdder,
@@ -331,6 +332,71 @@ class TestAdder(QiskitTestCase):
             synth = hls(circuit)
             ops = set(synth.count_ops().keys())
             self.assertTrue("rccx" in ops)
+
+    @data(0, -1, -5)
+    def test_modulus_raises_below_one(self, modulus):
+        """Test a ValueError is raised if modulus is smaller than 1."""
+        with self.assertRaises(ValueError):
+            ModularAdderGate(3, modulus=modulus)
+
+    @data(9, 16, 100)
+    def test_modulus_raises_above_range(self, modulus):
+        """Test a ValueError is raised if modulus is larger than 2 ** num_state_qubits."""
+        with self.assertRaises(ValueError):
+            ModularAdderGate(3, modulus=modulus)
+
+    @data(1, 3, 5, 7, 8)
+    def test_modulus_valid_range_accepted(self, modulus):
+        """Test values in [1, 2 ** num_state_qubits] are accepted without error."""
+        gate = ModularAdderGate(3, modulus=modulus)
+        self.assertEqual(gate.modulus, modulus)
+
+    def test_modulus_defaults_to_none(self):
+        """Test the modulus attribute defaults to None."""
+        gate = ModularAdderGate(3)
+        self.assertIsNone(gate.modulus)
+
+    def test_modulus_none_matches_full_range(self):
+        """Test that modulus=None and modulus=2**n give the identical decomposition."""
+        default_gate = ModularAdderGate(3)
+        explicit_gate = ModularAdderGate(3, modulus=8)
+        self.assertEqual(default_gate.definition, explicit_gate.definition)
+
+    def test_modulus_non_default_has_no_synthesis_yet(self):
+        """Test that a non-power-of-two modulus currently has no default synthesis.
+
+        This is expected until a synthesis method for arbitrary modulus (tracked as
+        adder_modular_s21 in https://github.com/Qiskit/qiskit/issues/13608) is added; the
+        gate should fail clearly rather than silently synthesizing the wrong operation.
+        """
+        gate = ModularAdderGate(3, modulus=5)
+        with self.assertRaises(CircuitError):
+            gate.definition  # pylint: disable=pointless-statement
+
+    @data("modular_v17", "ripple_c04", "ripple_v95", "qft_d00")
+    def test_modulus_guard_in_plugins(self, plugin):
+        """Test the existing ModularAdder plugins decline a non-default modulus."""
+        adder = ModularAdderGate(3, modulus=5)
+        circuit = QuantumCircuit(7)
+        circuit.append(adder, range(adder.num_qubits))
+
+        hls_config = HLSConfig(ModularAdder=[plugin])
+        hls = HighLevelSynthesis(hls_config=hls_config)
+        synth = hls(circuit)
+
+        # none of the existing plugins support this modulus, so the gate is left as-is
+        self.assertEqual(synth.count_ops(), {"ModularAdder": 1})
+
+    def test_modulus_guard_in_default_plugin(self):
+        """Test the default ModularAdder synthesis declines a non-default modulus too."""
+        adder = ModularAdderGate(3, modulus=5)
+        circuit = QuantumCircuit(7)
+        circuit.append(adder, range(adder.num_qubits))
+
+        hls = HighLevelSynthesis()
+        synth = hls(circuit)
+
+        self.assertEqual(synth.count_ops(), {"ModularAdder": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the `modulus` half of the API ShellyGarion proposed in https://github.com/Qiskit/qiskit/issues/13608#issuecomment-2859127930

`ModularAdderGate(num_state_qubits, label=None, modulus=None)`, when `modulus` is None (the default) or equals `2**num_state_qubits`, behaviour is byte-for-byte identical to before this PR. A smaller modulus is accepted and validated, but has no synthesis method yet: requesting its definition, or synthesizing it through HighLevelSynthesis, raises/declines rather than producing an incorrect circuit. The four existing ModularAdder plugins (V17, C04, V95, D00) are updated to explicitly decline non-default moduli.

`adder_modular_s21` (the ancilla-free arbitrary-modulus synthesis method named in the same comment) is deliberately not part of this PR. arXiv:2112.10537 (Seidel et al.), which the name refers to, only formulates arithmetic modulo 2**n (semi-boolean polynomials over Z/2^nZ) — it does not contain a construction for an arbitrary modulus. An ancilla-free, register-register adder for arbitrary N is a real derivation rather than a transcription, so I'm following up with that separately rather than rushing an unverified circuit into this PR.

### Testing

- New unit tests for modulus validation, default-equivalence, the not-yet-synthesizable error path, and the plugin guards.
- Full existing adder test module passes unmodified (55 tests).
- test_high_level_synthesis.py, test_arithmetic_counts.py, test_gate_definitions.py all pass unchanged (433 tests).
- black / ruff clean.

Part of #13608.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by:
- [ ] Some submitted code was generated by: