### PR TITLE
fix(transpiler): preserve wire layout with loose qubits in OptimizeSwapBeforeMeasure

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -52,6 +52,8 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
                 # the node swap needs to be removed and, if a measure follows, needs to be adapted
                 swap_qargs = swap.qargs
                 measure_layer = DAGCircuit()
+                measure_layer.add_qubits(dag.qubits)
+                measure_layer.add_clbits(dag.clbits)
                 for qreg in dag.qregs.values():
                     measure_layer.add_qreg(qreg)
                 for creg in dag.cregs.values():

--- a/releasenotes/notes/fix-optimize-swap-before-measure-loose-qubits-f9a8b7.yaml
+++ b/releasenotes/notes/fix-optimize-swap-before-measure-loose-qubits-f9a8b7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.OptimizeSwapBeforeMeasure` where circuits containing
+    loose qubits preceding quantum registers in the wire order would have
+    measurements retargeted to incorrect qubits when removing terminal SWAP gates.

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -352,6 +352,29 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
 
         self.assertEqual(expected, after)
 
+    def test_optimize_swap_loose_qubit_before_register(self):
+        """Verify that loose qubits preceding registers preserve correct wire targeting.
+        gh-16874
+        """
+        from qiskit.circuit import Qubit
+        loose_q = Qubit()
+        qreg = QuantumRegister(2, "q")
+        creg = ClassicalRegister(1, "c")
+
+        circuit = QuantumCircuit([loose_q], qreg, creg)
+        circuit.x(qreg[1])
+        circuit.swap(qreg[0], qreg[1])
+        circuit.measure(qreg[0], creg[0])
+
+        expected = QuantumCircuit([loose_q], qreg, creg)
+        expected.x(qreg[1])
+        expected.measure(qreg[1], creg[0])
+
+        pass_ = OptimizeSwapBeforeMeasure()
+        after = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary
`OptimizeSwapBeforeMeasure` previously only added `dag.qregs` and `dag.cregs` to the temporary `measure_layer` DAG. When loose qubits preceded registers in the circuit's wire order, the omitted loose bits caused the subsequent positional `dag.compose(measure_layer)` to retarget measurements to the wrong qubit wires.

### Details and comments
- Added `measure_layer.add_qubits(dag.qubits)` and `measure_layer.add_clbits(dag.clbits)` to preserve complete wire structure before composing.
- Added unit test in `test/python/transpiler/test_optimize_swap_before_measure.py`.
- Added release note in `releasenotes/notes/`.

Fixes #16874