### PR TITLE
fix(transpiler): preserve zero-qubit Store instructions in LookaheadSwap

### DIFF
--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -301,6 +301,8 @@ def _map_free_gates(state, gates):
             qubits = _first_op_node(gate["graph"]).qargs
 
             if not qubits:
+                mapped_gate = _transform_gate_for_system(gate, state)
+                mapped_gates.append(mapped_gate)
                 continue
 
             if blocked_qubits.intersection(qubits):

--- a/releasenotes/notes/fix-lookahead-swap-store-instruction-d7e8f9.yaml
+++ b/releasenotes/notes/fix-lookahead-swap-store-instruction-d7e8f9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue in :class:`.LookaheadSwap` where zero-qubit operations with
+    classical side effects (such as :class:`.Store` instructions) were silently
+    dropped during routing.

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -315,6 +315,19 @@ class TestLookaheadSwap(QiskitTestCase):
             mapped_dag.count_ops().get("swap", 0), dag_circuit.count_ops().get("swap", 0) + 1
         )
 
+    def test_zero_qubit_store_instruction_preserved(self):
+        """Test that LookaheadSwap preserves zero-qubit Store instructions.
+        gh-16858
+        """
+        circuit = QuantumCircuit(1, 1)
+        circuit.measure(0, 0)
+        circuit.store(circuit.clbits[0], True)
+
+        coupling_map = CouplingMap([[0, 0]])
+        mapped_dag = LookaheadSwap(coupling_map).run(circuit_to_dag(circuit))
+
+        self.assertEqual(mapped_dag.count_ops().get("store", 0), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary
`LookaheadSwap._map_free_gates` previously skipped operations that lacked a quantum partition and had empty `qargs` (`if not qubits: continue`). As a result, zero-qubit operations with classical side effects (such as `Store`) were omitted from `mapped_gates` and silently deleted from the output circuit.

### Details and comments
- In `_map_free_gates`, when `not qubits`, transform and append the operation to `mapped_gates` so it is preserved in the output DAG.
- Added unit test in `test/python/transpiler/test_lookahead_swap.py`.
- Added release note in `releasenotes/notes/`.

Fixes #16858