### PR TITLE
Fixed `HighLevelSynthesis` qubit tracking for if-then-else instructions

### DIFF
--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -608,7 +608,7 @@ fn run_on_circuitdata(
         // Currently we do not allow subcircuits within the control flow to use auxiliary qubits
         // and mark all the usable qubits as dirty. This is done in order to avoid complications
         // that different subcircuits may choose to use different auxiliary global qubits, and to
-        // avoid complications related to tracking qubit status for while- loops.
+        // avoid complications related to tracking qubit status for while-loops.
         // In the future, this handling can potentially be improved.
         if let Some(control_flow) = input_circuit.try_view_control_flow(inst) {
             // We do not allow using any additional qubits outside of the block.
@@ -623,8 +623,10 @@ fn run_on_circuitdata(
                 .blocks()
                 .into_iter()
                 .map(|block| -> PyResult<_> {
+                    // Make sure that each arm of an if-then-else block starts with an "all-dirty" qubit tracker.
+                    let mut new_tracker = block_tracker.clone();
                     let (new_block, _) =
-                        run_on_circuitdata(py, block, &op_qubits, data, &mut block_tracker)?;
+                        run_on_circuitdata(py, block, &op_qubits, data, &mut new_tracker)?;
                     Ok(output_circuit.add_block(new_block))
                 })
                 .collect::<PyResult<_>>()?;

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -608,7 +608,7 @@ fn run_on_circuitdata(
         // Currently we do not allow subcircuits within the control flow to use auxiliary qubits
         // and mark all the usable qubits as dirty. This is done in order to avoid complications
         // that different subcircuits may choose to use different auxiliary global qubits, and to
-        // avoid complications related to tracking qubit status for while-loops.
+        // avoid complications related to tracking qubit status for if-else, switch and while instructions.
         // In the future, this handling can potentially be improved.
         if let Some(control_flow) = input_circuit.try_view_control_flow(inst) {
             // We do not allow using any additional qubits outside of the block.
@@ -623,7 +623,7 @@ fn run_on_circuitdata(
                 .blocks()
                 .into_iter()
                 .map(|block| -> PyResult<_> {
-                    // Make sure that each arm of an if-then-else block starts with an "all-dirty" qubit tracker.
+                    // Make sure that each block starts with an "all-dirty" qubit tracker.
                     let mut new_tracker = block_tracker.clone();
                     let (new_block, _) =
                         run_on_circuitdata(py, block, &op_qubits, data, &mut new_tracker)?;

--- a/releasenotes/notes/fix-hls-if-else-tracking-fd12d599438008fb.yaml
+++ b/releasenotes/notes/fix-hls-if-else-tracking-fd12d599438008fb.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.HighLevelSynthesis` transpiler pass where qubit
+    states were not tracked correctly between the `if` and the `else` branches of an
+    if-then-else instruction, potentially resulting in incorrect circuits.
+
+    See `#16859 <https://github.com/Qiskit/qiskit/issues/16859>`__.

--- a/releasenotes/notes/fix-hls-if-else-tracking-fd12d599438008fb.yaml
+++ b/releasenotes/notes/fix-hls-if-else-tracking-fd12d599438008fb.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed a bug in the :class:`.HighLevelSynthesis` transpiler pass where qubit
-    states were not tracked correctly between the `if` and the `else` branches of an
-    if-then-else instruction, potentially resulting in incorrect circuits.
+    states were not tracked correctly between branches of an if-then-else or switch
+    instruction, potentially resulting in incorrect circuits.
 
     See `#16859 <https://github.com/Qiskit/qiskit/issues/16859>`__.

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -843,6 +843,35 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         for q in range(num_qubits):
             self.assertEqual(tracker.is_qubit_clean(q), q not in gate_qubits)
 
+    def test_if_else_tracking(self):
+        """
+        Test that the pass correctly tracks qubits states for if-else operations.
+        Regression test for gh-16859.
+        """
+
+        # HLS would mark qubit 4 as clean at the end of the true block.
+        true_body = QuantumCircuit(5)
+        true_body.reset(4)
+
+        false_body = QuantumCircuit(5)
+        false_body.mcx([0, 1, 2], 3)
+
+        qc = QuantumCircuit(5, 1)
+        qc.h([0, 1, 2, 3, 4])
+
+        qc.if_else((0, True), true_body, false_body, [0, 1, 2, 3, 4], [])
+
+        dag = circuit_to_dag(qc)
+
+        # This specified MCX synthesis method requires one clean ancilla, and hence should not synthesize
+        # the MCX gate. HighLevelSynthesis is currently suboptimal when processing control-flow operations
+        # (treating all qubits as dirty) however previously the reset instruction from the if-branch
+        # set the qubit status to clean, which (incorrectly) propagated to the else-branch, and the MCX
+        # gate was (incorrectly) synthesized.
+        hls_config = HLSConfig(mcx=["1_clean_kg24"])
+        transpiled = HighLevelSynthesis(hls_config=hls_config).run(dag)
+        self.assertIn("mcx", transpiled.count_ops())
+
 
 class TestHighLevelSynthesisQuality(QiskitTestCase):
     """Test the "quality" of circuits produced by HighLevelSynthesis."""

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -869,20 +869,14 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         transpiled = HighLevelSynthesis(hls_config=hls_config).run(dag)
         self.assertIn("mcx", transpiled.count_ops())
 
-    def test_qubit_states_after_if_else(self):
-        """
-        Test that the internal qubit tracking mechanism correctly tracks qubit states
-        after an if-else operation.
+    @staticmethod
+    def run_and_track_qubits(circuit: QuantumCircuit, tracker: QubitTracker):
+        """Run the internal high-level synthesis method in a specific test
+        configuration and track qubit states after applying the circuit.
+
+        Modifies tracker in place.
         """
 
-        # Create a quantum circuit with if/else
-        qc = QuantumCircuit(4, 1)
-        with qc.if_test((0, True)) as else_:
-            qc.x(2)
-        with else_:
-            qc.z(0)
-
-        # Initialize high-level-synthesis data
         hls_config = HLSConfig()
         hls_plugin_manager = HighLevelSynthesisPluginManager()
         hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
@@ -901,16 +895,29 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
             optimize_clifford_t=False,
         )
 
-        # Initialize qubit tracker: qubits 0, 1, 2 are clean; 3 is dirty
+        _ = synthesize_circuit(circuit._data, list(range(circuit.num_qubits)), hls_data, tracker)
+
+    def test_qubit_states_after_if_else(self):
+        """
+        Test that the internal qubit tracking mechanism correctly tracks qubit states
+        after an if-else operation.
+        """
+
+        qc = QuantumCircuit(4, 1)
+        with qc.if_test((0, True)) as else_:
+            qc.x(2)
+        with else_:
+            qc.z(0)
+
+        # Initially: qubits 0, 1, 2 are clean; qubit 3 is dirty
         tracker = QubitTracker(4, True)
         tracker.set_dirty([3])
 
-        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+        self.run_and_track_qubits(qc, tracker)
 
-        # Expected: 1 is clean; 0, 2, 4 are dirty
+        # Expected: 1 is clean; 0, 2, 3 are dirty
         expected_clean = {0: False, 1: True, 2: False, 3: False}
-        for q, should_be_clean in expected_clean.items():
-            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
+        self.assertEqual({q: tracker.is_qubit_clean(q) for q in range(4)}, expected_clean)
 
     def test_qubit_states_after_if_without_else(self):
         """
@@ -918,40 +925,19 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         after an if operation.
         """
 
-        # Create a quantum circuit with if/else
         qc = QuantumCircuit(4, 1)
         with qc.if_test((0, True)):
             qc.reset(2)
 
-        # Initialize high-level-synthesis data
-        hls_config = HLSConfig()
-        hls_plugin_manager = HighLevelSynthesisPluginManager()
-        hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
-        target = Target.from_configuration(basis_gates=["cx", "u"])
-        hls_data = HighLevelSynthesisData(
-            hls_config=hls_config,
-            hls_plugin_manager=hls_plugin_manager,
-            coupling_map=None,
-            target=target,
-            equivalence_library=std_eqlib,
-            hls_op_names=hls_op_names,
-            device_insts={"cx", "u"},
-            use_physical_indices=False,
-            min_qubits=0,
-            unroll_definitions=True,
-            optimize_clifford_t=False,
-        )
-
-        # Initialize qubit tracker: qubits 1, 3 are clean; qubits 0, 2 are dirty
+        # Initially: qubits 1, 3 are clean; qubits 0, 2 are dirty
         tracker = QubitTracker(4, True)
         tracker.set_dirty([0, 2])
 
-        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+        self.run_and_track_qubits(qc, tracker)
 
         # Expected: qubits 1, 3 are clean; qubits 0, 2 are dirty
         expected_clean = {0: False, 1: True, 2: False, 3: True}
-        for q, should_be_clean in expected_clean.items():
-            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
+        self.assertEqual({q: tracker.is_qubit_clean(q) for q in range(4)}, expected_clean)
 
     def test_qubit_states_after_switch(self):
         """
@@ -959,7 +945,6 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         after a switch.
         """
 
-        # Create a quantum circuit with a switch statement
         qubits = [Qubit(), Qubit(), Qubit(), Qubit()]
         creg = ClassicalRegister(2)
         qc = QuantumCircuit(qubits, creg)
@@ -973,34 +958,14 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
             with case(3):
                 qc.h(3)
 
-        # Initialize high-level-synthesis data
-        hls_config = HLSConfig()
-        hls_plugin_manager = HighLevelSynthesisPluginManager()
-        hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
-        target = Target.from_configuration(basis_gates=["cx", "u"])
-        hls_data = HighLevelSynthesisData(
-            hls_config=hls_config,
-            hls_plugin_manager=hls_plugin_manager,
-            coupling_map=None,
-            target=target,
-            equivalence_library=std_eqlib,
-            hls_op_names=hls_op_names,
-            device_insts={"cx", "u"},
-            use_physical_indices=False,
-            min_qubits=0,
-            unroll_definitions=True,
-            optimize_clifford_t=False,
-        )
-
-        # Initialize qubit tracker: qubits 0, 1, 2, 3 are clean
+        # Initially: qubits 0, 1, 2, 3 are clean
         tracker = QubitTracker(4, True)
 
-        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+        self.run_and_track_qubits(qc, tracker)
 
-        # Expected: qubits 1 is clean; qubits 0, 2, 3 are dirty
+        # Expected: qubit 1 is clean; qubits 0, 2, 3 are dirty
         expected_clean = {0: False, 1: True, 2: False, 3: False}
-        for q, should_be_clean in expected_clean.items():
-            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
+        self.assertEqual({q: tracker.is_qubit_clean(q) for q in range(4)}, expected_clean)
 
 
 class TestHighLevelSynthesisQuality(QiskitTestCase):

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -843,23 +843,20 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         for q in range(num_qubits):
             self.assertEqual(tracker.is_qubit_clean(q), q not in gate_qubits)
 
-    def test_if_else_tracking(self):
+    def test_no_clean_ancillas_after_if_else(self):
         """
-        Test that the pass correctly tracks qubits states for if-else operations.
+        Test that the pass correctly tracks qubit states after if-else operations.
         Regression test for gh-16859.
         """
-
-        # HLS would mark qubit 4 as clean at the end of the true block.
-        true_body = QuantumCircuit(5)
-        true_body.reset(4)
-
-        false_body = QuantumCircuit(5)
-        false_body.mcx([0, 1, 2], 3)
 
         qc = QuantumCircuit(5, 1)
         qc.h([0, 1, 2, 3, 4])
 
-        qc.if_else((0, True), true_body, false_body, [0, 1, 2, 3, 4], [])
+        with qc.if_test((0, True)) as else_:
+            # HLS would mark qubit 4 as clean at the end of this true block
+            qc.reset(4)
+        with else_:
+            qc.mcx([0, 1, 2], 3)
 
         dag = circuit_to_dag(qc)
 
@@ -871,6 +868,139 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         hls_config = HLSConfig(mcx=["1_clean_kg24"])
         transpiled = HighLevelSynthesis(hls_config=hls_config).run(dag)
         self.assertIn("mcx", transpiled.count_ops())
+
+    def test_qubit_states_after_if_else(self):
+        """
+        Test that the internal qubit tracking mechanism correctly tracks qubit states
+        after an if-else operation.
+        """
+
+        # Create a quantum circuit with if/else
+        qc = QuantumCircuit(4, 1)
+        with qc.if_test((0, True)) as else_:
+            qc.x(2)
+        with else_:
+            qc.z(0)
+
+        # Initialize high-level-synthesis data
+        hls_config = HLSConfig()
+        hls_plugin_manager = HighLevelSynthesisPluginManager()
+        hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
+        target = Target.from_configuration(basis_gates=["cx", "u"])
+        hls_data = HighLevelSynthesisData(
+            hls_config=hls_config,
+            hls_plugin_manager=hls_plugin_manager,
+            coupling_map=None,
+            target=target,
+            equivalence_library=std_eqlib,
+            hls_op_names=hls_op_names,
+            device_insts={"cx", "u"},
+            use_physical_indices=False,
+            min_qubits=0,
+            unroll_definitions=True,
+            optimize_clifford_t=False,
+        )
+
+        # Initialize qubit tracker: qubits 0, 1, 2 are clean; 3 is dirty
+        tracker = QubitTracker(4, True)
+        tracker.set_dirty([3])
+
+        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+
+        # Expected: 1 is clean; 0, 2, 4 are dirty
+        expected_clean = {0: False, 1: True, 2: False, 3: False}
+        for q, should_be_clean in expected_clean.items():
+            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
+
+    def test_qubit_states_after_if_without_else(self):
+        """
+        Test that the internal qubit tracking mechanism correctly tracks qubit states
+        after an if operation.
+        """
+
+        # Create a quantum circuit with if/else
+        qc = QuantumCircuit(4, 1)
+        with qc.if_test((0, True)):
+            qc.reset(2)
+
+        # Initialize high-level-synthesis data
+        hls_config = HLSConfig()
+        hls_plugin_manager = HighLevelSynthesisPluginManager()
+        hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
+        target = Target.from_configuration(basis_gates=["cx", "u"])
+        hls_data = HighLevelSynthesisData(
+            hls_config=hls_config,
+            hls_plugin_manager=hls_plugin_manager,
+            coupling_map=None,
+            target=target,
+            equivalence_library=std_eqlib,
+            hls_op_names=hls_op_names,
+            device_insts={"cx", "u"},
+            use_physical_indices=False,
+            min_qubits=0,
+            unroll_definitions=True,
+            optimize_clifford_t=False,
+        )
+
+        # Initialize qubit tracker: qubits 1, 3 are clean; qubits 0, 2 are dirty
+        tracker = QubitTracker(4, True)
+        tracker.set_dirty([0, 2])
+
+        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+
+        # Expected: qubits 1, 3 are clean; qubits 0, 2 are dirty
+        expected_clean = {0: False, 1: True, 2: False, 3: True}
+        for q, should_be_clean in expected_clean.items():
+            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
+
+    def test_qubit_states_after_switch(self):
+        """
+        Test that the internal qubit tracking mechanism correctly tracks qubit states
+        after a switch.
+        """
+
+        # Create a quantum circuit with a switch statement
+        qubits = [Qubit(), Qubit(), Qubit(), Qubit()]
+        creg = ClassicalRegister(2)
+        qc = QuantumCircuit(qubits, creg)
+        with qc.switch(expr.bit_and(creg, 2)) as case:
+            with case(0):
+                qc.x(0)
+            with case(1):
+                qc.x(2)
+            with case(2):
+                qc.h(0)
+            with case(3):
+                qc.h(3)
+
+        # Initialize high-level-synthesis data
+        hls_config = HLSConfig()
+        hls_plugin_manager = HighLevelSynthesisPluginManager()
+        hls_op_names = set(hls_plugin_manager.plugins_by_op.keys())
+        target = Target.from_configuration(basis_gates=["cx", "u"])
+        hls_data = HighLevelSynthesisData(
+            hls_config=hls_config,
+            hls_plugin_manager=hls_plugin_manager,
+            coupling_map=None,
+            target=target,
+            equivalence_library=std_eqlib,
+            hls_op_names=hls_op_names,
+            device_insts={"cx", "u"},
+            use_physical_indices=False,
+            min_qubits=0,
+            unroll_definitions=True,
+            optimize_clifford_t=False,
+        )
+
+        # Initialize qubit tracker: qubits 0, 1, 2, 3 are clean
+        tracker = QubitTracker(4, True)
+
+        _ = synthesize_circuit(qc._data, list(range(4)), hls_data, tracker)
+
+        # Expected: qubits 1 is clean; qubits 0, 2, 3 are dirty
+        expected_clean = {0: False, 1: True, 2: False, 3: False}
+        for q, should_be_clean in expected_clean.items():
+            self.assertEqual(tracker.is_qubit_clean(q), should_be_clean)
 
 
 class TestHighLevelSynthesisQuality(QiskitTestCase):


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

Fixes #16859.

`HighLevelSynthesis` (incorrectly) used the same qubit tracker when tracking qubit states for an if-then-else instruction, allowing the if-branch to change the status of a qubit to clean after a `reset`, and then using this clean status for synthesizing gates in the else-branch.

This PR provides a very simple fix to this problem by having each branch work with a separate qubit tracker. 

Not for this PR, but the qubit tracking in HighLevelSynthesis is already suboptimal when dealing with control-flow instructions, to avoid complications like "How do we update qubit status at the end of the for-loop?", or "What do we do if the if- and the else- branches of an if-then-else instruction require a different number of ancilla qubits?".

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
