### PR TITLE
Fix ParameterExpression equality for inverse vs negative power (#16840)

### DIFF
--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -877,38 +877,36 @@ impl SymbolExpr {
                     },
                 }
             }
-            SymbolExpr::Binary { op, lhs, rhs } => {
-                match op {
-                    BinaryOp::Mul => match lhs.mul_expand(rhs) {
-                        Some(e) => e,
-                        None => _mul(lhs.as_ref().clone(), rhs.as_ref().clone()),
-                    },
-                    BinaryOp::Div => match lhs.div_expand(rhs) {
-                        Some(e) => e,
-                        None => _div(lhs.as_ref().clone(), rhs.as_ref().clone()),
-                    },
-                    BinaryOp::Add => match lhs.add_opt(rhs, true) {
-                        Some(e) => e,
-                        None => _add(lhs.as_ref().clone(), rhs.as_ref().clone()),
-                    },
-                    BinaryOp::Sub => match lhs.sub_opt(rhs, true) {
-                        Some(e) => e,
-                        None => _sub(lhs.as_ref().clone(), rhs.as_ref().clone()),
-                    },
-                    BinaryOp::Pow => {
-                        let base = lhs.expand();
-                        let exponent = rhs.expand();
-                        match &exponent {
-                            SymbolExpr::Value(v) if v.is_minus_one() => base.rcp(),
-                            SymbolExpr::Value(v) if v.is_negative() => {
-                                let pos_exponent = SymbolExpr::Value(-*v);
-                                base.pow(&pos_exponent).rcp()
-                            }
-                            _ => _pow(base, exponent),
+            SymbolExpr::Binary { op, lhs, rhs } => match op {
+                BinaryOp::Mul => match lhs.mul_expand(rhs) {
+                    Some(e) => e,
+                    None => _mul(lhs.as_ref().clone(), rhs.as_ref().clone()),
+                },
+                BinaryOp::Div => match lhs.div_expand(rhs) {
+                    Some(e) => e,
+                    None => _div(lhs.as_ref().clone(), rhs.as_ref().clone()),
+                },
+                BinaryOp::Add => match lhs.add_opt(rhs, true) {
+                    Some(e) => e,
+                    None => _add(lhs.as_ref().clone(), rhs.as_ref().clone()),
+                },
+                BinaryOp::Sub => match lhs.sub_opt(rhs, true) {
+                    Some(e) => e,
+                    None => _sub(lhs.as_ref().clone(), rhs.as_ref().clone()),
+                },
+                BinaryOp::Pow => {
+                    let base = lhs.expand();
+                    let exponent = rhs.expand();
+                    match &exponent {
+                        SymbolExpr::Value(v) if v.is_minus_one() => base.rcp(),
+                        SymbolExpr::Value(v) if v.is_negative() => {
+                            let pos_exponent = SymbolExpr::Value(-*v);
+                            base.pow(&pos_exponent).rcp()
                         }
+                        _ => _pow(base, exponent),
                     }
                 }
-            }
+            },
         }
     }
 

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -784,7 +784,18 @@ impl SymbolExpr {
                         Some(e) => e,
                         None => _sub(lhs.as_ref().clone(), rhs.as_ref().clone()),
                     },
-                    _ => _pow(lhs.expand(), rhs.expand()), // TO DO : add expand for pow
+                    BinaryOp::Pow => {
+                        let base = lhs.expand();
+                        let exponent = rhs.expand();
+                        match &exponent {
+                            SymbolExpr::Value(v) if v.is_minus_one() => base.rcp(),
+                            SymbolExpr::Value(v) if v.is_negative() => {
+                                let pos_exponent = SymbolExpr::Value(-*v);
+                                base.pow(&pos_exponent).rcp()
+                            }
+                            _ => _pow(base, exponent),
+                        }
+                    }
                 }
             }
         }

--- a/releasenotes/notes/fix-inverse-negative-power-equality-d83f3b1194a4e5ed.yaml
+++ b/releasenotes/notes/fix-inverse-negative-power-equality-d83f3b1194a4e5ed.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :class:`.ParameterExpression` equality so that mathematically
+    equivalent expressions built via division and negative exponentiation
+    (for example, ``1 / x`` and ``x ** -1``) now compare equal. Previously
+    these produced structurally different expression trees and were
+    treated as unequal even though they represent the same value.
+    Fixed `#16840 <https://github.com/Qiskit/qiskit/issues/16840>`__.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -2256,6 +2256,13 @@ class TestParameterEquality(QiskitTestCase):
         self.assertEqual(expr, theta)
         self.assertEqual(theta, expr)
 
+    def test_inverse_equals_negative_power(self):
+        """Verify 1/x is equal to x ** (-1) for parameter expressions."""
+        theta = Parameter("theta")
+
+        self.assertEqual(1 / theta, theta ** (-1))
+        self.assertEqual(theta ** (-2), 1 / (theta**2))
+
 
 class TestParameterView(QiskitTestCase):
     """Test the ParameterView object."""


### PR DESCRIPTION
### Summary

Fixes #16840. `ParameterExpression` equality did not recognize that `1/x` and
`x ** -1` are mathematically identical, since the two operations built
structurally different expression trees (`Div` vs `Pow`), and `expand()` had
no normalization step for negative exponents (see the `// TO DO : add expand
for pow` comment that was previously in `symbol_expr.rs`).

### Details

- `SymbolExpr::expand()`'s `Pow` handling now recognizes a negative
  integer/value exponent and rewrites it as a reciprocal of the
  positive-exponent form (`x ** -1` -> `1/x` via `rcp()`, `x ** -n` ->
  `1/(x**n)`), matching the canonical shape that `Div` already normalizes to.
- Added `test_inverse_equals_negative_power` in
  `test/python/circuit/test_parameters.py` covering both `1/x == x**-1` and
  `x**-2 == 1/(x**2)`.
- Added a release note.

### Testing

- `pytest test/python/circuit/test_parameters.py -v` passes locally.
- `cargo fmt --check` and `cargo clippy -- -D warnings` pass locally.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: Claude (Anthropic)
- [x] Some submitted code was generated by: Claude (Anthropic)

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->