### PR TITLE
Keep identical summands when running `FindCommutingPauliEvolutions`.

### DIFF
--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -124,13 +124,12 @@ class FindCommutingPauliEvolutions(TransformationPass):
         """
         sub_dag = dag.copy_empty_like()
 
-        required_paulis = {
-            self._pauli_to_edge(pauli): (pauli, coeff)
-            for pauli, coeff in zip(op.operator.paulis, op.operator.coeffs)
-        }
+        required_paulis = {}
+        for pauli, coeff in zip(op.operator.paulis, op.operator.coeffs):
+            edge = self._pauli_to_edge(pauli)
+            required_paulis[(pauli, edge)] = required_paulis.get((pauli, edge), 0) + coeff
 
-        for edge, (pauli, coeff) in required_paulis.items():
-
+        for ((pauli, edge), coeff) in required_paulis.items():
             qubits = [dag.qubits[edge[0]], dag.qubits[edge[1]]]
 
             simple_pauli = Pauli(pauli.to_label().replace("I", ""))

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -32,11 +32,11 @@ class FindCommutingPauliEvolutions(TransformationPass):
         """
         Replaces :class:`.PauliEvolutionGate` objects where all summands commute by
         :class:`.Commuting2qBlock` objects.
-        
+
         The pass only modifies Pauli evolution gates that are defined on 2 or more qubits whose
-         Pauli terms all act nontrivially on exactly 2 qubits and commute qubit-wise. The pass
-         raises an error for Pauli evolution gates defined on 2 or more qubits and contains Pauli terms
-         that do not act nontrivially on 2 qubits.
+        Pauli terms all act nontrivially on exactly 2 qubits and commute qubit-wise. The pass
+        raises an error for Pauli evolution gates defined on 2 or more qubits and contains Pauli
+        terms that do not act nontrivially on 2 qubits.
 
         Args:
             dag: The DAG circuit in which to look for the commuting evolutions.
@@ -47,10 +47,8 @@ class FindCommutingPauliEvolutions(TransformationPass):
             gates contain nodes of two-qubit :class:`.PauliEvolutionGate` objects.
 
         Raises:
-            QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with more
-                         than 2 qubits.
-            QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with 2
-                         qubits, but term(s) interact with 1 qubit.
+            QiskitError: If a :class:`.PauliEvolutionGate` is defined on 2+ qubits, but its terms
+                         don't act non-trivially on exactly 2 qubits.
         """
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -24,18 +24,28 @@ from .commuting_2q_block import Commuting2qBlock
 
 
 class FindCommutingPauliEvolutions(TransformationPass):
-    """Finds :class:`.PauliEvolutionGate` objects where the operators, that are evolved, all commute."""
+    """
+    Finds :class:`.PauliEvolutionGate` objects where the operators, that are evolved, all commute.
+    """
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
-        """Check for :class:`.PauliEvolutionGate` objects where the summands all commute.
+        """
+        Check for :class:`.PauliEvolutionGate`s where the summands all commute. This pass skips
+        gates that interact with exactly 1 qubit.
 
         Args:
             dag: The DAG circuit in which to look for the commuting evolutions.
 
         Returns:
-            The dag in which :class:`.PauliEvolutionGate` objects made of commuting two-qubit Paulis
-            have been replaced with :class:`.Commuting2qBlocks`` gate instructions. These gates
-            contain nodes of two-qubit :class:`.PauliEvolutionGate` objects.
+            The dag in which :class:`.PauliEvolutionGate` objects made of commuting two-qubit
+            Paulis have been replaced with :class:`.Commuting2qBlocks`` gate instructions. These
+            gates contain nodes of two-qubit :class:`.PauliEvolutionGate` objects.
+
+        Raises:
+            QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with more
+                         than 2 qubits.
+            QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with 2
+                         qubits, but some terms interact with 1 qubit.
         """
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -30,8 +30,13 @@ class FindCommutingPauliEvolutions(TransformationPass):
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """
-        Simplifies :class:`.PauliEvolutionGate`s where all summands commute, skipping those
-        with exactly 1 qubit.
+        Replaces :class:`.PauliEvolutionGate` objects where all summands commute by
+        :class:`.Commuting2qBlock` objects.
+        
+        The pass only modifies Pauli evolution gates that are defined on 2 or more qubits whose
+         Pauli terms all act nontrivially on exactly 2 qubits and commute qubit-wise. The pass
+         raises an error for Pauli evolution gates defined on 2 or more qubits and contains Pauli terms
+         that do not act nontrivially on 2 qubits.
 
         Args:
             dag: The DAG circuit in which to look for the commuting evolutions.

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -30,8 +30,8 @@ class FindCommutingPauliEvolutions(TransformationPass):
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """
-        Simplifies :class:`.PauliEvolutionGate`s where all summands commute. The pass skips gates
-        that interact with exactly 1 qubit.
+        Simplifies :class:`.PauliEvolutionGate`s where all summands commute, skipping those
+        with exactly 1 qubit.
 
         Args:
             dag: The DAG circuit in which to look for the commuting evolutions.
@@ -45,7 +45,7 @@ class FindCommutingPauliEvolutions(TransformationPass):
             QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with more
                          than 2 qubits.
             QiskitError: If any :class:`.PauliEvolutionGate` in the circuit interacts with 2
-                         qubits, but some terms interact with 1 qubit.
+                         qubits, but term(s) interact with 1 qubit.
         """
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """An analysis pass to find evolution gates in which the Paulis commute."""
+from collections import defaultdict
 
 import numpy as np
 
@@ -124,10 +125,10 @@ class FindCommutingPauliEvolutions(TransformationPass):
         """
         sub_dag = dag.copy_empty_like()
 
-        required_paulis = {}
+        required_paulis = defaultdict(int)
         for pauli, coeff in zip(op.operator.paulis, op.operator.coeffs):
             edge = self._pauli_to_edge(pauli)
-            required_paulis[(pauli, edge)] = required_paulis.get((pauli, edge), 0) + coeff
+            required_paulis[(pauli, edge)] += coeff
 
         for (pauli, edge), coeff in required_paulis.items():
             qubits = [dag.qubits[edge[0]], dag.qubits[edge[1]]]

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -129,7 +129,7 @@ class FindCommutingPauliEvolutions(TransformationPass):
             edge = self._pauli_to_edge(pauli)
             required_paulis[(pauli, edge)] = required_paulis.get((pauli, edge), 0) + coeff
 
-        for ((pauli, edge), coeff) in required_paulis.items():
+        for (pauli, edge), coeff in required_paulis.items():
             qubits = [dag.qubits[edge[0]], dag.qubits[edge[1]]]
 
             simple_pauli = Pauli(pauli.to_label().replace("I", ""))

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -25,13 +25,13 @@ from .commuting_2q_block import Commuting2qBlock
 
 class FindCommutingPauliEvolutions(TransformationPass):
     """
-    Finds :class:`.PauliEvolutionGate` objects where the operators, that are evolved, all commute.
+    Simplifies :class:`.PauliEvolutionGate`s where all summands commute.
     """
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """
-        Check for :class:`.PauliEvolutionGate`s where the summands all commute. This pass skips
-        gates that interact with exactly 1 qubit.
+        Simplifies :class:`.PauliEvolutionGate`s where all summands commute. The pass skips gates
+        that interact with exactly 1 qubit.
 
         Args:
             dag: The DAG circuit in which to look for the commuting evolutions.

--- a/releasenotes/notes/keep-identical-summands-f263fcb032e38ff5.yaml
+++ b/releasenotes/notes/keep-identical-summands-f263fcb032e38ff5.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixed :class:`.FindCommutingPauliEvolutions` discarding identical summand
+    coefficients. See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`.

--- a/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
+++ b/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fixed :py:class:`~.FindCommutingPauliEvolutions` dropping identical terms
+    with different coefficients.
+
+    See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`__.

--- a/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
+++ b/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
@@ -1,4 +1,0 @@
-fixes:
-  - |
-    Fixed :class:`.FindCommutingPauliEvolutions` dropping identical terms with
-    different coefficients. See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`.

--- a/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
+++ b/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
@@ -1,6 +1,4 @@
 fixes:
   - |
-    Fixed :py:class:`~.FindCommutingPauliEvolutions` dropping identical terms
-    with different coefficients.
-
-    See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`__.
+    Fixed :class:`.FindCommutingPauliEvolutions` dropping identical terms with
+    different coefficients. See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`__.

--- a/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
+++ b/releasenotes/notes/keep-identical-terms-f263fcb032e38ff5.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
     Fixed :class:`.FindCommutingPauliEvolutions` dropping identical terms with
-    different coefficients. See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`__.
+    different coefficients. See `#16856 <https://github.com/Qiskit/qiskit/issues/16856>`.

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -769,4 +769,3 @@ class TestSwapRouterExceptions(QiskitTestCase):
         operator_b = Operator(circuit_b)
 
         self.assertEqual(operator_a, operator_b)
-

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -747,3 +747,27 @@ class TestSwapRouterExceptions(QiskitTestCase):
 
         assigned_circuit = circuit_with_block.assign_parameters({gamma: 0.7})
         self.assertEqual(len(assigned_circuit.parameters), 1)
+
+    def test_identical_terms_added(self):
+        term_a = SparsePauliOp(["ZZ", "ZZ"], coeffs = [0.2, 0.4])
+        term_b = SparsePauliOp(["ZZ"], coeffs = [0.6])
+
+        circuit_a = QuantumCircuit(2)
+        circuit_a.append(PauliEvolutionGate(term_a, time=1.0), [0, 1])
+
+        circuit_b = QuantumCircuit(2)
+        circuit_b.append(PauliEvolutionGate(term_b, time=1.0), [0, 1])
+
+        manager = PassManager([
+            FindCommutingPauliEvolutions(),
+            Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))
+        ])
+
+        pass_a = manager.run(circuit_a)
+        pass_b = manager.run(circuit_b)
+
+        operator_a = Operator(pass_a)
+        operator_b = Operator(pass_b)
+
+        self.assertEqual(operator_a, operator_b)
+

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -762,10 +762,24 @@ class TestSwapRouterExceptions(QiskitTestCase):
             [FindCommutingPauliEvolutions(), Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))]
         )
 
-        pass_a = manager.run(circuit_a)
-        pass_b = manager.run(circuit_b)
+        circuit_a = manager.run(circuit_a)
+        circuit_b = manager.run(circuit_b)
 
-        operator_a = Operator(pass_a)
-        operator_b = Operator(pass_b)
+        operator_a = Operator(circuit_a)
+        operator_b = Operator(circuit_b)
 
         self.assertEqual(operator_a, operator_b)
+
+    def test_non_identical_terms_retained(self):
+        term = SparsePauliOp(["XY", "ZY"], coeffs=[0.2, 0.4])
+
+        before = QuantumCircuit(2)
+        before.append(PauliEvolutionGate(term, time=1.0), [0, 1])
+
+        manager = PassManager(
+            [FindCommutingPauliEvolutions(), Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))]
+        )
+        after = manager.run(before)
+
+        before = Operator(before)
+        self.assertEqual(Operator(before), Operator(after))

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -748,15 +748,15 @@ class TestSwapRouterExceptions(QiskitTestCase):
         assigned_circuit = circuit_with_block.assign_parameters({gamma: 0.7})
         self.assertEqual(len(assigned_circuit.parameters), 1)
 
-    def test_identical_terms_added(self):
-        term_a = SparsePauliOp(["ZZ", "ZZ"], coeffs=[0.2, 0.4])
-        term_b = SparsePauliOp(["ZZ"], coeffs=[0.6])
+    def test_identical_summands_added(self):
+        summand_a = SparsePauliOp(["ZZ", "ZZ"], coeffs=[0.2, 0.4])
+        summand_b = SparsePauliOp(["ZZ"], coeffs=[0.6])
 
         circuit_a = QuantumCircuit(2)
-        circuit_a.append(PauliEvolutionGate(term_a, time=1.0), [0, 1])
+        circuit_a.append(PauliEvolutionGate(summand_a, time=1.0), [0, 1])
 
         circuit_b = QuantumCircuit(2)
-        circuit_b.append(PauliEvolutionGate(term_b, time=1.0), [0, 1])
+        circuit_b.append(PauliEvolutionGate(summand_b, time=1.0), [0, 1])
 
         manager = PassManager(
             [FindCommutingPauliEvolutions(), Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))]

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -749,8 +749,8 @@ class TestSwapRouterExceptions(QiskitTestCase):
         self.assertEqual(len(assigned_circuit.parameters), 1)
 
     def test_identical_terms_added(self):
-        term_a = SparsePauliOp(["ZZ", "ZZ"], coeffs = [0.2, 0.4])
-        term_b = SparsePauliOp(["ZZ"], coeffs = [0.6])
+        term_a = SparsePauliOp(["ZZ", "ZZ"], coeffs=[0.2, 0.4])
+        term_b = SparsePauliOp(["ZZ"], coeffs=[0.6])
 
         circuit_a = QuantumCircuit(2)
         circuit_a.append(PauliEvolutionGate(term_a, time=1.0), [0, 1])
@@ -758,10 +758,9 @@ class TestSwapRouterExceptions(QiskitTestCase):
         circuit_b = QuantumCircuit(2)
         circuit_b.append(PauliEvolutionGate(term_b, time=1.0), [0, 1])
 
-        manager = PassManager([
-            FindCommutingPauliEvolutions(),
-            Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))
-        ])
+        manager = PassManager(
+            [FindCommutingPauliEvolutions(), Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))]
+        )
 
         pass_a = manager.run(circuit_a)
         pass_b = manager.run(circuit_b)
@@ -770,4 +769,3 @@ class TestSwapRouterExceptions(QiskitTestCase):
         operator_b = Operator(pass_b)
 
         self.assertEqual(operator_a, operator_b)
-

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -770,16 +770,3 @@ class TestSwapRouterExceptions(QiskitTestCase):
 
         self.assertEqual(operator_a, operator_b)
 
-    def test_non_identical_terms_retained(self):
-        term = SparsePauliOp(["XY", "ZY"], coeffs=[0.2, 0.4])
-
-        before = QuantumCircuit(2)
-        before.append(PauliEvolutionGate(term, time=1.0), [0, 1])
-
-        manager = PassManager(
-            [FindCommutingPauliEvolutions(), Commuting2qGateRouter(SwapStrategy.from_line([0, 1]))]
-        )
-        after = manager.run(before)
-
-        before = Operator(before)
-        self.assertEqual(Operator(before), Operator(after))


### PR DESCRIPTION
`FindCommutingPauliEvolutions` silently ignores the coefficients of repeated identical terms.

Presently, the dictionary keyed on the edge is insufficient. If we use the edge _and Pauli_ value as the dictionary key, the coefficients are accumulated correctly. 

I've adjusted the documentation to better reflect the behavior of this pass.

Fixes #16856 

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:
