### PR TITLE
Use rust-native errors in the synthesis crate

### DIFF
--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -335,8 +335,7 @@ impl GateSequence {
                 OperationRef::StandardGate(gate) => Ok(gate),
                 _ => Err(DiscreteBasisError::NonStandardGate),
             })
-            .collect::<Result<_, DiscreteBasisError>>()
-            .map_err(PyErr::from)?;
+            .collect::<Result<_, DiscreteBasisError>>()?;
 
         let matrix_so3 = matrix3_from_pyreadonly(&matrix_so3);
         Ok(Self {

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -36,6 +36,9 @@ pub enum DiscreteBasisError {
 
     #[error("Cannot extract matrix from operation.")]
     NoMatrix,
+
+    #[error("Only standard gates are allowed in GateSequence.from_gates_and_matrix.")]
+    NonStandardGate,
 }
 
 impl From<DiscreteBasisError> for PyErr {
@@ -330,11 +333,10 @@ impl GateSequence {
             .iter()
             .map(|op| match op.operation.view() {
                 OperationRef::StandardGate(gate) => Ok(gate),
-                _ => Err(PyValueError::new_err(
-                    "Only standard gates are allowed in GateSequence.from_gates_and_matrix",
-                )),
+                _ => Err(DiscreteBasisError::NonStandardGate),
             })
-            .collect::<PyResult<_>>()?;
+            .collect::<Result<_, DiscreteBasisError>>()
+            .map_err(PyErr::from)?;
 
         let matrix_so3 = matrix3_from_pyreadonly(&matrix_so3);
         Ok(Self {

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -31,13 +31,13 @@ use super::math;
 
 #[derive(Error, Debug)]
 pub enum DiscreteBasisError {
-    #[error("Parameterized gates cannot be decomposed.")]
+    #[error("parameterized gates cannot be decomposed")]
     ParameterizedGate,
 
-    #[error("Cannot extract matrix from operation.")]
+    #[error("cannot extract matrix from operation")]
     NoMatrix,
 
-    #[error("Only standard gates are allowed in GateSequence.from_gates_and_matrix.")]
+    #[error("only standard gates are allowed in GateSequence.from_gates_and_matrix")]
     NonStandardGate,
 }
 

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -17,10 +17,7 @@ use nalgebra::{DMatrix, DMatrixView, Dim, Dyn, MatrixView, Scalar, ViewStorage};
 use ndarray::ArrayView2;
 use ndarray::ShapeBuilder;
 use num_complex::Complex64;
-use pyo3::PyErr;
 use thiserror::Error;
-
-use crate::QiskitError;
 
 pub mod cos_sin_decomp;
 
@@ -38,22 +35,6 @@ pub enum LinAlgError {
 
     #[error("SVD decomposition failed")]
     SVDDecompositionFailed,
-}
-
-impl From<LinAlgError> for PyErr {
-    fn from(error: LinAlgError) -> Self {
-        match error {
-            LinAlgError::EigenDecompositionFailed => QiskitError::new_err(
-                "Internal eigendecomposition failed. \
-                This can point to a numerical tolerance issue.",
-            ),
-
-            LinAlgError::SVDDecompositionFailed => QiskitError::new_err(
-                "Internal SVD decomposition failed. \
-                This can point to a numerical tolerance issue.",
-            ),
-        }
-    }
 }
 
 #[inline]

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -17,7 +17,10 @@ use nalgebra::{DMatrix, DMatrixView, Dim, Dyn, MatrixView, Scalar, ViewStorage};
 use ndarray::ArrayView2;
 use ndarray::ShapeBuilder;
 use num_complex::Complex64;
+use pyo3::PyErr;
 use thiserror::Error;
+
+use crate::QiskitError;
 
 pub mod cos_sin_decomp;
 
@@ -30,11 +33,27 @@ pub const VERIFY_TOL: f64 = 1e-7;
 /// Errors that might occur in linear algebra computations
 #[derive(Error, Debug)]
 pub enum LinAlgError {
-    #[error("Eigen decomposition failed")]
+    #[error("eigen decomposition failed")]
     EigenDecompositionFailed,
 
     #[error("SVD decomposition failed")]
     SVDDecompositionFailed,
+}
+
+impl From<LinAlgError> for PyErr {
+    fn from(error: LinAlgError) -> Self {
+        match error {
+            LinAlgError::EigenDecompositionFailed => QiskitError::new_err(
+                "Internal eigendecomposition failed. \
+                This can point to a numerical tolerance issue.",
+            ),
+
+            LinAlgError::SVDDecompositionFailed => QiskitError::new_err(
+                "Internal SVD decomposition failed. \
+                This can point to a numerical tolerance issue.",
+            ),
+        }
+    }
 }
 
 #[inline]

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -28,13 +28,13 @@ mod utils;
 /// Possible errors that can occur when validating a permutation pattern.
 #[derive(Debug, thiserror::Error)]
 pub enum PermutationError {
-    #[error("Invalid permutation: input contains a negative number.")]
+    #[error("invalid permutation: input contains a negative number")]
     NegativeEntry,
 
-    #[error("Invalid permutation: input has length {length} and contains {value}.")]
+    #[error("invalid permutation: input has length {length} and contains {value}")]
     OutOfBounds { length: usize, value: i64 },
 
-    #[error("Invalid permutation: input contains {value} more than once.")]
+    #[error("invalid permutation: input contains {value} more than once")]
     DuplicateEntry { value: i64 },
 }
 

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -13,6 +13,7 @@
 use numpy::PyArrayLike1;
 use smallvec::smallvec;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
@@ -24,6 +25,25 @@ use super::linear_phase::cz_depth_lnn::LnnGatesVec;
 
 mod utils;
 
+/// Possible errors that can occur when validating a permutation pattern.
+#[derive(Debug, thiserror::Error)]
+pub enum PermutationError {
+    #[error("Invalid permutation: input contains a negative number.")]
+    NegativeEntry,
+
+    #[error("Invalid permutation: input has length {length} and contains {value}.")]
+    OutOfBounds { length: usize, value: i64 },
+    
+    #[error("Invalid permutation: input contains {value} more than once.")]
+    DuplicateEntry { value: i64 },
+}
+
+impl From<PermutationError> for PyErr {
+    fn from(value: PermutationError) -> Self {
+        PyValueError::new_err(value.to_string())
+    }
+}
+
 /// Checks whether an array of size N is a permutation of 0, 1, ..., N - 1.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
@@ -32,7 +52,7 @@ pub fn _validate_permutation(
     pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
 ) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
-    utils::validate_permutation(&view)?;
+    utils::validate_permutation(&view).map_err(PyErr::from)?;
     Ok(py.None())
 }
 

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -33,7 +33,7 @@ pub enum PermutationError {
 
     #[error("Invalid permutation: input has length {length} and contains {value}.")]
     OutOfBounds { length: usize, value: i64 },
-    
+
     #[error("Invalid permutation: input contains {value} more than once.")]
     DuplicateEntry { value: i64 },
 }

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -13,7 +13,6 @@
 use numpy::PyArrayLike1;
 use smallvec::smallvec;
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
@@ -25,25 +24,6 @@ use super::linear_phase::cz_depth_lnn::LnnGatesVec;
 
 mod utils;
 
-/// Possible errors that can occur when validating a permutation pattern.
-#[derive(Debug, thiserror::Error)]
-pub enum PermutationError {
-    #[error("invalid permutation: input contains a negative number")]
-    NegativeEntry,
-
-    #[error("invalid permutation: input has length {length} and contains {value}")]
-    OutOfBounds { length: usize, value: i64 },
-
-    #[error("invalid permutation: input contains {value} more than once")]
-    DuplicateEntry { value: i64 },
-}
-
-impl From<PermutationError> for PyErr {
-    fn from(value: PermutationError) -> Self {
-        PyValueError::new_err(value.to_string())
-    }
-}
-
 /// Checks whether an array of size N is a permutation of 0, 1, ..., N - 1.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
@@ -52,7 +32,7 @@ pub fn _validate_permutation(
     pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
 ) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
-    utils::validate_permutation(&view).map_err(PyErr::from)?;
+    utils::validate_permutation(&view)?;
     Ok(py.None())
 }
 

--- a/crates/synthesis/src/permutation/utils.rs
+++ b/crates/synthesis/src/permutation/utils.rs
@@ -10,10 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::permutation::PermutationError;
 use ndarray::ArrayViewMut1;
 use ndarray::{Array1, ArrayView1};
 use std::vec::Vec;
-use crate::permutation::PermutationError;
 
 use qiskit_util::py::PySequenceIndex;
 

--- a/crates/synthesis/src/permutation/utils.rs
+++ b/crates/synthesis/src/permutation/utils.rs
@@ -12,33 +12,29 @@
 
 use ndarray::ArrayViewMut1;
 use ndarray::{Array1, ArrayView1};
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
 use std::vec::Vec;
+use crate::permutation::PermutationError;
 
 use qiskit_util::py::PySequenceIndex;
 
-pub fn validate_permutation(pattern: &ArrayView1<i64>) -> PyResult<()> {
+pub fn validate_permutation(pattern: &ArrayView1<i64>) -> Result<(), PermutationError> {
     let n = pattern.len();
     let mut seen: Vec<bool> = vec![false; n];
 
     for &x in pattern {
         if x < 0 {
-            return Err(PyValueError::new_err(
-                "Invalid permutation: input contains a negative number.",
-            ));
+            return Err(PermutationError::NegativeEntry);
         }
 
         if x as usize >= n {
-            return Err(PyValueError::new_err(format!(
-                "Invalid permutation: input has length {n} and contains {x}."
-            )));
+            return Err(PermutationError::OutOfBounds {
+                length: n,
+                value: x,
+            });
         }
 
         if seen[x as usize] {
-            return Err(PyValueError::new_err(format!(
-                "Invalid permutation: input contains {x} more than once."
-            )));
+            return Err(PermutationError::DuplicateEntry { value: x });
         }
 
         seen[x as usize] = true;

--- a/crates/synthesis/src/permutation/utils.rs
+++ b/crates/synthesis/src/permutation/utils.rs
@@ -10,12 +10,32 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::permutation::PermutationError;
+use crate::PyErr;
 use ndarray::ArrayViewMut1;
 use ndarray::{Array1, ArrayView1};
+use pyo3::exceptions::PyValueError;
 use std::vec::Vec;
 
 use qiskit_util::py::PySequenceIndex;
+
+/// Possible errors that can occur when validating a permutation pattern.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PermutationError {
+    #[error("invalid permutation: input contains a negative number")]
+    NegativeEntry,
+
+    #[error("invalid permutation: input has length {length} and contains {value}")]
+    OutOfBounds { length: usize, value: i64 },
+
+    #[error("invalid permutation: input contains {value} more than once")]
+    DuplicateEntry { value: i64 },
+}
+
+impl From<PermutationError> for PyErr {
+    fn from(value: PermutationError) -> Self {
+        PyValueError::new_err(value.to_string())
+    }
+}
 
 pub fn validate_permutation(pattern: &ArrayView1<i64>) -> Result<(), PermutationError> {
     let n = pattern.len();

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -24,6 +24,7 @@ use pyo3::prelude::*;
 use smallvec::smallvec;
 use thiserror::Error;
 
+use crate::QiskitError;
 use crate::euler_one_qubit_decomposer::{
     EulerBasis, EulerBasisSet, unitary_to_gate_sequence_inner,
 };
@@ -68,6 +69,22 @@ impl From<QSDError> for PyErr {
             QSDError::ErrorFromCircuitData(err) => err.into(),
 
             QSDError::ErrorFromPython(err) => err,
+        }
+    }
+}
+
+impl From<LinAlgError> for PyErr {
+    fn from(error: LinAlgError) -> Self {
+        match error {
+            LinAlgError::EigenDecompositionFailed => QiskitError::new_err(
+                "Internal eigendecomposition failed. \
+                This can point to a numerical tolerance issue.",
+            ),
+
+            LinAlgError::SVDDecompositionFailed => QiskitError::new_err(
+                "Internal SVD decomposition failed. \
+                This can point to a numerical tolerance issue.",
+            ),
         }
     }
 }

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -19,12 +19,10 @@ use nalgebra::{Matrix4, U4};
 use ndarray::prelude::*;
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use smallvec::smallvec;
 use thiserror::Error;
 
-use crate::QiskitError;
 use crate::euler_one_qubit_decomposer::{
     EulerBasis, EulerBasisSet, unitary_to_gate_sequence_inner,
 };
@@ -59,6 +57,10 @@ pub enum QSDError {
     // wraps PyErr, e.g. produced by 2q decomposer
     #[error(transparent)]
     ErrorFromPython(#[from] PyErr),
+
+    // unknown one-qubit decomposer basis name
+    #[error("unknown basis name {0}")]
+    UnknownBasis(String),
 }
 
 impl From<QSDError> for PyErr {
@@ -69,22 +71,8 @@ impl From<QSDError> for PyErr {
             QSDError::ErrorFromCircuitData(err) => err.into(),
 
             QSDError::ErrorFromPython(err) => err,
-        }
-    }
-}
 
-impl From<LinAlgError> for PyErr {
-    fn from(error: LinAlgError) -> Self {
-        match error {
-            LinAlgError::EigenDecompositionFailed => QiskitError::new_err(
-                "Internal eigendecomposition failed. \
-                This can point to a numerical tolerance issue.",
-            ),
-
-            LinAlgError::SVDDecompositionFailed => QiskitError::new_err(
-                "Internal SVD decomposition failed. \
-                This can point to a numerical tolerance issue.",
-            ),
+            QSDError::UnknownBasis(_) => pyo3::exceptions::PyValueError::new_err(error.to_string()),
         }
     }
 }
@@ -901,7 +889,7 @@ pub fn qs_decomposition(
     let one_qubit_decomposer = if let Some(basis_string) = one_qubit_decomposer_basis_string {
         let basis = basis_string
             .parse::<EulerBasis>()
-            .map_err(|_| PyValueError::new_err(format!("Unknown basis name {}", basis_string)))?;
+            .map_err(|_| QSDError::UnknownBasis(basis_string))?;
         one_qubit_decomposer_basis_set.add_basis(basis);
         Some(&one_qubit_decomposer_basis_set)
     } else {

--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -54,20 +54,14 @@ use qiskit_util::complex::{C_M_ONE, C_ONE, IM, M_IM, c64};
 /// Errors that can occur during two-qubit basis decomposition.
 #[derive(Error, Debug)]
 pub enum TwoQubitBasisError {
-    #[error("'{basis}' is not a ZSX basis; 'pulse_optimize' requires ZSX")]
+    #[error("'{basis}' is not a ZSX/SZXX basis; 'pulse_optimize' requires ZSX or ZSXX")]
     PulseOptimizeWrongBasis { basis: String },
 
     #[error("'pulse_optimize' requires a CNOT entangling gate")]
     PulseOptimizeNotCNOT,
 
-    #[error("pulse optimal decomposition could not be computed")]
+    #[error("failed to compute requested pulse optimal decomposition")]
     PulseOptimizeFailed,
-
-    #[error("control flow operations are not supported by the two-qubit decomposer")]
-    UnsupportedControlFlow,
-
-    #[error("KAK gate must be unparameterized")]
-    ParameterizedKAKGate,
 }
 
 impl From<TwoQubitBasisError> for PyErr {
@@ -695,8 +689,7 @@ impl TwoQubitBasisDecomposer {
         };
         let pulse_optimize = self.pulse_optimize.unwrap_or(true);
         let sequence = if pulse_optimize {
-            self.pulse_optimal_chooser(best_nbasis, &decomposition, &target_decomposed)
-                .map_err(PyErr::from)?
+            self.pulse_optimal_chooser(best_nbasis, &decomposition, &target_decomposed)?
         } else {
             None
         };
@@ -795,14 +788,18 @@ impl TwoQubitBasisDecomposer {
         pulse_optimize: Option<bool>,
     ) -> PyResult<Self> {
         if gate.operation.try_control_flow().is_some() {
-            return Err(TwoQubitBasisError::UnsupportedControlFlow.into());
+            return Err(PyValueError::new_err(
+                "Only gates are supported by two qubit decomposer",
+            ));
         }
-        let gate_params: Result<SmallVec<[f64; 3]>, TwoQubitBasisError> = gate
+        let gate_params: Result<SmallVec<[f64; 3]>, PyErr> = gate
             .params_view()
             .iter()
             .map(|x| match x {
                 Param::Float(val) => Ok(*val),
-                _ => Err(TwoQubitBasisError::ParameterizedKAKGate),
+                _ => Err(PyValueError::new_err(
+                    "Only unparameterized gates are supported as KAK gate",
+                )),
             })
             .collect();
         TwoQubitBasisDecomposer::new_inner(

--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -54,14 +54,20 @@ use qiskit_util::complex::{C_M_ONE, C_ONE, IM, M_IM, c64};
 /// Errors that can occur during two-qubit basis decomposition.
 #[derive(Error, Debug)]
 pub enum TwoQubitBasisError {
-    #[error("'pulse_optimize' currently only works with ZSX basis ({basis} used)")]
+    #[error("'{basis}' is not a ZSX basis; 'pulse_optimize' requires ZSX")]
     PulseOptimizeWrongBasis { basis: String },
 
-    #[error("pulse_optimizer currently only works with CNOT entangling gate")]
+    #[error("'pulse_optimize' requires a CNOT entangling gate")]
     PulseOptimizeNotCNOT,
 
-    #[error("Failed to compute requested pulse optimal decomposition")]
+    #[error("pulse optimal decomposition could not be computed")]
     PulseOptimizeFailed,
+
+    #[error("control flow operations are not supported by the two-qubit decomposer")]
+    UnsupportedControlFlow,
+
+    #[error("KAK gate must be unparameterized")]
+    ParameterizedKAKGate,
 }
 
 impl From<TwoQubitBasisError> for PyErr {
@@ -789,18 +795,14 @@ impl TwoQubitBasisDecomposer {
         pulse_optimize: Option<bool>,
     ) -> PyResult<Self> {
         if gate.operation.try_control_flow().is_some() {
-            return Err(PyValueError::new_err(
-                "Only gates are supported by two qubit decomposer",
-            ));
+            return Err(TwoQubitBasisError::UnsupportedControlFlow.into());
         }
-        let gate_params: PyResult<SmallVec<[f64; 3]>> = gate
+        let gate_params: Result<SmallVec<[f64; 3]>, TwoQubitBasisError> = gate
             .params_view()
             .iter()
             .map(|x| match x {
                 Param::Float(val) => Ok(*val),
-                _ => Err(PyValueError::new_err(
-                    "Only unparameterized gates are supported as KAK gate",
-                )),
+                _ => Err(TwoQubitBasisError::ParameterizedKAKGate),
             })
             .collect();
         TwoQubitBasisDecomposer::new_inner(
@@ -808,7 +810,9 @@ impl TwoQubitBasisDecomposer {
             gate_params?,
             gate_matrix.as_array(),
             basis_fidelity,
-            EulerBasis::from_str(euler_basis).map_err(PyValueError::new_err)?,
+            EulerBasis::from_str(euler_basis).map_err(|_| {
+                PyValueError::new_err(format!("unknown euler basis: {euler_basis}"))
+            })?,
             pulse_optimize,
         )
     }

--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -26,6 +26,7 @@ use numpy::{IntoPyArray, ToPyArray};
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use thiserror::Error;
 
 use super::common::{DEFAULT_FIDELITY, HGATE, IPZ, TraceToFidelity, rx_matrix, rz_matrix};
 use super::gate_sequence::{TwoQubitGateSequence, TwoQubitSequenceVec};
@@ -49,6 +50,25 @@ use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{NoBlocks, Qubit};
 use qiskit_util::complex::{C_M_ONE, C_ONE, IM, M_IM, c64};
+
+/// Errors that can occur during two-qubit basis decomposition.
+#[derive(Error, Debug)]
+pub enum TwoQubitBasisError {
+    #[error("'pulse_optimize' currently only works with ZSX basis ({basis} used)")]
+    PulseOptimizeWrongBasis { basis: String },
+
+    #[error("pulse_optimizer currently only works with CNOT entangling gate")]
+    PulseOptimizeNotCNOT,
+
+    #[error("Failed to compute requested pulse optimal decomposition")]
+    PulseOptimizeFailed,
+}
+
+impl From<TwoQubitBasisError> for PyErr {
+    fn from(error: TwoQubitBasisError) -> Self {
+        QiskitError::new_err(error.to_string())
+    }
+}
 
 // Worst case length is 5x 1q gates for each 1q decomposition + 1x 2q gate
 // We might overallocate a bit if the euler basis is different but
@@ -474,7 +494,7 @@ impl TwoQubitBasisDecomposer {
         best_nbasis: u8,
         decomposition: &SmallVec<[Matrix2<Complex64>; 8]>,
         target_decomposed: &TwoQubitWeylDecomposition,
-    ) -> PyResult<Option<TwoQubitGateSequence>> {
+    ) -> Result<Option<TwoQubitGateSequence>, TwoQubitBasisError> {
         if self.pulse_optimize.is_some()
             && (best_nbasis == 0 || best_nbasis == 1 || best_nbasis > 3)
         {
@@ -488,10 +508,9 @@ impl TwoQubitBasisDecomposer {
             }
             _ => {
                 if self.pulse_optimize.is_some() {
-                    return Err(QiskitError::new_err(format!(
-                        "'pulse_optimize' currently only works with ZSX basis ({} used)",
-                        self.euler_basis.as_str()
-                    )));
+                    return Err(TwoQubitBasisError::PulseOptimizeWrongBasis {
+                        basis: self.euler_basis.as_str().to_owned(),
+                    });
                 } else {
                     return Ok(None);
                 }
@@ -502,9 +521,7 @@ impl TwoQubitBasisDecomposer {
             OperationRef::StandardGate(StandardGate::CX)
         ) {
             if self.pulse_optimize.is_some() {
-                return Err(QiskitError::new_err(
-                    "pulse_optimizer currently only works with CNOT entangling gate",
-                ));
+                return Err(TwoQubitBasisError::PulseOptimizeNotCNOT);
             } else {
                 return Ok(None);
             }
@@ -517,9 +534,7 @@ impl TwoQubitBasisDecomposer {
             None
         };
         if self.pulse_optimize.is_some() && res.is_none() {
-            return Err(QiskitError::new_err(
-                "Failed to compute requested pulse optimal decomposition",
-            ));
+            return Err(TwoQubitBasisError::PulseOptimizeFailed);
         }
         Ok(res)
     }
@@ -674,7 +689,8 @@ impl TwoQubitBasisDecomposer {
         };
         let pulse_optimize = self.pulse_optimize.unwrap_or(true);
         let sequence = if pulse_optimize {
-            self.pulse_optimal_chooser(best_nbasis, &decomposition, &target_decomposed)?
+            self.pulse_optimal_chooser(best_nbasis, &decomposition, &target_decomposed)
+                .map_err(PyErr::from)?
         } else {
             None
         };

--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -62,11 +62,22 @@ pub enum TwoQubitBasisError {
 
     #[error("failed to compute requested pulse optimal decomposition")]
     PulseOptimizeFailed,
+
+    #[error("control flow operations are not supported by the two-qubit decomposer")]
+    UnsupportedControlFlow,
+
+    #[error("KAK gate must be unparameterized")]
+    ParameterizedKAKGate,
 }
 
 impl From<TwoQubitBasisError> for PyErr {
     fn from(error: TwoQubitBasisError) -> Self {
-        QiskitError::new_err(error.to_string())
+        let msg = error.to_string();
+        match error {
+            TwoQubitBasisError::UnsupportedControlFlow
+            | TwoQubitBasisError::ParameterizedKAKGate => PyValueError::new_err(msg),
+            _ => QiskitError::new_err(msg),
+        }
     }
 }
 
@@ -788,18 +799,14 @@ impl TwoQubitBasisDecomposer {
         pulse_optimize: Option<bool>,
     ) -> PyResult<Self> {
         if gate.operation.try_control_flow().is_some() {
-            return Err(PyValueError::new_err(
-                "Only gates are supported by two qubit decomposer",
-            ));
+            return Err(TwoQubitBasisError::UnsupportedControlFlow.into());
         }
-        let gate_params: Result<SmallVec<[f64; 3]>, PyErr> = gate
+        let gate_params: Result<SmallVec<[f64; 3]>, TwoQubitBasisError> = gate
             .params_view()
             .iter()
             .map(|x| match x {
                 Param::Float(val) => Ok(*val),
-                _ => Err(PyValueError::new_err(
-                    "Only unparameterized gates are supported as KAK gate",
-                )),
+                _ => Err(TwoQubitBasisError::ParameterizedKAKGate),
             })
             .collect();
         TwoQubitBasisDecomposer::new_inner(

--- a/crates/synthesis/src/two_qubit_decompose/weyl_decomposition.rs
+++ b/crates/synthesis/src/two_qubit_decompose/weyl_decomposition.rs
@@ -26,6 +26,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
+use thiserror::Error;
 
 use crate::QiskitError;
 use crate::euler_one_qubit_decomposer::{
@@ -304,6 +305,36 @@ pub enum Specialization {
 }
 impl_intopyobject_for_copy_pyclass!(Specialization);
 
+#[derive(Error, Debug)]
+pub enum SpecializationError {
+    #[error("unknown specialization discriminant '{0}'")]
+    UnknownDiscriminant(u8),
+}
+
+impl From<SpecializationError> for PyErr {
+    fn from(error: SpecializationError) -> Self {
+        PyValueError::new_err(error.to_string())
+    }
+}
+
+impl Specialization {
+    pub fn from_u8(val: u8) -> Result<Self, SpecializationError> {
+        match val {
+            0 => Ok(Self::General),
+            1 => Ok(Self::IdEquiv),
+            2 => Ok(Self::SWAPEquiv),
+            3 => Ok(Self::PartialSWAPEquiv),
+            4 => Ok(Self::PartialSWAPFlipEquiv),
+            5 => Ok(Self::ControlledEquiv),
+            6 => Ok(Self::MirrorControlledEquiv),
+            7 => Ok(Self::fSimaabEquiv),
+            8 => Ok(Self::fSimabbEquiv),
+            9 => Ok(Self::fSimabmbEquiv),
+            x => Err(SpecializationError::UnknownDiscriminant(x)),
+        }
+    }
+}
+
 #[pymethods]
 impl Specialization {
     fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
@@ -326,21 +357,7 @@ impl Specialization {
 
     #[staticmethod]
     fn _from_u8(val: u8) -> PyResult<Self> {
-        match val {
-            0 => Ok(Self::General),
-            1 => Ok(Self::IdEquiv),
-            2 => Ok(Self::SWAPEquiv),
-            3 => Ok(Self::PartialSWAPEquiv),
-            4 => Ok(Self::PartialSWAPFlipEquiv),
-            5 => Ok(Self::ControlledEquiv),
-            6 => Ok(Self::MirrorControlledEquiv),
-            7 => Ok(Self::fSimaabEquiv),
-            8 => Ok(Self::fSimabbEquiv),
-            9 => Ok(Self::fSimabmbEquiv),
-            x => Err(PyValueError::new_err(format!(
-                "unknown specialization discriminant '{x}'"
-            ))),
-        }
+        Self::from_u8(val).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
### Summary
Replaces Python errors in the pure Rust logic of crates/synthesis with native Rust error types, ensuring that conversion to Python errors occurs at the PyO3 boundary rather than deep within the pure Rust implementation.
The changes include:
- discrete_basis/basic_approximations.rs - add DiscreteBasisError::NonStandardGate variant.
- permutation - introduce PermutationError enum.
- qsd.rs - add QSDError::UnknownBasis variant. 
- two_qubit_decompose/basis_decomposer.rs - introduce TwoQubitBasisError enum.
- two_qubit_decompose/weyl_decomposition.rs - introduce SpecializationError enum.

Note that there is no behaviour changes - all Python-visible error types and messages are preserved exactly.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [X] Some written text was generated by: IBM Bob 2.0.3; I reviewed and checked the tool's suggestions.
- [ ] Some submitted code was generated by: