### PR TITLE
docs: fix unintentional code example indents

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -89,7 +89,7 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 ///
 /// # Example
 /// ```c
-///     QkQuantumRegister *qr = qk_quantum_register_new(5, "five_qubits");
+/// QkQuantumRegister *qr = qk_quantum_register_new(5, "five_qubits");
 /// ```
 ///
 /// # Safety
@@ -120,8 +120,8 @@ pub unsafe extern "C" fn qk_quantum_register_new(
 ///
 /// # Example
 /// ```c
-///     QkQuantumRegister *qr = qk_quantum_register_new(1024, "qreg");
-///     qk_quantum_register_free(qr);
+/// QkQuantumRegister *qr = qk_quantum_register_new(1024, "qreg");
+/// qk_quantum_register_free(qr);
 /// ```
 ///
 /// # Safety
@@ -155,11 +155,11 @@ pub unsafe extern "C" fn qk_quantum_register_free(reg: *mut QuantumRegister) {
 ///
 /// # Example
 /// ```c
-///     QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
-///     char *name = qk_quantum_register_name(qr);
-///     printf("Register name: %s\n", name);
-///     qk_str_free(name);
-///     qk_quantum_register_free(qr);
+/// QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
+/// char *name = qk_quantum_register_name(qr);
+/// printf("Register name: %s\n", name);
+/// qk_str_free(name);
+/// qk_quantum_register_free(qr);
 /// ```
 ///
 /// # Safety
@@ -186,10 +186,10 @@ pub unsafe extern "C" fn qk_quantum_register_name(qreg: *const QuantumRegister) 
 ///
 /// # Example
 /// ```c
-///     QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
-///     size_t num_qubits = qk_quantum_register_num_bits(qr);
-///     printf("Number of qubits: %zu\n", num_qubits);  // Prints: 5
-///     qk_quantum_register_free(qr);
+/// QkQuantumRegister *qr = qk_quantum_register_new(5, "my_qreg");
+/// size_t num_qubits = qk_quantum_register_num_bits(qr);
+/// printf("Number of qubits: %zu\n", num_qubits);  // Prints: 5
+/// qk_quantum_register_free(qr);
 /// ```
 ///
 /// # Safety
@@ -219,19 +219,19 @@ pub unsafe extern "C" fn qk_quantum_register_num_bits(qreg: *const QuantumRegist
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(2, 0);
-///     QkQuantumRegister *qr = qk_quantum_register_new(3, "my_qreg");
-///     qk_circuit_add_quantum_register(qc, qr);
+/// QkCircuit *qc = qk_circuit_new(2, 0);
+/// QkQuantumRegister *qr = qk_quantum_register_new(3, "my_qreg");
+/// qk_circuit_add_quantum_register(qc, qr);
 ///
-///     uint32_t bit_indices[3];
+/// uint32_t bit_indices[3];
 ///
-///     qk_quantum_register_circuit_bits(qr, qc, bit_indices);
+/// qk_quantum_register_circuit_bits(qr, qc, bit_indices);
 ///
-///     // bit_indices now contains [2, 3, 4] since all qubits are in the circuit
-///     // and the circuit has 2 anonymous qubits
+/// // bit_indices now contains [2, 3, 4] since all qubits are in the circuit
+/// // and the circuit has 2 anonymous qubits
 ///
-///     qk_quantum_register_free(qr);
-///     qk_circuit_free(qc);
+/// qk_quantum_register_free(qr);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn qk_quantum_register_circuit_bits(
 ///
 /// # Example
 /// ```c
-///     QkClassicalRegister *cr = qk_classical_register_new(5, "five_qubits");
+/// QkClassicalRegister *cr = qk_classical_register_new(5, "five_qubits");
 /// ```
 ///
 /// # Safety
@@ -301,8 +301,8 @@ pub unsafe extern "C" fn qk_classical_register_new(
 ///
 /// # Example
 /// ```c
-///     QkClassicalRegister *cr = qk_classical_register_new(1024, "creg");
-///     qk_classical_register_free(cr);
+/// QkClassicalRegister *cr = qk_classical_register_new(1024, "creg");
+/// qk_classical_register_free(cr);
 /// ```
 ///
 /// # Safety
@@ -336,11 +336,11 @@ pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister)
 ///
 /// # Example
 /// ```c
-///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
-///     char *name = qk_classical_register_name(cr);
-///     printf("Register name: %s\n", name);
-///     qk_str_free(name);
-///     qk_classical_register_free(cr);
+/// QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+/// char *name = qk_classical_register_name(cr);
+/// printf("Register name: %s\n", name);
+/// qk_str_free(name);
+/// qk_classical_register_free(cr);
 /// ```
 ///
 /// # Safety
@@ -367,10 +367,10 @@ pub unsafe extern "C" fn qk_classical_register_name(creg: *const ClassicalRegist
 ///
 /// # Example
 /// ```c
-///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
-///     size_t num_clbits = qk_classical_register_num_bits(cr);
-///     printf("Number of clbits: %zu\n", num_clbits);  // Prints: 3
-///     qk_classical_register_free(cr);
+/// QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+/// size_t num_clbits = qk_classical_register_num_bits(cr);
+/// printf("Number of clbits: %zu\n", num_clbits);  // Prints: 3
+/// qk_classical_register_free(cr);
 /// ```
 ///
 /// # Safety
@@ -400,19 +400,19 @@ pub unsafe extern "C" fn qk_classical_register_num_bits(creg: *const ClassicalRe
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 2);
-///     QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
-///     qk_circuit_add_classical_register(qc, cr);
+/// QkCircuit *qc = qk_circuit_new(0, 2);
+/// QkClassicalRegister *cr = qk_classical_register_new(3, "my_creg");
+/// qk_circuit_add_classical_register(qc, cr);
 ///
-///     uint32_t bit_indices[3];
+/// uint32_t bit_indices[3];
 ///
-///     qk_classical_register_circuit_bits(cr, qc, bit_indices);
+/// qk_classical_register_circuit_bits(cr, qc, bit_indices);
 ///
-///     // bit_indices now contains [2, 3, 4] since all clbits are in the circuit
-///     // and the circuit has 2 anonymous clbits
+/// // bit_indices now contains [2, 3, 4] since all clbits are in the circuit
+/// // and the circuit has 2 anonymous clbits
 ///
-///     qk_classical_register_free(cr);
-///     qk_circuit_free(qc);
+/// qk_classical_register_free(cr);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -448,11 +448,11 @@ pub unsafe extern "C" fn qk_classical_register_circuit_bits(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkQuantumRegister *qr = qk_quantum_register_new(1024, "my_little_register");
-///     qk_circuit_add_quantum_register(qc, qr);
-///     qk_quantum_register_free(qr);
-///     qk_circuit_free(qc);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkQuantumRegister *qr = qk_quantum_register_new(1024, "my_little_register");
+/// qk_circuit_add_quantum_register(qc, qr);
+/// qk_quantum_register_free(qr);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -484,18 +484,18 @@ pub unsafe extern "C" fn qk_circuit_add_quantum_register(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
-///     QkQuantumRegister *qr2 = qk_quantum_register_new(3, "qr2");
-///     qk_circuit_add_quantum_register(qc, qr1);
-///     qk_circuit_add_quantum_register(qc, qr2);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
+/// QkQuantumRegister *qr2 = qk_quantum_register_new(3, "qr2");
+/// qk_circuit_add_quantum_register(qc, qr1);
+/// qk_circuit_add_quantum_register(qc, qr2);
 ///
-///     size_t num_qregs = qk_circuit_num_quantum_registers(qc);
-///     printf("Number of quantum registers: %zu\n", num_qregs);  // Prints: 2
+/// size_t num_qregs = qk_circuit_num_quantum_registers(qc);
+/// printf("Number of quantum registers: %zu\n", num_qregs);  // Prints: 2
 ///
-///     qk_quantum_register_free(qr1);
-///     qk_quantum_register_free(qr2);
-///     qk_circuit_free(qc);
+/// qk_quantum_register_free(qr1);
+/// qk_quantum_register_free(qr2);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -524,14 +524,14 @@ pub unsafe extern "C" fn qk_circuit_num_quantum_registers(circuit: *const Circui
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
-///     qk_circuit_add_quantum_register(qc, qr1);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkQuantumRegister *qr1 = qk_quantum_register_new(2, "qr1");
+/// qk_circuit_add_quantum_register(qc, qr1);
 ///
-///     const QkQuantumRegister *retrieved = qk_circuit_get_quantum_register(qc, 0);
+/// const QkQuantumRegister *retrieved = qk_circuit_get_quantum_register(qc, 0);
 ///
-///     qk_quantum_register_free(qr1);
-///     qk_circuit_free(qc);
+/// qk_quantum_register_free(qr1);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -557,11 +557,11 @@ pub unsafe extern "C" fn qk_circuit_get_quantum_register(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkClassicalRegister *cr = qk_classical_register_new(24, "my_big_register");
-///     qk_circuit_add_classical_register(qc, cr);
-///     qk_classical_register_free(cr);
-///     qk_circuit_free(qc);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkClassicalRegister *cr = qk_classical_register_new(24, "my_big_register");
+/// qk_circuit_add_classical_register(qc, cr);
+/// qk_classical_register_free(cr);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -593,18 +593,18 @@ pub unsafe extern "C" fn qk_circuit_add_classical_register(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
-///     QkClassicalRegister *cr2 = qk_classical_register_new(3, "cr2");
-///     qk_circuit_add_classical_register(qc, cr1);
-///     qk_circuit_add_classical_register(qc, cr2);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
+/// QkClassicalRegister *cr2 = qk_classical_register_new(3, "cr2");
+/// qk_circuit_add_classical_register(qc, cr1);
+/// qk_circuit_add_classical_register(qc, cr2);
 ///
-///     size_t num_cregs = qk_circuit_num_classical_registers(qc);
-///     printf("Number of classical registers: %zu\n", num_cregs);  // Prints: 2
+/// size_t num_cregs = qk_circuit_num_classical_registers(qc);
+/// printf("Number of classical registers: %zu\n", num_cregs);  // Prints: 2
 ///
-///     qk_classical_register_free(cr1);
-///     qk_classical_register_free(cr2);
-///     qk_circuit_free(qc);
+/// qk_classical_register_free(cr1);
+/// qk_classical_register_free(cr2);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -633,14 +633,14 @@ pub unsafe extern "C" fn qk_circuit_num_classical_registers(circuit: *const Circ
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
-///     qk_circuit_add_classical_register(qc, cr1);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkClassicalRegister *cr1 = qk_classical_register_new(2, "cr1");
+/// qk_circuit_add_classical_register(qc, cr1);
 ///
-///     const QkClassicalRegister *retrieved = qk_circuit_get_classical_register(qc, 0);
+/// const QkClassicalRegister *retrieved = qk_circuit_get_classical_register(qc, 0);
 ///
-///     qk_classical_register_free(cr1);
-///     qk_circuit_free(qc);
+/// qk_classical_register_free(cr1);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -667,8 +667,8 @@ pub unsafe extern "C" fn qk_circuit_get_classical_register(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 100);
-///     QkCircuit *copy = qk_circuit_copy(qc);
+/// QkCircuit *qc = qk_circuit_new(100, 100);
+/// QkCircuit *copy = qk_circuit_copy(qc);
 /// ```
 ///
 /// # Safety
@@ -690,8 +690,8 @@ pub unsafe extern "C" fn qk_circuit_copy(circuit: *const CircuitData) -> *mut Ci
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 100);
-///     uint32_t num_qubits = qk_circuit_num_qubits(qc);  // num_qubits==100
+/// QkCircuit *qc = qk_circuit_new(100, 100);
+/// uint32_t num_qubits = qk_circuit_num_qubits(qc);  // num_qubits==100
 /// ```
 ///
 /// # Safety
@@ -714,8 +714,8 @@ pub unsafe extern "C" fn qk_circuit_num_qubits(circuit: *const CircuitData) -> u
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 50);
-///     uint32_t num_clbits = qk_circuit_num_clbits(qc);  // num_clbits==50
+/// QkCircuit *qc = qk_circuit_new(100, 50);
+/// uint32_t num_clbits = qk_circuit_num_clbits(qc);  // num_clbits==50
 /// ```
 ///
 /// # Safety
@@ -853,8 +853,8 @@ pub unsafe extern "C" fn qk_circuit_set_global_phase(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 100);
-///     qk_circuit_free(qc);
+/// QkCircuit *qc = qk_circuit_new(100, 100);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -890,9 +890,9 @@ pub unsafe extern "C" fn qk_circuit_free(circuit: *mut CircuitData) {
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t qubit[1] = {0};
-///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// uint32_t qubit[1] = {0};
+/// qk_circuit_gate(qc, QkGate_H, qubit, NULL);
 /// ```
 ///
 /// # Safety
@@ -1026,7 +1026,7 @@ pub unsafe extern "C" fn qk_circuit_parameterized_gate(
 ///
 /// # Example
 /// ```c
-///     uint32_t num_qubits = qk_gate_num_qubits(QkGate_CCX);
+/// uint32_t num_qubits = qk_gate_num_qubits(QkGate_CCX);
 /// ```
 ///
 #[unsafe(no_mangle)]
@@ -1043,7 +1043,7 @@ pub extern "C" fn qk_gate_num_qubits(gate: StandardGate) -> u32 {
 ///
 /// # Example
 /// ```c
-///     uint32_t num_params = qk_gate_num_params(QkGate_R);
+/// uint32_t num_params = qk_gate_num_params(QkGate_R);
 /// ```
 ///
 #[unsafe(no_mangle)]
@@ -1062,8 +1062,8 @@ pub extern "C" fn qk_gate_num_params(gate: StandardGate) -> u32 {
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 1);
-///     qk_circuit_measure(qc, 0, 0);
+/// QkCircuit *qc = qk_circuit_new(100, 1);
+/// qk_circuit_measure(qc, 0, 0);
 /// ```
 ///
 /// # Safety
@@ -1098,8 +1098,8 @@ pub unsafe extern "C" fn qk_circuit_measure(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     qk_circuit_reset(qc, 0);
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// qk_circuit_reset(qc, 0);
 /// ```
 ///
 /// # Safety
@@ -1135,9 +1135,9 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 1);
-///     uint32_t qubits[5] = {0, 1, 2, 3, 4};
-///     qk_circuit_barrier(qc, qubits, 5);
+/// QkCircuit *qc = qk_circuit_new(100, 1);
+/// uint32_t qubits[5] = {0, 1, 2, 3, 4};
+/// qk_circuit_barrier(qc, qubits, 5);
 /// ```
 ///
 /// # Safety
@@ -1437,12 +1437,12 @@ pub unsafe extern "C" fn qk_circuit_instruction_kind(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t qubits[1] = {0};
-///     qk_circuit_gate(qc, QkGate_H, qubits, NULL);
-///     QkOpCounts counts = qk_circuit_count_ops(qc);
-///     // .. once done
-///     qk_opcounts_clear(&counts);
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// uint32_t qubits[1] = {0};
+/// qk_circuit_gate(qc, QkGate_H, qubits, NULL);
+/// QkOpCounts counts = qk_circuit_count_ops(qc);
+/// // .. once done
+/// qk_opcounts_clear(&counts);
 /// ```
 ///
 /// # Safety
@@ -1477,10 +1477,10 @@ pub unsafe extern "C" fn qk_circuit_count_ops(circuit: *const CircuitData) -> Op
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t qubit[1] = {0};
-///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
-///     size_t num = qk_circuit_num_instructions(qc); // 1
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// uint32_t qubit[1] = {0};
+/// qk_circuit_gate(qc, QkGate_H, qubit, NULL);
+/// size_t num = qk_circuit_num_instructions(qc); // 1
 /// ```
 ///
 /// # Safety
@@ -1574,12 +1574,12 @@ impl CInstruction {
 ///
 /// # Example
 /// ```c
-///     QkCircuitInstruction inst;
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t qubit[1] = {0};
-///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
-///     qk_circuit_get_instruction(qc, 0, &inst);
-///     qk_circuit_instruction_clear(&inst);
+/// QkCircuitInstruction inst;
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// uint32_t qubit[1] = {0};
+/// qk_circuit_gate(qc, QkGate_H, qubit, NULL);
+/// qk_circuit_get_instruction(qc, 0, &inst);
+/// qk_circuit_instruction_clear(&inst);
 /// ```
 ///
 /// # Safety
@@ -1861,14 +1861,14 @@ pub unsafe extern "C" fn qk_circuit_inst_pauli_product_measurement(
 ///
 /// # Example
 /// ```c
-///     QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
-///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t q0[1] = {0};
-///     qk_circuit_gate(qc, QkGate_H, q0, NULL);
-///     qk_circuit_get_instruction(qc, 0, inst);
-///     qk_circuit_instruction_clear(inst); // clear internal allocations
-///     free(inst); // free struct
-///     qk_circuit_free(qc); // free the circuit
+/// QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
+/// QkCircuit *qc = qk_circuit_new(100, 0);
+/// uint32_t q0[1] = {0};
+/// qk_circuit_gate(qc, QkGate_H, q0, NULL);
+/// qk_circuit_get_instruction(qc, 0, inst);
+/// qk_circuit_instruction_clear(inst); // clear internal allocations
+/// free(inst); // free struct
+/// qk_circuit_free(qc); // free the circuit
 /// ```
 ///
 /// # Safety
@@ -2373,8 +2373,8 @@ impl From<CDelayUnit> for DelayUnit {
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(1, 0);
-///     qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);
+/// QkCircuit *qc = qk_circuit_new(1, 0);
+/// qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);
 /// ```
 ///
 /// # Safety
@@ -2436,21 +2436,21 @@ pub struct CircuitDrawerConfig {
 ///
 /// # Example
 /// ```c
-///     QkCircuit *circuit = qk_circuit_new(2, 1);
+/// QkCircuit *circuit = qk_circuit_new(2, 1);
 ///
-///     qk_circuit_gate(circuit, QkGate_H, (uint32_t[]){0}, NULL);
-///     qk_circuit_gate(circuit, QkGate_CX, (uint32_t[]){0, 1}, NULL);
-///     qk_circuit_measure(circuit, 0, 0);
-///     qk_circuit_measure(circuit, 1, 0);
+/// qk_circuit_gate(circuit, QkGate_H, (uint32_t[]){0}, NULL);
+/// qk_circuit_gate(circuit, QkGate_CX, (uint32_t[]){0, 1}, NULL);
+/// qk_circuit_measure(circuit, 0, 0);
+/// qk_circuit_measure(circuit, 1, 0);
 ///
-///     QkCircuitDrawerConfig config = {false, true, 0};
+/// QkCircuitDrawerConfig config = {false, true, 0};
 ///
-///     char *circ_str = qk_circuit_draw(circuit, &config);
+/// char *circ_str = qk_circuit_draw(circuit, &config);
 ///
-///     printf("%s", circ_str);
+/// printf("%s", circ_str);
 ///
-///     qk_str_free(circ_str);
-///     qk_circuit_free(circuit);
+/// qk_str_free(circ_str);
+/// qk_circuit_free(circuit);
 /// ```
 ///
 /// # Safety
@@ -2499,15 +2499,15 @@ pub unsafe extern "C" fn qk_circuit_draw(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(0, 0);
-///     QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
-///     qk_circuit_add_quantum_register(qc, qr);
-///     qk_quantum_register_free(qr);
+/// QkCircuit *qc = qk_circuit_new(0, 0);
+/// QkQuantumRegister *qr = qk_quantum_register_new(3, "qr");
+/// qk_circuit_add_quantum_register(qc, qr);
+/// qk_quantum_register_free(qr);
 ///
-///     QkDag *dag = qk_circuit_to_dag(qc);
+/// QkDag *dag = qk_circuit_to_dag(qc);
 ///
-///     qk_dag_free(dag);
-///     qk_circuit_free(qc);
+/// qk_dag_free(dag);
+/// qk_circuit_free(qc);
 /// ```
 ///
 /// # Safety
@@ -2674,10 +2674,10 @@ pub unsafe extern "C" fn qk_circuit_estimate_fidelity(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *circuit = ...; // Assume circuit contains a control flow instruction at index 0
-///     QkControlFlowInstruction *cf_inst = qk_circuit_get_control_flow_instruction(circuit, 0, NULL);
-///     QkControlFlowKind kind = qk_control_flow_kind(cf_inst);
-///     qk_control_flow_instruction_free(cf_inst);
+/// QkCircuit *circuit = ...; // Assume circuit contains a control flow instruction at index 0
+/// QkControlFlowInstruction *cf_inst = qk_circuit_get_control_flow_instruction(circuit, 0, NULL);
+/// QkControlFlowKind kind = qk_control_flow_kind(cf_inst);
+/// qk_control_flow_instruction_free(cf_inst);
 /// ```
 ///
 /// # Safety
@@ -2742,9 +2742,9 @@ pub unsafe extern "C" fn qk_circuit_get_control_flow_instruction(
 ///
 /// # Example
 /// ```c
-///     QkCircuit *circuit = ...; // Assume circuit contains a control flow instruction at index 0
-///     QkControlFlowInstruction *cf_inst = qk_circuit_get_control_flow_instruction(circuit, 0, NULL);
-///     qk_control_flow_instruction_free(cf_inst);
+/// QkCircuit *circuit = ...; // Assume circuit contains a control flow instruction at index 0
+/// QkControlFlowInstruction *cf_inst = qk_circuit_get_control_flow_instruction(circuit, 0, NULL);
+/// qk_control_flow_instruction_free(cf_inst);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/control_flow.rs
+++ b/crates/cext/src/control_flow.rs
@@ -828,12 +828,12 @@ pub unsafe extern "C" fn qk_control_flow_box_duration_kind(
 /// # Example
 /// ```c
 /// // Assuming cf_inst is a Box instruction with a concrete duration
-///  QkDurationInfo duration_info = qk_control_flow_box_duration_val_info(cf_inst);
-///  if (duration_info.ty == QkDurationType_Dt) {
-///      int64_t dt = duration_info.value.dt;
-///  } else {
-///      double time = duration_info.value.time;
-///  }
+/// QkDurationInfo duration_info = qk_control_flow_box_duration_val_info(cf_inst);
+/// if (duration_info.ty == QkDurationType_Dt) {
+///     int64_t dt = duration_info.value.dt;
+/// } else {
+///     double time = duration_info.value.time;
+/// }
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -71,7 +71,7 @@ impl TryFrom<&CSparseTerm> for SparseTermView<'_> {
 ///
 /// # Example
 /// ```c
-///     QkObs *zero = qk_obs_zero(100);
+/// QkObs *zero = qk_obs_zero(100);
 /// ```
 ///
 #[unsafe(no_mangle)]
@@ -89,7 +89,7 @@ pub extern "C" fn qk_obs_zero(num_qubits: u32) -> *mut SparseObservable {
 ///
 /// # Example
 /// ```c
-///     QkObs *identity = qk_obs_identity(100);
+/// QkObs *identity = qk_obs_identity(100);
 /// ```
 ///
 #[unsafe(no_mangle)]
@@ -143,19 +143,19 @@ pub extern "C" fn qk_obs_with_capacity(
 ///
 /// # Example
 /// ```c
-///    // define the raw data for the 100-qubit observable |01><01|_{0, 1} - |+-><+-|_{98, 99}
-///    uint32_t num_qubits = 100;
-///    uint64_t num_terms = 2;  // we have 2 terms: |01><01|, -1 * |+-><+-|
-///    uint64_t num_bits = 4; // we have 4 non-identity bits: 0, 1, +, -
-///    QkComplex64 coeffs[] = {{1, 0}, {-1, 0}};
-///    QkBitTerm bits[4] = {QkBitTerm_Zero, QkBitTerm_One, QkBitTerm_Plus, QkBitTerm_Minus};
+/// // define the raw data for the 100-qubit observable |01><01|_{0, 1} - |+-><+-|_{98, 99}
+/// uint32_t num_qubits = 100;
+/// uint64_t num_terms = 2;  // we have 2 terms: |01><01|, -1 * |+-><+-|
+/// uint64_t num_bits = 4; // we have 4 non-identity bits: 0, 1, +, -
+/// QkComplex64 coeffs[] = {{1, 0}, {-1, 0}};
+/// QkBitTerm bits[4] = {QkBitTerm_Zero, QkBitTerm_One, QkBitTerm_Plus, QkBitTerm_Minus};
 ///
-///    uint32_t indices[4] = {0, 1, 98, 99};  // <-- e.g. {1, 0, 99, 98} would be invalid
-///    size_t boundaries[3] = {0, 2, 4};
-///    QkObs *obs = qk_obs_new(
-///        num_qubits, num_terms, num_bits, coeffs, bits, indices, boundaries
-///    );
-///    qk_obs_free(obs);
+/// uint32_t indices[4] = {0, 1, 98, 99};  // <-- e.g. {1, 0, 99, 98} would be invalid
+/// size_t boundaries[3] = {0, 2, 4};
+/// QkObs *obs = qk_obs_new(
+///     num_qubits, num_terms, num_bits, coeffs, bits, indices, boundaries
+/// );
+/// qk_obs_free(obs);
 /// ```
 ///
 /// # Safety
@@ -200,8 +200,8 @@ pub unsafe extern "C" fn qk_obs_new(
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_zero(100);
-///     qk_obs_free(obs);
+/// QkObs *obs = qk_obs_zero(100);
+/// qk_obs_free(obs);
 /// ```
 ///
 /// # Safety
@@ -282,11 +282,11 @@ pub unsafe extern "C" fn qk_obs_add_term(
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     QkObsTerm term;
-///     QkExitCode exit_code = qk_obs_term(obs, 0, &term);
-///     // out-of-bounds indices return an error code
-///     // QkExitCode error = qk_obs_term(obs, 12, &term);
+/// QkObs *obs = qk_obs_identity(100);
+/// QkObsTerm term;
+/// QkExitCode exit_code = qk_obs_term(obs, 0, &term);
+/// // out-of-bounds indices return an error code
+/// // QkExitCode error = qk_obs_term(obs, 12, &term);
 /// ```
 ///
 /// # Safety
@@ -330,8 +330,8 @@ pub unsafe extern "C" fn qk_obs_term(
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     size_t num_terms = qk_obs_num_terms(obs);  // num_terms==1
+/// QkObs *obs = qk_obs_identity(100);
+/// size_t num_terms = qk_obs_num_terms(obs);  // num_terms==1
 /// ```
 ///
 /// # Safety
@@ -354,8 +354,8 @@ pub unsafe extern "C" fn qk_obs_num_terms(obs: *const SparseObservable) -> usize
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     uint32_t num_qubits = qk_obs_num_qubits(obs);  // num_qubits==100
+/// QkObs *obs = qk_obs_identity(100);
+/// uint32_t num_qubits = qk_obs_num_qubits(obs);  // num_qubits==100
 /// ```
 ///
 /// # Safety
@@ -378,8 +378,8 @@ pub unsafe extern "C" fn qk_obs_num_qubits(obs: *const SparseObservable) -> u32 
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     size_t len = qk_obs_len(obs);  // len==0, as there are no non-trivial bit terms
+/// QkObs *obs = qk_obs_identity(100);
+/// size_t len = qk_obs_len(obs);  // len==0, as there are no non-trivial bit terms
 /// ```
 ///
 /// # Safety
@@ -405,13 +405,13 @@ pub unsafe extern "C" fn qk_obs_len(obs: *const SparseObservable) -> usize {
 ///
 /// # Example
 /// ```c
-///    QkObs *obs = qk_obs_identity(100);
-///    size_t num_terms = qk_obs_num_terms(obs);
-///    QkComplex64 *coeffs = qk_obs_coeffs(obs);
+/// QkObs *obs = qk_obs_identity(100);
+/// size_t num_terms = qk_obs_num_terms(obs);
+/// QkComplex64 *coeffs = qk_obs_coeffs(obs);
 ///
-///    for (size_t i = 0; i < num_terms; i++) {
-///        printf("%f + i%f\n", coeffs[i].re, coeffs[i].im);
-///    }
+/// for (size_t i = 0; i < num_terms; i++) {
+///     printf("%f + i%f\n", coeffs[i].re, coeffs[i].im);
+/// }
 /// ```
 ///
 /// # Safety
@@ -480,21 +480,21 @@ pub unsafe extern "C" fn qk_obs_indices(obs: *mut SparseObservable) -> *mut u32 
 ///
 /// # Example
 /// ```c
-///    uint32_t num_qubits = 100;
-///    QkObs *obs = qk_obs_zero(num_qubits);
+/// uint32_t num_qubits = 100;
+/// QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///    QkComplex64 coeff = {1, 0};
-///    QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///    uint32_t indices[3] = {0, 1, 2};
-///    QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
-///    qk_obs_add_term(obs, &term);
+/// QkComplex64 coeff = {1, 0};
+/// QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
+/// uint32_t indices[3] = {0, 1, 2};
+/// QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
+/// qk_obs_add_term(obs, &term);
 ///
-///    size_t num_terms = qk_obs_num_terms(obs);
-///    size_t *boundaries = qk_obs_boundaries(obs);
+/// size_t num_terms = qk_obs_num_terms(obs);
+/// size_t *boundaries = qk_obs_boundaries(obs);
 ///
-///    for (size_t i = 0; i < num_terms + 1; i++) {
-///        printf("boundary %i: %i\n", i, boundaries[i]);
-///    }
+/// for (size_t i = 0; i < num_terms + 1; i++) {
+///     printf("boundary %i: %i\n", i, boundaries[i]);
+/// }
 /// ```
 ///
 /// # Safety
@@ -522,23 +522,23 @@ pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut u
 ///
 /// # Example
 /// ```c
-///     uint32_t num_qubits = 100;
-///     QkObs *obs = qk_obs_zero(num_qubits);
+/// uint32_t num_qubits = 100;
+/// QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     QkComplex64 coeff = {1, 0};
-///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
-///     qk_obs_add_term(obs, &term);
+/// QkComplex64 coeff = {1, 0};
+/// QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
+/// uint32_t indices[3] = {0, 1, 2};
+/// QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
+/// qk_obs_add_term(obs, &term);
 ///
-///     size_t len = qk_obs_len(obs);
-///     QkBitTerm *bits = qk_obs_bit_terms(obs);
+/// size_t len = qk_obs_len(obs);
+/// QkBitTerm *bits = qk_obs_bit_terms(obs);
 ///
-///     for (size_t i = 0; i < len; i++) {
-///         printf("bit term %i: %i\n", i, bits[i]);
-///     }
+/// for (size_t i = 0; i < len; i++) {
+///     printf("bit term %i: %i\n", i, bits[i]);
+/// }
 ///
-///     qk_obs_free(obs);
+/// qk_obs_free(obs);
 /// ```
 ///
 /// # Safety
@@ -563,9 +563,9 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     QkComplex64 coeff = {2, 0};
-///     QkObs *result = qk_obs_multiply(obs, &coeff);
+/// QkObs *obs = qk_obs_identity(100);
+/// QkComplex64 coeff = {2, 0};
+/// QkObs *result = qk_obs_multiply(obs, &coeff);
 /// ```
 ///
 /// # Safety
@@ -626,9 +626,9 @@ pub unsafe extern "C" fn qk_obs_multiply_inplace(
 ///
 /// # Example
 /// ```c
-///     QkObs *left = qk_obs_identity(100);
-///     QkObs *right = qk_obs_zero(100);
-///     QkObs *result = qk_obs_add(left, right);
+/// QkObs *left = qk_obs_identity(100);
+/// QkObs *right = qk_obs_zero(100);
+/// QkObs *result = qk_obs_add(left, right);
 /// ```
 ///
 /// # Safety
@@ -757,9 +757,9 @@ pub unsafe extern "C" fn qk_obs_scaled_add_inplace(
 ///
 /// # Example
 /// ```c
-///     QkObs *first = qk_obs_zero(100);
-///     QkObs *second = qk_obs_identity(100);
-///     QkObs *result = qk_obs_compose(first, second);
+/// QkObs *first = qk_obs_zero(100);
+/// QkObs *second = qk_obs_identity(100);
+/// QkObs *result = qk_obs_compose(first, second);
 /// ```
 ///
 /// # Safety
@@ -794,9 +794,9 @@ pub unsafe extern "C" fn qk_obs_compose(
 ///
 /// # Example
 /// ```c
-///     QkObs *first = qk_obs_zero(100);
-///     QkObs *second = qk_obs_identity(100);
-///     QkObs *result = qk_obs_compose(first, second);
+/// QkObs *first = qk_obs_zero(100);
+/// QkObs *second = qk_obs_identity(100);
+/// QkObs *result = qk_obs_compose(first, second);
 /// ```
 ///
 /// # Safety
@@ -931,11 +931,11 @@ pub unsafe extern "C" fn qk_obs_apply_layout(
 ///
 /// # Example
 /// ```c
-///    QkObs *iden = qk_obs_identity(100);
-///    QkObs *two = qk_obs_add(iden, iden);
+/// QkObs *iden = qk_obs_identity(100);
+/// QkObs *two = qk_obs_add(iden, iden);
 ///
-///    double tol = 1e-6;
-///    QkObs *canonical = qk_obs_canonicalize(two, tol);
+/// double tol = 1e-6;
+/// QkObs *canonical = qk_obs_canonicalize(two, tol);
 /// ```
 ///
 /// # Safety
@@ -962,8 +962,8 @@ pub unsafe extern "C" fn qk_obs_canonicalize(
 ///
 /// # Example
 /// ```c
-///     QkObs *original = qk_obs_identity(100);
-///     QkObs *copied = qk_obs_copy(original);
+/// QkObs *original = qk_obs_identity(100);
+/// QkObs *copied = qk_obs_copy(original);
 /// ```
 ///
 /// # Safety
@@ -991,9 +991,9 @@ pub unsafe extern "C" fn qk_obs_copy(obs: *const SparseObservable) -> *mut Spars
 ///
 /// # Example
 /// ```c
-///     QkObs *observable = qk_obs_identity(100);
-///     QkObs *other = qk_obs_identity(100);
-///     bool are_equal = qk_obs_equal(observable, other);
+/// QkObs *observable = qk_obs_identity(100);
+/// QkObs *other = qk_obs_identity(100);
+/// bool are_equal = qk_obs_equal(observable, other);
 /// ```
 ///
 /// # Safety
@@ -1021,10 +1021,10 @@ pub unsafe extern "C" fn qk_obs_equal(
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     char *string = qk_obs_str(obs);
-///     qk_str_free(string);
-///     qk_obs_free(obs);
+/// QkObs *obs = qk_obs_identity(100);
+/// char *string = qk_obs_str(obs);
+/// qk_str_free(string);
+/// qk_obs_free(obs);
 /// ```
 ///
 /// # Safety
@@ -1102,12 +1102,12 @@ pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
 ///
 /// # Example
 /// ```c
-///     QkObs *obs = qk_obs_identity(100);
-///     QkObsTerm term;
-///     qk_obs_term(obs, 0, &term);
-///     char *string = qk_obsterm_str(&term);
-///     qk_str_free(string);
-///     qk_obs_free(obs);
+/// QkObs *obs = qk_obs_identity(100);
+/// QkObsTerm term;
+/// qk_obs_term(obs, 0, &term);
+/// char *string = qk_obsterm_str(&term);
+/// qk_str_free(string);
+/// qk_obs_free(obs);
 /// ```
 ///
 /// # Safety
@@ -1144,9 +1144,9 @@ pub unsafe extern "C" fn qk_obsterm_str(term: *const CSparseTerm) -> *mut c_char
 ///
 /// # Example
 /// ```c
-///     QkBitTerm bit_term = QkBitTerm_Y;
-///     // cast the uint8_t to char
-///     char label = qk_bitterm_label(bit_term);
+/// QkBitTerm bit_term = QkBitTerm_Y;
+/// // cast the uint8_t to char
+/// char label = qk_bitterm_label(bit_term);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -33,24 +33,24 @@ use qiskit_transpiler::target::Target;
 /// # Example
 ///
 /// ```c
-///    #include <qiskit.h>
+/// #include <qiskit.h>
 ///
-///    QkCircuit *circuit = qk_circuit_new(3, 0);
-///    qk_circuit_gate(circuit, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL);
+/// QkCircuit *circuit = qk_circuit_new(3, 0);
+/// qk_circuit_gate(circuit, QkGate_CCX, (uint32_t[3]){0, 1, 2}, NULL);
 ///
-///    // Create a Target with global properties.
-///    QkTarget *target = qk_target_new(3);
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
-///    qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
+/// // Create a Target with global properties.
+/// QkTarget *target = qk_target_new(3);
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_H));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_T));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_Tdg));
+/// qk_target_add_instruction(target, qk_target_entry_new(QkGate_CX));
 ///
-///    // Run pass
-///    qk_transpiler_pass_standalone_basis_translator(circuit, target, 0);
+/// // Run pass
+/// qk_transpiler_pass_standalone_basis_translator(circuit, target, 0);
 ///
-///    // Free the circuit and target pointers once you're done
-///    qk_circuit_free(circuit);
-///    qk_target_free(target);
+/// // Free the circuit and target pointers once you're done
+/// qk_circuit_free(circuit);
+/// qk_target_free(target);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/transpiler/passes/inverse_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/inverse_cancellation.rs
@@ -49,13 +49,13 @@ use qiskit_transpiler::passes::run_inverse_cancellation_standard_gates;
 /// # Example
 ///
 /// ```c
-///     QkCircuit *qc = qk_circuit_new(2, 2);
-///     uint32_t qargs[1] = {0};
-///     qk_circuit_gate(qc, QkGate_X, qargs, NULL);
-///     qk_circuit_gate(qc, QkGate_H, qargs, NULL);
-///     qk_circuit_gate(qc, QkGate_H, qargs, NULL);
-///     qk_circuit_gate(qc, QkGate_Y, qargs, NULL);
-///     qk_transpiler_pass_standalone_inverse_cancellation(qc);
+/// QkCircuit *qc = qk_circuit_new(2, 2);
+/// uint32_t qargs[1] = {0};
+/// qk_circuit_gate(qc, QkGate_X, qargs, NULL);
+/// qk_circuit_gate(qc, QkGate_H, qargs, NULL);
+/// qk_circuit_gate(qc, QkGate_H, qargs, NULL);
+/// qk_circuit_gate(qc, QkGate_Y, qargs, NULL);
+/// qk_transpiler_pass_standalone_inverse_cancellation(qc);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -46,26 +46,26 @@ use qiskit_transpiler::target::Target;
 /// # Example
 ///
 /// ```c
-///     QkTarget *target = qk_target_new(2);
-///     uint32_t current_num_qubits = qk_target_num_qubits(target);
-///     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
-///     for (uint32_t i = 0; i < current_num_qubits - 1; i++) {
-///         uint32_t qargs[2] = {i, i + 1};
-///         double inst_error = 0.0090393 * (current_num_qubits - i);
-///         double inst_duration = 0.020039;
-///         qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
-///     }
-///     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
-///     QkCircuit *qc = qk_circuit_new(2, 0);
-///     QkComplex64 c0 = {0., 0.};
-///     QkComplex64 c1 = {1., 0.};
-///     QkComplex64 unitary[16] = {c1, c0, c0, c0,  // row 0
-///                                c0, c1, c0, c0,  // row 1
-///                                c0, c0, c1, c0,  // row 2
-///                                c0, c0, c0, c1}; // row 3
-///     uint32_t qargs[2] = {0, 1};
-///     qk_circuit_unitary(qc, unitary, qargs, 2, false);
-///     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
+/// QkTarget *target = qk_target_new(2);
+/// uint32_t current_num_qubits = qk_target_num_qubits(target);
+/// QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
+/// for (uint32_t i = 0; i < current_num_qubits - 1; i++) {
+///     uint32_t qargs[2] = {i, i + 1};
+///     double inst_error = 0.0090393 * (current_num_qubits - i);
+///     double inst_duration = 0.020039;
+///     qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
+/// }
+/// QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
+/// QkCircuit *qc = qk_circuit_new(2, 0);
+/// QkComplex64 c0 = {0., 0.};
+/// QkComplex64 c1 = {1., 0.};
+/// QkComplex64 unitary[16] = {c1, c0, c0, c0,  // row 0
+///                            c0, c1, c0, c0,  // row 1
+///                            c0, c0, c1, c0,  // row 2
+///                            c0, c0, c0, c1}; // row 3
+/// uint32_t qargs[2] = {0, 1};
+/// qk_circuit_unitary(qc, unitary, qargs, 2, false);
+/// qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -40,7 +40,7 @@ use smallvec::{SmallVec, smallvec};
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
+/// QkTarget *target = qk_target_new(5);
 /// ```
 ///
 #[unsafe(no_mangle)]
@@ -131,8 +131,8 @@ pub unsafe extern "C" fn qk_target_convert_from_python(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     uint32_t num_qubits = qk_target_num_qubits(target);
+/// QkTarget *target = qk_target_new(5);
+/// uint32_t num_qubits = qk_target_num_qubits(target);
 /// ```
 ///
 /// # Safety
@@ -154,9 +154,9 @@ pub unsafe extern "C" fn qk_target_num_qubits(target: *const Target) -> u32 {
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     qk_target_set_dt(target, 10e-9);
-///     double dt = qk_target_dt(target);
+/// QkTarget *target = qk_target_new(5);
+/// qk_target_set_dt(target, 10e-9);
+/// double dt = qk_target_dt(target);
 /// ```
 ///
 /// # Safety
@@ -178,9 +178,9 @@ pub unsafe extern "C" fn qk_target_dt(target: *const Target) -> f64 {
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     uint32_t granularity = qk_target_granularity(target);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// uint32_t granularity = qk_target_granularity(target);
 /// ```
 ///
 /// # Safety
@@ -202,9 +202,9 @@ pub unsafe extern "C" fn qk_target_granularity(target: *const Target) -> u32 {
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     size_t min_length = qk_target_min_length(target);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// size_t min_length = qk_target_min_length(target);
 /// ```
 ///
 /// # Safety
@@ -226,9 +226,9 @@ pub unsafe extern "C" fn qk_target_min_length(target: *const Target) -> u32 {
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// uint32_t pulse_alignment = qk_target_pulse_alignment(target);
 /// ```
 ///
 /// # Safety
@@ -250,9 +250,9 @@ pub unsafe extern "C" fn qk_target_pulse_alignment(target: *const Target) -> u32
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 0
-///     uint32_t acquire_alignment = qk_target_pulse_alignment(target);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 0
+/// uint32_t acquire_alignment = qk_target_pulse_alignment(target);
 /// ```
 ///
 /// # Safety
@@ -276,8 +276,8 @@ pub unsafe extern "C" fn qk_target_acquire_alignment(target: *const Target) -> u
 /// # Example
 ///
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     double dt = qk_target_set_dt(target, 10e-9);
+/// QkTarget *target = qk_target_new(5);
+/// double dt = qk_target_set_dt(target, 10e-9);
 /// ```
 ///
 /// # Safety
@@ -302,9 +302,9 @@ pub unsafe extern "C" fn qk_target_set_dt(target: *mut Target, dt: f64) -> ExitC
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     qk_target_set_granularity(target, 2);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// qk_target_set_granularity(target, 2);
 /// ```
 ///
 /// # Safety
@@ -332,9 +332,9 @@ pub unsafe extern "C" fn qk_target_set_granularity(
 /// # Example
 ///
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     qk_target_set_min_length(target, 3);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// qk_target_set_min_length(target, 3);
 /// ```
 ///
 /// # Safety
@@ -361,9 +361,9 @@ pub unsafe extern "C" fn qk_target_set_min_length(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 1
-///     qk_target_set_pulse_alignment(target, 4);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 1
+/// qk_target_set_pulse_alignment(target, 4);
 /// ```
 ///
 /// # Safety
@@ -391,9 +391,9 @@ pub unsafe extern "C" fn qk_target_set_pulse_alignment(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     // The value defaults to 0
-///     qk_target_set_acquire_alignment(target, 5);
+/// QkTarget *target = qk_target_new(5);
+/// // The value defaults to 0
+/// qk_target_set_acquire_alignment(target, 5);
 /// ```
 ///
 /// # Safety
@@ -419,13 +419,13 @@ pub unsafe extern "C" fn qk_target_set_acquire_alignment(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     QkExitCode result = qk_target_add_instruction(target, entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// QkExitCode result = qk_target_add_instruction(target, entry);
 ///
-///     QkTarget *copied = qk_target_copy(target);
+/// QkTarget *copied = qk_target_copy(target);
 /// ```
 ///
 /// # Safety
@@ -446,8 +446,8 @@ pub unsafe extern "C" fn qk_target_copy(target: *mut Target) -> *mut Target {
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     qk_target_free(target);
+/// QkTarget *target = qk_target_new(5);
+/// qk_target_free(target);
 /// ```
 ///
 /// # Safety
@@ -560,7 +560,7 @@ impl TargetEntry {
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *had_entry = qk_target_entry_new(QkGate_H);
+/// QkTargetEntry *had_entry = qk_target_entry_new(QkGate_H);
 /// ```
 #[unsafe(no_mangle)]
 pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEntry {
@@ -574,17 +574,17 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *entry = qk_target_entry_new_measure();
-///     // Add fixed duration and error rates from qubits at index 0 to 4.
-///     for (uint32_t i = 0; i < 5; i++) {
-///         // Measure is a single qubit instruction
-///         uint32_t qargs[1] = {i};
-///         qk_target_entry_add_property(entry, qargs, 1, 1.928e-10, 7.9829e-11);
-///     }
+/// QkTargetEntry *entry = qk_target_entry_new_measure();
+/// // Add fixed duration and error rates from qubits at index 0 to 4.
+/// for (uint32_t i = 0; i < 5; i++) {
+///     // Measure is a single qubit instruction
+///     uint32_t qargs[1] = {i};
+///     qk_target_entry_add_property(entry, qargs, 1, 1.928e-10, 7.9829e-11);
+/// }
 ///
-///     // Add the entry to a target with 5 qubits
-///     QkTarget *measure_target = qk_target_new(5);
-///     qk_target_add_instruction(measure_target, entry);
+/// // Add the entry to a target with 5 qubits
+/// QkTarget *measure_target = qk_target_new(5);
+/// qk_target_add_instruction(measure_target, entry);
 /// ```
 #[unsafe(no_mangle)]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
@@ -600,17 +600,17 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *entry = qk_target_entry_new_reset();
-///     // Add fixed duration and error rates from qubits at index 0 to 2.
-///     for (uint32_t i = 0; i < 3; i++) {
-///         // Reset is a single qubit instruction
-///         uint32_t qargs[1] = {i};
-///         qk_target_entry_add_property(entry, qargs, 1, 1.2e-11, 5.9e-13);
-///     }
+/// QkTargetEntry *entry = qk_target_entry_new_reset();
+/// // Add fixed duration and error rates from qubits at index 0 to 2.
+/// for (uint32_t i = 0; i < 3; i++) {
+///     // Reset is a single qubit instruction
+///     uint32_t qargs[1] = {i};
+///     qk_target_entry_add_property(entry, qargs, 1, 1.2e-11, 5.9e-13);
+/// }
 ///
-///     // Add the entry to a target with 3 qubits
-///     QkTarget *reset_target = qk_target_new(3);
-///     qk_target_add_instruction(reset_target, entry);
+/// // Add the entry to a target with 3 qubits
+/// QkTarget *reset_target = qk_target_new(3);
+/// qk_target_add_instruction(reset_target, entry);
 /// ```
 #[unsafe(no_mangle)]
 pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
@@ -634,8 +634,8 @@ pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
 ///
 /// # Example
 /// ```c
-///     double crx_params[1] = {3.14};
-///     QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, crx_params, "crx_fixed")";
+/// double crx_params[1] = {3.14};
+/// QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, crx_params, "crx_fixed")";
 /// ```
 ///
 /// # Safety
@@ -682,9 +682,9 @@ pub unsafe extern "C" fn qk_target_entry_new_fixed(
 ///
 /// # Example
 /// ```c
-///     // Create an entry for an H gate
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
-///     size_t props_size = qk_target_entry_num_properties(entry);
+/// // Create an entry for an H gate
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
+/// size_t props_size = qk_target_entry_num_properties(entry);
 /// ```
 ///
 /// # Safety
@@ -709,8 +709,8 @@ pub unsafe extern "C" fn qk_target_entry_num_properties(entry: *const TargetEntr
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
-///     qk_target_entry_free(entry);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
+/// qk_target_entry_free(entry);
 /// ```
 ///
 /// # Safety
@@ -747,9 +747,9 @@ pub unsafe extern "C" fn qk_target_entry_free(entry: *mut TargetEntry) {
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
 /// ```
 ///
 /// # Safety
@@ -794,8 +794,8 @@ pub unsafe extern "C" fn qk_target_entry_add_property(
 ///
 /// # Example
 /// ```c
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     qk_target_entry_set_name(entry, "cx_gate");
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// qk_target_entry_set_name(entry, "cx_gate");
 /// ```
 ///
 /// # Safety
@@ -837,11 +837,11 @@ pub unsafe extern "C" fn qk_target_entry_set_name(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     QkExitCode result = qk_target_add_instruction(target, entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// QkExitCode result = qk_target_add_instruction(target, entry);
 /// ```
 ///
 /// # Safety
@@ -902,14 +902,14 @@ pub unsafe extern "C" fn qk_target_add_instruction(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     double params[1] = {3.1415};
-///     QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, params, "crx_pi");
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     qk_target_add_instruction(target, entry);
+/// QkTarget *target = qk_target_new(5);
+/// double params[1] = {3.1415};
+/// QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, params, "crx_pi");
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// qk_target_add_instruction(target, entry);
 ///
-///     qk_target_update_property(target, QkGate_CRX, qargs, 2, 0.0012, 1.1);
+/// qk_target_update_property(target, QkGate_CRX, qargs, 2, 0.0012, 1.1);
 /// ```
 ///
 /// # Safety
@@ -962,11 +962,11 @@ pub unsafe extern "C" fn qk_target_update_property(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
-///     qk_target_add_instruction(target, target_entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
+/// qk_target_add_instruction(target, target_entry);
 ///
-///     size_t num_instructions = qk_target_num_instructions(target);
+/// size_t num_instructions = qk_target_num_instructions(target);
 /// ```
 ///
 /// # Safety
@@ -995,21 +995,21 @@ pub unsafe extern "C" fn qk_target_num_instructions(target: *const Target) -> us
 ///
 /// # Example
 /// ```c
-///     // Create a mock target with only a global crx entry
-///     // and 3.14 as its rotation parameter.
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *crx_entry = qk_target_entry_new_fixed(QkGate_CRX, (double[]){3.14});
-///     qk_target_entry_add_property(crx_entry, NULL, 0, 0.0, 0.1);
-///     qk_target_add_instruction(target, crx_entry);
+/// // Create a mock target with only a global crx entry
+/// // and 3.14 as its rotation parameter.
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *crx_entry = qk_target_entry_new_fixed(QkGate_CRX, (double[]){3.14});
+/// qk_target_entry_add_property(crx_entry, NULL, 0, 0.0, 0.1);
+/// qk_target_add_instruction(target, crx_entry);
 ///
-///     // Check if target is compatible with a "crx" gate
-///     // at [0, 1] with 3.14 rotation.
-///     QkParam *params[1] = {qk_param_from_double(3.14)};
-///     qk_target_instruction_supported(target, "crx", (uint32_t []){0, 1}, params);
+/// // Check if target is compatible with a "crx" gate
+/// // at [0, 1] with 3.14 rotation.
+/// QkParam *params[1] = {qk_param_from_double(3.14)};
+/// qk_target_instruction_supported(target, "crx", (uint32_t []){0, 1}, params);
 ///
-///     // Free the pointers
-///     qk_param_free(params[0]);
-///     qk_target_free(target);
+/// // Free the pointers
+/// qk_param_free(params[0]);
+/// qk_target_free(target);
 /// ```
 ///
 /// # Safety
@@ -1077,11 +1077,11 @@ pub unsafe extern "C" fn qk_target_instruction_supported(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
-///     qk_target_add_instruction(target, target_entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
+/// qk_target_add_instruction(target, target_entry);
 ///
-///     size_t op_idx = qk_target_op_index(target, "h");
+/// size_t op_idx = qk_target_op_index(target, "h");
 /// ```
 ///
 /// # Safety
@@ -1113,13 +1113,13 @@ pub unsafe extern "C" fn qk_target_op_index(target: *const Target, name: *const 
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
-///     qk_target_add_instruction(target, target_entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
+/// qk_target_add_instruction(target, target_entry);
 ///
-///     char *op_name = qk_target_op_name(target, 0);
-///     // Free after use
-///     qk_str_free(op_name);
+/// char *op_name = qk_target_op_name(target, 0);
+/// // Free after use
+/// qk_str_free(op_name);
 /// ```
 ///
 /// # Safety
@@ -1150,11 +1150,11 @@ pub unsafe extern "C" fn qk_target_op_name(target: *const Target, index: usize) 
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
-///     qk_target_add_instruction(target, target_entry);
+/// QkTarget *target = qk_target_new(5);
+/// QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
+/// qk_target_add_instruction(target, target_entry);
 ///
-///     size_t num_props = qk_target_op_num_properties(target, 0);
+/// size_t num_props = qk_target_op_num_properties(target, 0);
 /// ```
 ///
 /// # Safety
@@ -1232,22 +1232,22 @@ pub unsafe extern "C" fn qk_target_op_qargs_index(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
+/// QkTarget *target = qk_target_new(5);
 ///
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     qk_target_add_instruction(target, entry);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// qk_target_add_instruction(target, entry);
 ///
-///     uint32_t *qargs_retrieved;
-///     uint32_t qargs_length;
-///     qk_target_op_qargs(target, 0, 0, &qargs_retrieved, &qargs_length);
-///     if (qargs_retrieved) {
-///         // We should enter this branch.
-///         printf("Number of qargs: %lu\n", qargs_length);
-///     } else {
-///         printf("Qargs are global\n");
-///     }
+/// uint32_t *qargs_retrieved;
+/// uint32_t qargs_length;
+/// qk_target_op_qargs(target, 0, 0, &qargs_retrieved, &qargs_length);
+/// if (qargs_retrieved) {
+///     // We should enter this branch.
+///     printf("Number of qargs: %lu\n", qargs_length);
+/// } else {
+///     printf("Qargs are global\n");
+/// }
 /// ```
 ///
 /// # Safety
@@ -1293,15 +1293,15 @@ pub unsafe extern "C" fn qk_target_op_qargs(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
+/// QkTarget *target = qk_target_new(5);
 ///
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     qk_target_add_instruction(target, entry);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// qk_target_add_instruction(target, entry);
 ///
-///     QkInstructionProperties inst_props;
-///     qk_target_op_props(target, 0, 0, &inst_props);
+/// QkInstructionProperties inst_props;
+/// qk_target_op_props(target, 0, 0, &inst_props);
 /// ```
 ///
 /// # Safety
@@ -1512,24 +1512,24 @@ pub unsafe extern "C" fn qk_target_op_get(
 ///
 /// # Example
 /// ```c
-///     QkTarget *target = qk_target_new(5);
+/// QkTarget *target = qk_target_new(5);
 ///
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-///     uint32_t qargs[2] = {0, 1};
-///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
-///     qk_target_add_instruction(target, entry);
+/// QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
+/// uint32_t qargs[2] = {0, 1};
+/// qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// qk_target_add_instruction(target, entry);
 ///
-///     QkTargetOp op;
-///     qk_target_op_get(target, 0, &op);
+/// QkTargetOp op;
+/// qk_target_op_get(target, 0, &op);
 ///
-///     // Check if the operation is a gate;
-///     if (op.op_type == QkOperationKind_Gate) {
-///         QkGate gate = qk_target_op_gate(target, 0);
-///         // Do something
-///     }
+/// // Check if the operation is a gate;
+/// if (op.op_type == QkOperationKind_Gate) {
+///     QkGate gate = qk_target_op_gate(target, 0);
+///     // Do something
+/// }
 ///
-///     // Clean up after you're done.
-///     qk_target_op_clear(&op);
+/// // Clean up after you're done.
+/// qk_target_op_clear(&op);
 /// ```
 ///
 /// # Safety


### PR DESCRIPTION
Following up on https://github.com/Qiskit/qiskit/pull/16889#discussion_r3895340659 this PR addresses the unintetional code example indentations in the C API docstrings.

I initially started with a fancy Vim `:substitute` command, but quickly ran into limitations of handling varying indentation levels as well as some _intentional_ whitespace where line continuation asks for it. So finally Claude was the quickest solution to dealing with all the C code examples in the `cext` crate docs consistently.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: Claude Opus 5