### PR TITLE
Fix non-identity removal in ConsolidateBlocks for gates wider than 2 qubits

### DIFF
--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -327,8 +327,8 @@ fn should_substitute(
                 .to_owned();
             Ok(matrix)
         })?;
-        let trace = matrix[(0, 0)] + matrix[(1, 1)];
-        let dim = 2.0;
+        let trace = matrix.diag().sum();
+        let dim = matrix.nrows() as f64;
         if let Some(phase_update) = average_gate_fidelity_below_tol(trace / dim, dim, tol) {
             return Ok(ConsolidateResult::Identity(phase_update));
         } else {

--- a/releasenotes/notes/fix-consolidate-blocks-identity-removal-0a3cdb5711b76c7e.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-identity-removal-0a3cdb5711b76c7e.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Fixed :class:`.ConsolidateBlocks` incorrectly removing non-identity gates
-    wider than 2 qubits with two 1s present at the beginning of their main
-    diagonal.
+    wider than 2 qubits with two unit roots present at the beginning of their 
+    main diagonal.
     Fixed `#16852 <https://github.com/Qiskit/qiskit/issues/16852>`__.

--- a/releasenotes/notes/fix-consolidate-blocks-identity-removal-0a3cdb5711b76c7e.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-identity-removal-0a3cdb5711b76c7e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed :class:`.ConsolidateBlocks` incorrectly removing non-identity gates
+    wider than 2 qubits with two 1s present at the beginning of their main
+    diagonal.
+    Fixed `#16852 <https://github.com/Qiskit/qiskit/issues/16852>`__.

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -35,7 +35,12 @@ from qiskit.converters import circuit_to_dag
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.measures import process_fidelity
 from qiskit.transpiler import PassManager, Target, generate_preset_pass_manager
-from qiskit.transpiler.passes import ConsolidateBlocks, Collect1qRuns, Collect2qBlocks
+from qiskit.transpiler.passes import (
+    ConsolidateBlocks,
+    Collect1qRuns,
+    Collect2qBlocks,
+    CollectMultiQBlocks,
+)
 from test import QiskitTestCase
 
 
@@ -465,6 +470,13 @@ class TestConsolidateBlocks(QiskitTestCase):
         qc.h(0)
         pm = PassManager([Collect2qBlocks(), Collect1qRuns(), ConsolidateBlocks()])
         self.assertEqual(QuantumCircuit(5, global_phase=np.pi), pm.run(qc))
+
+    def test_toffoli_is_not_removed(self):
+        """Test that toffoli gate is not removed during consolidated block pass."""
+        qc = QuantumCircuit(3)
+        qc.ccx(0, 1, 2)
+        pm = PassManager([CollectMultiQBlocks(max_block_size=3), ConsolidateBlocks()])
+        self.assertTrue(Operator(qc).equiv(Operator(pm.run(qc))))
 
     def test_descent_into_control_flow(self):
         """Test consolidation in blocks when control flow op is the same as at top level."""


### PR DESCRIPTION
### Summary

PR #16082 updated `ConsolidateBlocks` to use the average gate fidelity to check whether gates are equivalent to the identity and removed. However, for gates wider than two qubits, the code for one qubit gates was reused. As a result, it calculated the trace using only the first two entries of the gate's main diagonal and hard coded the dimension as 2. This issue caused the pass to, for example, incorrectly remove the Toffoli gate.

### Details

- Updated the trace calculation to sum the entire diagonal of the matrix
- Removed the hard coding of `dim = 2.0` to instead use the number of rows in the matrix to get the dimension
- Added a regression test that ensures Toffoli gates are not removed during the pass

Fixes #16852 

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:
