### PR TITLE
Fixed Litinski transformation on PPMs with negative phases

### DIFF
--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -439,7 +439,11 @@ pub fn run_litinski_transformation(
                         .collect();
 
                     let (sign, z, x, indices) = clifford.evolve_pauli(in_z, in_x, &indices_in);
-                    let ppm = PauliProductMeasurement { z, x, neg: pp_meas.neg ^ sign };
+                    let ppm = PauliProductMeasurement {
+                        z,
+                        x,
+                        neg: pp_meas.neg ^ sign,
+                    };
                     qargs.clear();
                     qargs.extend(bytemuck::cast_slice(&indices));
 

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -439,7 +439,7 @@ pub fn run_litinski_transformation(
                         .collect();
 
                     let (sign, z, x, indices) = clifford.evolve_pauli(in_z, in_x, &indices_in);
-                    let ppm = PauliProductMeasurement { z, x, neg: sign };
+                    let ppm = PauliProductMeasurement { z, x, neg: pp_meas.neg ^ sign };
                     qargs.clear();
                     qargs.extend(bytemuck::cast_slice(&indices));
 

--- a/releasenotes/notes/fix-litinsky-ppm-d64bb3d99fe3eaba.yaml
+++ b/releasenotes/notes/fix-litinsky-ppm-d64bb3d99fe3eaba.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.LitinskiTransformation` when processing circuits
+    with :class:`.PauliProductMeasurement`  instructions, where the a of the
+    Pauli product measurement instruction was incorrectly dropped.
+
+    See `#16869 <https://github.com/Qiskit/qiskit/issues/16869>`__.

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -621,6 +621,16 @@ class TestLitinskiTransformation(QiskitTestCase):
 
         self.assertEqual(qct, expected)
 
+    @data("Z", "-Z", "X", "-X", "Y", "-Y")
+    def test_preserves_ppm_sign(self, pauli1q):
+        """Test that Litinski transformation preserves the PPM instruction (including
+        its sign), when evolving under identity.
+        """
+        qc = QuantumCircuit(1, 1)
+        qc.append(PauliProductMeasurement(Pauli(pauli1q)), [0], [0])
+        qct = LitinskiTransformation(use_ppr=True)(qc)
+        self.assertEqual(qc, qct)
+
     def test_on_circuits_with_ppr_ppm(self):
         """Test the Litinski transformation pass on a more complex with Clifford gates,
         T gates and Z-measures.
@@ -645,9 +655,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [1])
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [2])
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [3])
-        qc.append(PauliProductMeasurement(Pauli("Z")), [0], [0])
+        qc.append(PauliProductMeasurement(Pauli("-Z")), [0], [0])
         qc.append(PauliProductMeasurement(Pauli("Z")), [1], [1])
-        qc.append(PauliProductMeasurement(Pauli("Z")), [2], [2])
+        qc.append(PauliProductMeasurement(Pauli("-Z")), [2], [2])
         qc.append(PauliProductMeasurement(Pauli("Z")), [3], [3])
 
         # Apply the Litinski transform with fix_cliffords=False (ignoring the Clifford gates
@@ -660,9 +670,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         expected.append(PauliProductRotationGate(Pauli("YX"), np.pi / 4), [1, 2])
         expected.append(PauliProductRotationGate(Pauli("Y"), -np.pi / 4), [3])
         expected.append(PauliProductRotationGate(Pauli("YZZZ"), -np.pi / 4), [0, 1, 2, 3])
-        expected.append(PauliProductMeasurement(Pauli("YZZY")), [0, 1, 2, 3], [0])
+        expected.append(PauliProductMeasurement(Pauli("-YZZY")), [0, 1, 2, 3], [0])
         expected.append(PauliProductMeasurement(Pauli("XX")), [0, 1], [1])
-        expected.append(PauliProductMeasurement(Pauli("-Z")), [2], [2])
+        expected.append(PauliProductMeasurement(Pauli("Z")), [2], [2])
         expected.append(PauliProductMeasurement(Pauli("XX")), [0, 3], [3])
 
         self.assertEqual(qct, expected)

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -655,9 +655,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [1])
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [2])
         qc.append(PauliProductRotationGate(Pauli("X"), np.pi / 2), [3])
-        qc.append(PauliProductMeasurement(Pauli("-Z")), [0], [0])
+        qc.append(PauliProductMeasurement(Pauli("Z")), [0], [0])
         qc.append(PauliProductMeasurement(Pauli("Z")), [1], [1])
-        qc.append(PauliProductMeasurement(Pauli("-Z")), [2], [2])
+        qc.append(PauliProductMeasurement(Pauli("Z")), [2], [2])
         qc.append(PauliProductMeasurement(Pauli("Z")), [3], [3])
 
         # Apply the Litinski transform with fix_cliffords=False (ignoring the Clifford gates
@@ -670,9 +670,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         expected.append(PauliProductRotationGate(Pauli("YX"), np.pi / 4), [1, 2])
         expected.append(PauliProductRotationGate(Pauli("Y"), -np.pi / 4), [3])
         expected.append(PauliProductRotationGate(Pauli("YZZZ"), -np.pi / 4), [0, 1, 2, 3])
-        expected.append(PauliProductMeasurement(Pauli("-YZZY")), [0, 1, 2, 3], [0])
+        expected.append(PauliProductMeasurement(Pauli("YZZY")), [0, 1, 2, 3], [0])
         expected.append(PauliProductMeasurement(Pauli("XX")), [0, 1], [1])
-        expected.append(PauliProductMeasurement(Pauli("Z")), [2], [2])
+        expected.append(PauliProductMeasurement(Pauli("-Z")), [2], [2])
         expected.append(PauliProductMeasurement(Pauli("XX")), [0, 3], [3])
 
         self.assertEqual(qct, expected)


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Fixes #16869: when applying `LitinskiTransformation` on a circuit containing a `PauliProductMeasurement` instruction with a negative phase, the negative phase sign was omitted.

Thanks to @windoctober for finding the bug and suggesting the 1-line fix.

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
