### PR TITLE
Pin `scs` to `<3.3.0`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -7,3 +7,8 @@ pydot>=4.0.0
 # z3-solver 5.0 fails to install/load in CI on macOS 15 / Python 3.10 jobs.  See
 # https://github.com/Qiskit/qiskit/issues/16601 for the current state.
 z3-solver<5.0; sys_platform == "darwin"
+
+# scs 3.3.0 (a cvxpy solver backend) bundles Intel oneMKL in its Linux/Windows
+# x86_64 wheel but fails to load it, aborting with "Cannot load libmkl_def.so.3".
+# Pin back until upstream ships a fixed release.
+scs<3.3.0


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

A new version of SCS was released yesterday, breaking our CI (SCS is a _splitting conic solver_ used by CVXPY, which is a _Python library for convex optimizations_, optionally used by Qiskit).

Claude suggested to pin the SCS version to <3.3.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: `Claude sonnet`

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
