### PR TITLE
fix(circuit): require exact canonical equality when merging PauliEvolutionGates

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -406,8 +406,8 @@ def _merge_two_pauli_evolutions(
         # When both operators are SparseObservables, we can compare their canonical representatives.
         can_merge = gate1.operator.simplify() == gate2.operator.simplify()
     elif isinstance(gate1.operator, SparsePauliOp) and isinstance(gate2.operator, SparsePauliOp):
-        # SparsePauliOp already has a function that compares canonical representatives.
-        can_merge = gate1.operator.equiv(gate2.operator)
+        # When both operators are SparsePauliOps, compare their simplified canonical forms for exact equality.
+        can_merge = gate1.operator.simplify() == gate2.operator.simplify()
     else:
         can_merge = gate1.operator == gate2.operator
 

--- a/releasenotes/notes/fix-pauli-evolution-merge-exact-equiv-e8f7a6.yaml
+++ b/releasenotes/notes/fix-pauli-evolution-merge-exact-equiv-e8f7a6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue in :func:`._merge_two_pauli_evolutions` (used by
+    :class:`.CommutativeOptimization`) where :class:`.SparsePauliOp` Hamiltonians
+    were compared using approximate equivalence rather than exact canonical
+    equality, which could cause gates with slight coefficient differences to be
+    incorrectly merged when evolution times are large.

--- a/test/python/transpiler/test_commutative_optimization.py
+++ b/test/python/transpiler/test_commutative_optimization.py
@@ -336,6 +336,20 @@ class TestCommutativeOptimization(QiskitTestCase):
 
         self.assertEqual(qct, qc)
 
+    def test_not_merge_pauli_evolutions_different_hamiltonian_small_diff(self):
+        """Test that PauliEvolutionGates with slightly different Hamiltonians are not merged.
+        gh-16873
+        """
+        op1 = SparsePauliOp.from_list([("Z", 1.0)])
+        op2 = SparsePauliOp.from_list([("Z", 1.000000005)])
+        qc = QuantumCircuit(1)
+        qc.append(PauliEvolutionGate(op1, 2e8), [0])
+        qc.append(PauliEvolutionGate(op2, 2e8), [0])
+
+        qct = CommutativeOptimization()(qc)
+
+        self.assertEqual(len(qct.data), 2)
+
     def test_merge_pauli_product_rotations(self):
         """Test that the pass merges PauliProductRotationGates."""
 


### PR DESCRIPTION
### Summary
In `_merge_two_pauli_evolutions`, `SparsePauliOp` Hamiltonians were compared using `equiv()`, which allows an absolute tolerance of `1e-8`. When evolution times `t` are large (e.g. `1e8`), even a tiny coefficient difference is amplified by `t`, leading to an unacceptably large phase discrepancy in the merged evolution operator.

### Details and comments
- Changed the merge condition for `SparsePauliOp` to require exact simplified canonical equality (`gate1.operator.simplify() == gate2.operator.simplify()`), matching the logic for `SparseObservable`.
- Added unit test in `test/python/transpiler/test_commutative_optimization.py`.
- Added release note in `releasenotes/notes/`.

Fixes #16873