### PR TITLE
Add missing wheel-build requirements to CI

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -146,8 +146,11 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
-
+      - name: run dmesg
+        if: always()
+        run: dmesg
       - uses: actions/upload-artifact@v7
+        if: always()
         with:
           path: ./wheelhouse/*.whl
           name: ${{ inputs.artifact-prefix }}wheels-macos-intel

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -146,11 +146,8 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
-      - name: run dmesg
-        if: always()
-        run: dmesg
+
       - uses: actions/upload-artifact@v7
-        if: always()
         with:
           path: ./wheelhouse/*.whl
           name: ${{ inputs.artifact-prefix }}wheels-macos-intel

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -121,7 +121,7 @@ jobs:
           PGO_OUT_PATH: ${{ github.workspace }}/merged.profdata
 
       - name: Install deployment requirements
-        run: python3 -m pip install --user -r ./github/workflows/wheels/requirements.txt
+        run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
 
@@ -143,7 +143,7 @@ jobs:
         run: rustup toolchain install stable --override --profile minimal --no-self-update
 
       - name: Install deployment requirements
-        run: python3 -m pip install --user -r ./github/workflows/wheels/requirements.txt
+        run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
 
@@ -163,7 +163,7 @@ jobs:
         run: rustup toolchain install stable --override --profile minimal --no-self-update
 
       - name: Install deployment requirements
-        run: python3 -m pip install --user -r ./github/workflows/wheels/requirements.txt
+        run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
 
@@ -182,7 +182,7 @@ jobs:
         run: rustup toolchain install stable --override --profile minimal --no-self-update
 
       - name: Install deployment requirements
-        run: python3 -m pip install --user -r ./github/workflows/wheels/requirements.txt
+        run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
 

--- a/.github/workflows/wheels/requirements.txt
+++ b/.github/workflows/wheels/requirements.txt
@@ -1,0 +1,4 @@
+# Requirements for the wheel-build CI jobs.  Stored in this directory to allow
+# job isolation in the dependabot configuration.
+
+cibuildwheel==3.4.0


### PR DESCRIPTION
In gh-16728[^1] we changed the configuration of the build files, but failed to commit the necessary `requirements.txt` file because our `.gitignore` file includes many unnecessary entries that are completely unscoped, so reached deep into the tree.  Consequently, dependabot has been failing to update two weeks, and the wheel builds would (presumably) have failed had we tried them.

We failed to detect this in CI because we didn't apply the optional `ci: test wheels` label.  I'm not sure how I forgot to do this.

[^1]: 6dba9447eb: Re-enable dependabot updates for `cibuildwheel` (#16728)

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
