### PR TITLE
feat: add `qk_obs_with_capacity`

### DIFF
--- a/capi_slots.txt
+++ b/capi_slots.txt
@@ -866,7 +866,7 @@ qi = [
     "qk_obs_to_python",
     "qk_obs_borrow_from_python",
     "qk_obs_convert_from_python",
-    "qk_obs_with_capacity",
+    "",
     "",
     "",
     "",

--- a/capi_slots.txt
+++ b/capi_slots.txt
@@ -866,7 +866,7 @@ qi = [
     "qk_obs_to_python",
     "qk_obs_borrow_from_python",
     "qk_obs_convert_from_python",
-    "",
+    "qk_obs_with_capacity",
     "",
     "",
     "",

--- a/crates/cext-vtable/src/lib.rs
+++ b/crates/cext-vtable/src/lib.rs
@@ -292,6 +292,7 @@ mod sparse_observable {
             export_fn!(qk_obs_to_python, feature = "python_binding"),
             export_fn!(qk_obs_borrow_from_python, feature = "python_binding"),
             export_fn!(qk_obs_convert_from_python, feature = "python_binding"),
+            export_fn!(qk_obs_with_capacity),
         ]
     });
 }

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -109,9 +109,8 @@ pub extern "C" fn qk_obs_identity(num_qubits: u32) -> *mut SparseObservable {
 ///
 /// # Example
 /// ```c
-///     QkObs *empty = qk_obs_with_capacity(100, 100, 1000);
+/// QkObs *empty = qk_obs_with_capacity(100, 100, 1000);
 /// ```
-///
 #[unsafe(no_mangle)]
 pub extern "C" fn qk_obs_with_capacity(
     num_qubits: u32,

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -99,6 +99,30 @@ pub extern "C" fn qk_obs_identity(num_qubits: u32) -> *mut SparseObservable {
 }
 
 /// @ingroup QkObs
+/// Construct an empty observable with a pre-allocated capacity.
+///
+/// @param num_qubits The number of qubits the observable is defined on.
+/// @param num_terms The number of terms for which to pre-allocate capacity.
+/// @param num_bit_terms The number of bit terms for which to pre-allocate capacity.
+///
+/// @return A pointer to the created observable.
+///
+/// # Example
+/// ```c
+///     QkObs *empty = qk_obs_with_capacity(100, 100, 1000);
+/// ```
+///
+#[unsafe(no_mangle)]
+pub extern "C" fn qk_obs_with_capacity(
+    num_qubits: u32,
+    num_terms: usize,
+    num_bit_terms: usize,
+) -> *mut SparseObservable {
+    let obs = SparseObservable::with_capacity(num_qubits, num_terms, num_bit_terms);
+    Box::into_raw(Box::new(obs))
+}
+
+/// @ingroup QkObs
 /// Construct a new observable from raw data.
 ///
 /// Any of the pointer arguments may be ``NULL`` if and only if their corresponding length is zero.

--- a/docs/cdoc/qk-obs.rst
+++ b/docs/cdoc/qk-obs.rst
@@ -215,23 +215,26 @@ of the number of terms, you can iterate over all observable terms as
 Construction
 ============
 
-``QkObs`` can be constructed by initializing an empty observable (with ``qk_obs_zero``) and
-iteratively adding terms (with ``qk_obs_add_term``). Alternatively, an observable can be
-constructed from "raw" data (with ``qk_obs_new``) if all internal data is specified. This requires
-care to ensure the data is coherent and results in a valid observable.
+``QkObs`` can be constructed by initializing an empty observable (with ``qk_obs_zero`` or
+``qk_obs_with_capacity``) and iteratively adding terms (with
+``qk_obs_add_term``). Alternatively, an observable can be constructed from "raw"
+data (with ``qk_obs_new``) if all internal data is specified. This requires care
+to ensure the data is coherent and results in a valid observable.
 
 .. _qkobs-constructors:
 .. table:: Constructors
 
-  ===================  =========================================================================
-  Function             Summary
-  ===================  =========================================================================
-  ``qk_obs_zero``      Construct an empty observable on a given number of qubits.
+  ========================  =========================================================================
+  Function                  Summary
+  ========================  =========================================================================
+  ``qk_obs_zero``           Construct an empty observable on a given number of qubits.
 
-  ``qk_obs_identity``  Construct the identity observable on a given number of qubits.
+  ``qk_obs_with_capacity``  Construct an empty observable with a pre-allocated capacity.
 
-  ``qk_obs_new``       Construct an observable from :ref:`the raw data arrays <qkobs-arrays>`.
-  ===================  =========================================================================
+  ``qk_obs_identity``       Construct the identity observable on a given number of qubits.
+
+  ``qk_obs_new``            Construct an observable from :ref:`the raw data arrays <qkobs-arrays>`.
+  ========================  =========================================================================
 
 
 Mathematical manipulation

--- a/releasenotes/notes/qkobs-with-capacity-62bf34a6ccde88f2.yaml
+++ b/releasenotes/notes/qkobs-with-capacity-62bf34a6ccde88f2.yaml
@@ -1,0 +1,5 @@
+---
+features_c:
+  - |
+    Added :c:func:`qk_obs_with_capacity` for constructing emtpy ``QkObs`` instances with a
+    pre-allocated capacity for terms.

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -43,6 +43,18 @@ static int test_identity(void) {
 }
 
 /**
+ * Test the with_capacity constructor.
+ */
+static int test_with_capacity(void) {
+    QkObs *obs = qk_obs_with_capacity(100, 100, 1000);
+    size_t num_terms = qk_obs_num_terms(obs);
+    uint32_t num_qubits = qk_obs_num_qubits(obs);
+    qk_obs_free(obs);
+
+    return (num_terms != 0 || num_qubits != 100) ? EqualityError : Ok;
+}
+
+/**
  * Test copying an observable.
  */
 static int test_copy(void) {
@@ -975,6 +987,7 @@ int test_sparse_observable(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_zero);
     num_failed += RUN_TEST(test_identity);
+    num_failed += RUN_TEST(test_with_capacity);
     num_failed += RUN_TEST(test_add);
     num_failed += RUN_TEST(test_add_inplace);
     num_failed += RUN_TEST(test_scaled_add);


### PR DESCRIPTION
This exposes the Rust-internal `SparseObservable::with_capacity` via the C API as `qk_obs_with_capacity`. This functionality can be quite useful in downstream development when the number of terms to be added to an observable later on is known (at least to some level of approximation) up front for the same reasons that it can be useful for internal development. This is a trivial functionality to expose via the C API.

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by: