### PR TITLE
Add Rust native Store instruction

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1421,6 +1421,7 @@ pub unsafe extern "C" fn qk_circuit_instruction_kind(
         OperationRef::PauliProductRotation(_) => COperationKind::PauliProductRotation,
         OperationRef::ControlFlow(_) => COperationKind::ControlFlow,
         OperationRef::PyCustom(_) | OperationRef::CustomOperation(_) => COperationKind::Unknown,
+        OperationRef::Store(_) => COperationKind::Unknown,
     }
 }
 

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1067,6 +1067,7 @@ pub unsafe extern "C" fn qk_dag_op_node_kind(dag: *const DAGCircuit, node: u32) 
         OperationRef::PauliProductRotation(_) => COperationKind::PauliProductRotation,
         OperationRef::ControlFlow(_) => COperationKind::ControlFlow,
         OperationRef::PyCustom(_) | OperationRef::CustomOperation(_) => COperationKind::Unknown,
+        OperationRef::Store(_) => COperationKind::Unknown,
     }
 }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1311,7 +1311,8 @@ impl CircuitData {
                     | OperationRef::Unitary(_)
                     | OperationRef::PauliProductMeasurement(_)
                     | OperationRef::PauliProductRotation(_)
-                    | OperationRef::CustomOperation(_) => {
+                    | OperationRef::CustomOperation(_)
+                    | OperationRef::Store(_) => {
                         // TODO: `PauliProductRotation` actually stores a `Param` inside itself,
                         // which this code does not account for.  We most likely need to make an
                         // `OperationRefMut` in order to modify that without cloning the whole
@@ -2549,6 +2550,7 @@ impl PyCircuitData {
                     OperationRef::CustomOperation(custom_operation) => {
                         BoxedCustomOperation::from(custom_operation.clone_dyn()).into()
                     }
+                    OperationRef::Store(store) => store.clone().into(),
                 };
                 res.data.push(PackedInstruction {
                     op: new_op,
@@ -2577,6 +2579,7 @@ impl PyCircuitData {
                     OperationRef::CustomOperation(custom_operation) => {
                         BoxedCustomOperation::from(custom_operation.clone_dyn()).into()
                     }
+                    OperationRef::Store(store) => store.clone().into(),
                 };
                 res.data.push(PackedInstruction {
                     op: new_op,

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -23,6 +23,7 @@ use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::{PyResult, intern};
 
 use crate::circuit_data::{CircuitData, PyCircuitData};
+use crate::classical::expr;
 use crate::dag_circuit::DAGCircuit;
 use crate::duration::Duration;
 use crate::imports::{CONTROLLED_GATE, WARNINGS_WARN};
@@ -30,7 +31,7 @@ use crate::instruction::{Instruction, Parameters, create_py_op};
 use crate::operations::{
     ArrayType, BoxDuration, ControlFlow, ControlFlowInstruction, ControlFlowType, Operation,
     OperationRef, Param, PauliBased, PauliProductMeasurement, PauliProductRotation, PyInstruction,
-    PyOpKind, StandardGate, StandardInstruction, StandardInstructionType, UnitaryGate,
+    PyOpKind, StandardGate, StandardInstruction, StandardInstructionType, Store, UnitaryGate,
 };
 use crate::packed_instruction::PackedOperation;
 use crate::parameter::parameter_expression::ParameterExpression;
@@ -912,6 +913,16 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
                 params: Some(Parameters::Params(smallvec![angle])),
                 label: extract_label()?,
             });
+        } else if ob_name == "store" {
+            let params = get_params()?;
+            let lhs: expr::Expr = params.get_item(0)?.extract()?;
+            let rhs: expr::Expr = params.get_item(1)?.extract()?;
+            let store = Box::new(Store::new(lhs, rhs));
+            return Ok(OperationFromPython {
+                operation: PackedOperation::from_store(store),
+                params: None,
+                label: extract_label()?,
+            });
         }
 
         let Some(kind) = PyOpKind::from_type(ob_type.as_borrowed())? else {
@@ -1011,6 +1022,7 @@ pub fn extract_params<T: CircuitBlock>(
             let params: SmallVec<[Param; 3]> = params.extract()?;
             Some(Parameters::Params(params))
         }
+        OperationRef::Store(_) => None,
     })
 }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6350,19 +6350,11 @@ impl DAGCircuit {
             }
         } else if let OperationRef::Store(store) = instr.op.view() {
             let (expr_clbits, expr_vars) = wires_from_expr(store.lvalue())?;
-            for bit in expr_clbits {
-                clbits.push(bit);
-            }
-            for var in expr_vars {
-                vars.push(var);
-            }
+            clbits.extend(expr_clbits);
+            vars.extend(expr_vars);
             let (expr_clbits, expr_vars) = wires_from_expr(store.rvalue())?;
-            for bit in expr_clbits {
-                clbits.push(bit);
-            }
-            for var in expr_vars {
-                vars.push(var);
-            }
+            clbits.extend(expr_clbits);
+            vars.extend(expr_vars);
         }
         Ok((clbits, vars))
     }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2596,6 +2596,9 @@ impl DAGCircuit {
                                     OperationRef::PauliProductRotation(op_a),
                                     OperationRef::PauliProductRotation(op_b),
                                 ] => Ok((op_a == op_b) && check_args()),
+                                [OperationRef::Store(store_a), OperationRef::Store(store_b)] => {
+                                    Ok(store_a == store_b)
+                                }
                                 _ => Ok(false),
                             }
                         }
@@ -3062,7 +3065,7 @@ impl DAGCircuit {
             let cargs_set: HashSet<&ShareableClbit> =
                 HashSet::from_iter(cargs_list.iter().cloned());
             if self.may_have_additional_wires(&node) {
-                let (add_cargs, _add_vars) = Python::attach(|py| self.additional_wires(py, &node))?;
+                let (add_cargs, _add_vars) = self.additional_wires(&node)?;
                 for wire in add_cargs {
                     let clbit = self.clbits.get(wire).unwrap();
                     if !cargs_set.contains(clbit) {
@@ -3176,7 +3179,7 @@ impl DAGCircuit {
             input_dag.vars_stretches.vars().objects().iter().collect();
 
         let node_vars = if self.may_have_additional_wires(&node) {
-            let (_additional_clbits, additional_vars) = self.additional_wires(py, &node)?;
+            let (_additional_clbits, additional_vars) = self.additional_wires(&node)?;
             let var_set: HashSet<&expr::Var> = additional_vars
                 .into_iter()
                 .map(|v| self.vars_stretches.vars().get(v).unwrap())
@@ -6064,8 +6067,7 @@ impl DAGCircuit {
             if self.may_have_additional_wires(instr) {
                 let mut clbits: IndexSet<Clbit> =
                     IndexSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());
-                let (additional_clbits, additional_vars) =
-                    Python::attach(|py| self.additional_wires(py, instr))?;
+                let (additional_clbits, additional_vars) = self.additional_wires(instr)?;
                 for clbit in additional_clbits {
                     clbits.insert(clbit);
                 }
@@ -6262,22 +6264,13 @@ impl DAGCircuit {
     }
 
     fn may_have_additional_wires(&self, instr: &PackedInstruction) -> bool {
-        match instr.op.view() {
-            OperationRef::ControlFlow(_) => true,
-            OperationRef::PyCustom(PyInstruction {
-                kind: PyOpKind::Instruction,
-                op_name,
-                ..
-            }) => op_name == "store",
-            _ => false,
-        }
+        matches!(
+            instr.op.view(),
+            OperationRef::ControlFlow(_) | OperationRef::Store(_)
+        )
     }
 
-    fn additional_wires(
-        &self,
-        py: Python,
-        instr: &PackedInstruction,
-    ) -> PyResult<(Vec<Clbit>, Vec<Var>)> {
+    fn additional_wires(&self, instr: &PackedInstruction) -> PyResult<(Vec<Clbit>, Vec<Var>)> {
         let wires_from_expr = |node: &expr::Expr| -> PyResult<(Vec<Clbit>, Vec<Var>)> {
             let mut clbits = Vec::new();
             let mut vars: Vec<Var> = Vec::new();
@@ -6355,23 +6348,20 @@ impl DAGCircuit {
                     vars.push(self.vars_stretches.vars().find(var).unwrap());
                 }
             }
-        } else if let OperationRef::PyCustom(instr) = instr.op.view() {
-            let op = instr.ob.bind(py);
-            if op.is_instance(imports::STORE_OP.get_bound(py))? {
-                let (expr_clbits, expr_vars) = wires_from_expr(&op.getattr("lvalue")?.extract()?)?;
-                for bit in expr_clbits {
-                    clbits.push(bit);
-                }
-                for var in expr_vars {
-                    vars.push(var);
-                }
-                let (expr_clbits, expr_vars) = wires_from_expr(&op.getattr("rvalue")?.extract()?)?;
-                for bit in expr_clbits {
-                    clbits.push(bit);
-                }
-                for var in expr_vars {
-                    vars.push(var);
-                }
+        } else if let OperationRef::Store(store) = instr.op.view() {
+            let (expr_clbits, expr_vars) = wires_from_expr(store.lhs())?;
+            for bit in expr_clbits {
+                clbits.push(bit);
+            }
+            for var in expr_vars {
+                vars.push(var);
+            }
+            let (expr_clbits, expr_vars) = wires_from_expr(store.rhs())?;
+            for bit in expr_clbits {
+                clbits.push(bit);
+            }
+            for var in expr_vars {
+                vars.push(var);
             }
         }
         Ok((clbits, vars))
@@ -7322,8 +7312,7 @@ impl DAGCircuit {
         }
 
         if self.may_have_additional_wires(inst) {
-            let (clbits, vars) =
-                Python::attach(|py| self.additional_wires(py, inst).map_err(DAGError::Python))?;
+            let (clbits, vars) = self.additional_wires(inst).map_err(DAGError::Python)?;
             for b in clbits {
                 if !self.clbit_io_map.len() - 1 < b.index() {
                     return Err(DAGError::WireNotInOutput(ShareableWire::Clbit(
@@ -7812,9 +7801,8 @@ impl DAGCircuit {
             block_qargs.extend(self.qargs_interner.get(instr.qubits));
             block_cargs.extend(self.cargs_interner.get(instr.clbits));
             if self.may_have_additional_wires(instr) {
-                let (additional_clbits, _) = Python::attach(|py| {
-                    self.additional_wires(py, instr).map_err(DAGError::Python)
-                })?;
+                let (additional_clbits, _) =
+                    self.additional_wires(instr).map_err(DAGError::Python)?;
                 for clbit in additional_clbits {
                     block_cargs.insert(clbit);
                 }
@@ -8268,10 +8256,9 @@ impl DAGCircuit {
             py_op: OnceLock::from(op.clone().unbind()),
         };
 
-        let (additional_clbits, additional_vars) = Python::attach(|py| {
-            self.additional_wires(py, &new_instr)
-                .map_err(DAGError::Python)
-        })?;
+        let (additional_clbits, additional_vars) = self
+            .additional_wires(&new_instr)
+            .map_err(DAGError::Python)?;
         new_wires.extend(additional_clbits.iter().map(|x| Wire::Clbit(*x)));
         new_wires.extend(additional_vars.iter().map(|x| Wire::Var(*x)));
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6349,14 +6349,14 @@ impl DAGCircuit {
                 }
             }
         } else if let OperationRef::Store(store) = instr.op.view() {
-            let (expr_clbits, expr_vars) = wires_from_expr(store.lhs())?;
+            let (expr_clbits, expr_vars) = wires_from_expr(store.lvalue())?;
             for bit in expr_clbits {
                 clbits.push(bit);
             }
             for var in expr_vars {
                 vars.push(var);
             }
-            let (expr_clbits, expr_vars) = wires_from_expr(store.rhs())?;
+            let (expr_clbits, expr_vars) = wires_from_expr(store.rvalue())?;
             for bit in expr_clbits {
                 clbits.push(bit);
             }

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -138,6 +138,7 @@ pub static SYMPIFY_PARAMETER_EXPRESSION: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.parameterexpression", "sympify");
 pub static TRANSPILE_LAYOUT: ImportOnceCell =
     ImportOnceCell::new("qiskit.transpiler.layout", "TranspileLayout");
+pub static STORE: ImportOnceCell = ImportOnceCell::new("qiskit.circuit.store", "Store");
 
 /// A mapping from the enum variant in crate::operations::StandardGate to the python
 /// module path and class name to import it. This is used to populate the conversion table

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -194,5 +194,6 @@ pub fn create_py_op(
         OperationRef::CustomOperation(_) => Err(PyNotImplementedError::new_err(
             "Custom operations from Rust cannot be exposed to Python",
         )),
+        OperationRef::Store(store) => store.create_py_op(py, label),
     }
 }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -288,6 +288,7 @@ pub enum OperationRef<'a> {
     PauliProductMeasurement(&'a PauliProductMeasurement),
     PauliProductRotation(&'a PauliProductRotation),
     CustomOperation(&'a dyn CustomOperation),
+    Store(&'a Store),
 }
 
 impl Operation for OperationRef<'_> {
@@ -302,6 +303,7 @@ impl Operation for OperationRef<'_> {
             Self::PauliProductMeasurement(ppm) => ppm.name(),
             Self::PauliProductRotation(rotation) => rotation.name(),
             Self::CustomOperation(operation) => operation.name(),
+            Self::Store(store) => store.name(),
         }
     }
     #[inline]
@@ -315,6 +317,7 @@ impl Operation for OperationRef<'_> {
             Self::PauliProductMeasurement(ppm) => ppm.num_qubits(),
             Self::PauliProductRotation(rotation) => rotation.num_qubits(),
             Self::CustomOperation(operation) => operation.num_qubits(),
+            Self::Store(store) => store.num_qubits(),
         }
     }
     #[inline]
@@ -328,6 +331,7 @@ impl Operation for OperationRef<'_> {
             Self::PauliProductMeasurement(ppm) => ppm.num_clbits(),
             Self::PauliProductRotation(rotation) => rotation.num_clbits(),
             Self::CustomOperation(operation) => operation.num_clbits(),
+            Self::Store(store) => store.num_clbits(),
         }
     }
     #[inline]
@@ -341,6 +345,7 @@ impl Operation for OperationRef<'_> {
             Self::PauliProductMeasurement(ppm) => ppm.num_params(),
             Self::PauliProductRotation(rotation) => rotation.num_params(),
             Self::CustomOperation(operation) => operation.num_params(),
+            Self::Store(store) => store.num_params(),
         }
     }
     #[inline]
@@ -354,6 +359,7 @@ impl Operation for OperationRef<'_> {
             Self::PauliProductMeasurement(ppm) => ppm.directive(),
             Self::PauliProductRotation(rotation) => rotation.directive(),
             Self::CustomOperation(operation) => operation.directive(),
+            Self::Store(store) => store.directive(),
         }
     }
 }
@@ -1918,6 +1924,62 @@ impl PartialEq for PauliProductMeasurement {
 }
 
 impl Eq for PauliProductMeasurement {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Store {
+    lhs: expr::Expr,
+    rhs: expr::Expr,
+}
+
+impl Store {
+    pub fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
+        if let Some(label) = label {
+            Ok(imports::STORE
+                .get_bound(py)
+                .call1((self.lhs.clone(), self.rhs.clone(), label))?
+                .unbind())
+        } else {
+            Ok(imports::STORE
+                .get_bound(py)
+                .call1((self.lhs.clone(), self.rhs.clone()))?
+                .unbind())
+        }
+    }
+
+    pub fn lhs(&self) -> &expr::Expr {
+        &self.lhs
+    }
+
+    pub fn rhs(&self) -> &expr::Expr {
+        &self.rhs
+    }
+
+    pub fn new(lhs: expr::Expr, rhs: expr::Expr) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+impl Operation for Store {
+    fn name(&self) -> &str {
+        "store"
+    }
+
+    fn num_qubits(&self) -> u32 {
+        0
+    }
+
+    fn num_clbits(&self) -> u32 {
+        0
+    }
+
+    fn num_params(&self) -> u32 {
+        0
+    }
+
+    fn directive(&self) -> bool {
+        true
+    }
+}
 
 /// Private module with especific traits that allow for the implementation
 /// of non dyn-compatible traits for [`CustomOperation`]. Namely [`PartialEq`]

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1925,10 +1925,11 @@ impl PartialEq for PauliProductMeasurement {
 
 impl Eq for PauliProductMeasurement {}
 
+/// A manual storage of some classical value to a classical memory location
 #[derive(Debug, Clone, PartialEq)]
 pub struct Store {
-    lhs: expr::Expr,
-    rhs: expr::Expr,
+    lvalue: expr::Expr,
+    rvalue: expr::Expr,
 }
 
 impl Store {
@@ -1936,26 +1937,39 @@ impl Store {
         if let Some(label) = label {
             Ok(imports::STORE
                 .get_bound(py)
-                .call1((self.lhs.clone(), self.rhs.clone(), label))?
+                .call1((self.lvalue.clone(), self.rvalue.clone(), label))?
                 .unbind())
         } else {
             Ok(imports::STORE
                 .get_bound(py)
-                .call1((self.lhs.clone(), self.rhs.clone()))?
+                .call1((self.lvalue.clone(), self.rvalue.clone()))?
                 .unbind())
         }
     }
 
-    pub fn lhs(&self) -> &expr::Expr {
-        &self.lhs
+    /// Get an immutable borrow to the lvalue of this Store operation
+    pub fn lvalue(&self) -> &expr::Expr {
+        &self.lvalue
     }
 
-    pub fn rhs(&self) -> &expr::Expr {
-        &self.rhs
+    /// Get an immutable borrow to the rvalue of this Store operation
+    pub fn rvalue(&self) -> &expr::Expr {
+        &self.rvalue
     }
 
-    pub fn new(lhs: expr::Expr, rhs: expr::Expr) -> Self {
-        Self { lhs, rhs }
+    /// Create a new Store operation
+    ///
+    /// The `lvalue` argument must be a valid lvalue (typically a var)
+    /// and the `rvalue` argument must be a valid value for that
+    /// storage location. This is a raw interface that has no input
+    /// checking done by this function to validate these constraints.
+    /// If they are violated you will create an invalid Store operation
+    /// that will potentially corrupt the [`CircuitData`] or [`DAGCircuit`]
+    /// objects when they are added. This is primarily intended to be used
+    /// when created the rust source of truth from a user created object
+    /// in Python (which has the input validation).
+    pub fn new(lvalue: expr::Expr, rvalue: expr::Expr) -> Self {
+        Self { lvalue, rvalue }
     }
 }
 

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -13,15 +13,15 @@
 use crate::circuit_data::CircuitData;
 use crate::imports::{
     BARRIER, BOX_OP, BREAK_LOOP_OP, CONTINUE_LOOP_OP, DELAY, FOR_LOOP_OP, IF_ELSE_OP, MEASURE,
-    PAULI_PRODUCT_MEASUREMENT, PAULI_PRODUCT_ROTATION_GATE, RESET, SWITCH_CASE_OP, UNITARY_GATE,
-    WHILE_LOOP_OP, get_std_gate_class,
+    PAULI_PRODUCT_MEASUREMENT, PAULI_PRODUCT_ROTATION_GATE, RESET, STORE, SWITCH_CASE_OP,
+    UNITARY_GATE, WHILE_LOOP_OP, get_std_gate_class,
 };
 use crate::instruction::Parameters;
 use crate::interner::Interned;
 use crate::operations::{
     BoxedCustomOperation, ControlFlow, ControlFlowInstruction, CustomOperation, Operation,
     OperationRef, Param, PauliBased, PyInstruction, PyOpKind, PythonOperation, StandardGate,
-    StandardInstruction, UnitaryGate,
+    StandardInstruction, Store, UnitaryGate,
 };
 use crate::{Block, Clbit, Qubit};
 use hashbrown::HashMap;
@@ -49,6 +49,7 @@ enum PackedOperationType {
     PauliBased = 4,
     ControlFlow = 5,
     Custom = 6,
+    Store = 7,
 }
 impl PackedOperationType {
     /// Get `self` as a mask that can be used as a discriminant for `PackedOperation` pointers.
@@ -62,7 +63,7 @@ unsafe impl ::bytemuck::CheckedBitPattern for PackedOperationType {
     type Bits = u8;
 
     fn is_valid_bit_pattern(bits: &Self::Bits) -> bool {
-        *bits < 7
+        *bits < 8
     }
 }
 unsafe impl ::bytemuck::NoUninit for PackedOperationType {}
@@ -159,6 +160,7 @@ impl From<*mut ()> for PackedOperationInner {
 ///     PauliBased(Box<PauliBased>),
 ///     ControlFlow(Box<ControlFlowInstruction>),
 ///     Custom(Box<dyn CustomOperation>),
+///     Store(Box<Store>),
 /// }
 /// ```
 ///
@@ -359,7 +361,7 @@ mod standard_instruction {
 /// A private module to encapsulate the encoding of pointer types.
 mod pointer {
     use crate::operations::{
-        BoxedCustomOperation, ControlFlowInstruction, PyInstruction, UnitaryGate,
+        BoxedCustomOperation, ControlFlowInstruction, PyInstruction, Store, UnitaryGate,
     };
     use crate::packed_instruction::{PackedOperation, PackedOperationType, PauliBased};
     use std::ptr::NonNull;
@@ -445,6 +447,7 @@ mod pointer {
     impl_packable_pointer!(PauliBased, PackedOperationType::PauliBased);
     impl_packable_pointer!(ControlFlowInstruction, PackedOperationType::ControlFlow);
     impl_packable_pointer!(BoxedCustomOperation, PackedOperationType::Custom);
+    impl_packable_pointer!(Store, PackedOperationType::Store);
 }
 
 impl PackedOperation {
@@ -533,6 +536,7 @@ impl PackedOperation {
                 let custom_op: &BoxedCustomOperation = self.try_into().unwrap();
                 OperationRef::CustomOperation(&**custom_op)
             }
+            PackedOperationType::Store => OperationRef::Store(self.try_into().unwrap()),
         }
     }
 
@@ -596,6 +600,11 @@ impl PackedOperation {
         BoxedCustomOperation::from(custom).into()
     }
 
+    #[inline]
+    pub fn from_store(store: Box<Store>) -> Self {
+        store.into()
+    }
+
     /// Clone this `PackedOperation`, deepcopying if the internal object is a Python object.
     ///
     /// This is similar to [py_deepcopy], but only attaches to a Python interpreter if it has to.
@@ -610,7 +619,8 @@ impl PackedOperation {
             | OperationRef::Unitary(_)
             | OperationRef::PauliProductMeasurement(_)
             | OperationRef::PauliProductRotation(_)
-            | OperationRef::CustomOperation(_) => Ok(self.clone()),
+            | OperationRef::CustomOperation(_)
+            | OperationRef::Store(_) => Ok(self.clone()),
         }
     }
 
@@ -627,7 +637,8 @@ impl PackedOperation {
             | OperationRef::Unitary(_)
             | OperationRef::PauliProductMeasurement(_)
             | OperationRef::PauliProductRotation(_)
-            | OperationRef::CustomOperation(_) => Ok(self.clone()),
+            | OperationRef::CustomOperation(_)
+            | OperationRef::Store(_) => Ok(self.clone()),
         }
     }
 
@@ -655,6 +666,7 @@ impl PackedOperation {
                 OperationRef::PauliProductRotation(left),
                 OperationRef::PauliProductRotation(right),
             ) => Ok(left == right),
+            (OperationRef::Store(left), OperationRef::Store(right)) => Ok(left == right),
             _ => Ok(false),
         }
     }
@@ -728,6 +740,7 @@ impl PackedOperation {
             OperationRef::CustomOperation(_) => Err(PyNotImplementedError::new_err(
                 "Custom operations from Rust cannot be checked by instance",
             )),
+            OperationRef::Store(_) => STORE.get_bound(py).cast::<PyType>()?.is_subclass(py_type),
         }
     }
 }
@@ -744,6 +757,7 @@ impl Operation for PackedOperation {
             OperationRef::PauliProductMeasurement(ppm) => ppm.name(),
             OperationRef::PauliProductRotation(rotation) => rotation.name(),
             OperationRef::CustomOperation(op) => op.name(),
+            OperationRef::Store(store) => store.name(),
         };
         // SAFETY: all of the inner parts of the view are owned by `self`, so it's valid for us to
         // forcibly reborrowing up to our own lifetime. We avoid using `<OperationRef as Operation>`
@@ -794,6 +808,7 @@ impl Clone for PackedOperation {
             OperationRef::CustomOperation(custom_gate) => {
                 Self::from(BoxedCustomOperation::from(custom_gate.clone_dyn()))
             }
+            OperationRef::Store(store) => Self::from_store(Box::new(store.clone())),
         }
     }
 }
@@ -808,6 +823,7 @@ impl Drop for PackedOperation {
             PackedOperationType::PauliBased => PauliBased::drop_packed(self),
             PackedOperationType::ControlFlow => ControlFlowInstruction::drop_packed(self),
             PackedOperationType::Custom => BoxedCustomOperation::drop_packed(self),
+            PackedOperationType::Store => Store::drop_packed(self),
         }
     }
 }

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -34,7 +34,7 @@ use qiskit_circuit::interner::Interned;
 use qiskit_circuit::operations::{
     ArrayType, BoxDuration, CaseSpecifier, Condition, ControlFlow, ControlFlowInstruction,
     ControlFlowType, LoopParam, Param, PauliBased, PauliProductMeasurement, PauliProductRotation,
-    StandardInstruction, StandardInstructionType, SwitchTarget, UnitaryGate,
+    StandardInstruction, StandardInstructionType, Store, SwitchTarget, UnitaryGate,
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
@@ -56,8 +56,8 @@ use crate::formats::QPYCircuit;
 use crate::params::generic_value_to_param;
 use crate::py_methods::{
     PAULI_PRODUCT_MEASUREMENT_GATE_CLASS_NAME, PAULI_PRODUCT_ROTATION_GATE_CLASS_NAME,
-    UNITARY_GATE_CLASS_NAME, deserialize_pauli_evolution_gate, py_convert_from_generic_value,
-    unpack_custom_instruction, unpack_py_instruction,
+    STORE_INSTR_CLASS_NAME, UNITARY_GATE_CLASS_NAME, deserialize_pauli_evolution_gate,
+    py_convert_from_generic_value, unpack_custom_instruction, unpack_py_instruction,
 };
 use crate::value::{
     BitType, CircuitInstructionType, ExpressionType, ExpressionVarDeclaration, GenericValue,
@@ -91,6 +91,7 @@ pub enum InstructionType {
     PauliProductRotation,
     Unitary,
     ControlFlow,
+    Store,
     // covers instruction types require resorting to python space
     Custom,
     Python,
@@ -192,6 +193,8 @@ fn recognize_instruction_type(
         || ["Barrier", "Delay", "Measure", "Reset"].contains(&name)
     {
         InstructionType::StandardInstruction
+    } else if name == STORE_INSTR_CLASS_NAME {
+        InstructionType::Store
     } else if custom_instructions.get(name).is_some() {
         InstructionType::Custom
     } else {
@@ -363,6 +366,7 @@ pub fn unpack_instruction(
         }
         InstructionType::Unitary => unpack_unitary(instruction, qpy_data)?,
         InstructionType::ControlFlow => unpack_control_flow(instruction, qpy_data)?,
+        InstructionType::Store => unpack_store(instruction, qpy_data)?,
         InstructionType::Custom => {
             QpyCaller::Python.attach("Python custom instruction unpacking", |py| {
                 unpack_custom_instruction(
@@ -438,6 +442,33 @@ fn unpack_standard_instruction(
     let param_values =
         get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
     Ok((op, param_values))
+}
+
+fn unpack_store(
+    instruction: &formats::CircuitInstructionV2Pack,
+    qpy_data: &mut QPYReadData,
+) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
+    if instruction.params.len() != 2 {
+        return Err(QpyError::InvalidParameter(
+            "Store operations should have exactly 2 parameters".to_string(),
+        ));
+    }
+    let GenericValue::Expression(lvalue) =
+        unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?
+    else {
+        return Err(QpyError::InvalidExpression(
+            "could not determine expression for instruction's lvalue".to_string(),
+        ));
+    };
+    let GenericValue::Expression(rvalue) =
+        unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?
+    else {
+        return Err(QpyError::InvalidExpression(
+            "could not determine expression for store instruction's rvalue".to_string(),
+        ));
+    };
+    let store = Store::new(lvalue, rvalue);
+    Ok((Box::new(store).into(), vec![]))
 }
 
 fn unpack_pauli_product_measurement(

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -49,8 +49,8 @@ use crate::interface::ExtraCircuitData;
 use crate::params::pack_param_obj;
 use crate::py_methods::{
     PAULI_PRODUCT_MEASUREMENT_GATE_CLASS_NAME, PAULI_PRODUCT_ROTATION_GATE_CLASS_NAME,
-    UNITARY_GATE_CLASS_NAME, gate_class_name, py_pack_param, py_pack_pauli_evolution_gate,
-    recognize_custom_operation, serialize_metadata,
+    STORE_INSTR_CLASS_NAME, UNITARY_GATE_CLASS_NAME, gate_class_name, py_pack_param,
+    py_pack_pauli_evolution_gate, recognize_custom_operation, serialize_metadata,
 };
 use crate::value::{
     BitType, CircuitInstructionType, ExpressionVarDeclaration, GenericValue, ParamRegisterValue,
@@ -633,7 +633,7 @@ fn pack_store(
         extras_key: 0,
         num_ctrl_qubits: 0,
         ctrl_state: 0,
-        gate_class_name: "Store".to_string(),
+        gate_class_name: STORE_INSTR_CLASS_NAME.to_string(),
         label: instruction
             .label
             .as_ref()

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -37,7 +37,7 @@ use qiskit_circuit::instruction::Parameters;
 use qiskit_circuit::operations::{
     BoxDuration, CaseSpecifier, Condition, ControlFlow, ControlFlowInstruction, LoopParam,
     Operation, OperationRef, Param, PauliProductMeasurement, PauliProductRotation, PyInstruction,
-    PyOpKind, StandardGate, StandardInstruction, SwitchTarget, UnitaryGate,
+    PyOpKind, StandardGate, StandardInstruction, Store, SwitchTarget, UnitaryGate,
 };
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
 
@@ -269,6 +269,7 @@ fn pack_instruction(
                 "compiled custom operations are not yet supported in QPY".to_owned(),
             ));
         }
+        OperationRef::Store(store) => pack_store(store, instruction, qpy_data)?,
     };
 
     // common data extraction for all instruction types
@@ -610,6 +611,34 @@ fn pack_unitary_gate(
         ctrl_state: 0,
         gate_class_name,
         label: Default::default(),
+        condition: Default::default(),
+        bit_data: Default::default(),
+        params,
+        annotations: None,
+    })
+}
+
+fn pack_store(
+    store: &Store,
+    instruction: &PackedInstruction,
+    qpy_data: &mut QPYWriteData,
+) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
+    let params: Vec<formats::GenericDataPack> = vec![
+        pack_generic_value(&GenericValue::Expression(store.lhs().clone()), qpy_data)?,
+        pack_generic_value(&GenericValue::Expression(store.rhs().clone()), qpy_data)?,
+    ];
+    Ok(formats::CircuitInstructionV2Pack {
+        num_qargs: 0,
+        num_cargs: 0,
+        extras_key: 0,
+        num_ctrl_qubits: 0,
+        ctrl_state: 0,
+        gate_class_name: "Store".to_string(),
+        label: instruction
+            .label
+            .as_ref()
+            .map(|x| x.as_ref().clone())
+            .unwrap_or("".to_string()),
         condition: Default::default(),
         bit_data: Default::default(),
         params,

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -624,8 +624,8 @@ fn pack_store(
     qpy_data: &mut QPYWriteData,
 ) -> Result<formats::CircuitInstructionV2Pack, QpyError> {
     let params: Vec<formats::GenericDataPack> = vec![
-        pack_generic_value(&GenericValue::Expression(store.lhs().clone()), qpy_data)?,
-        pack_generic_value(&GenericValue::Expression(store.rhs().clone()), qpy_data)?,
+        pack_generic_value(&GenericValue::Expression(store.lvalue().clone()), qpy_data)?,
+        pack_generic_value(&GenericValue::Expression(store.rvalue().clone()), qpy_data)?,
     ];
     Ok(formats::CircuitInstructionV2Pack {
         num_qargs: 0,

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -53,6 +53,7 @@ use crate::value::{
 };
 
 pub const UNITARY_GATE_CLASS_NAME: &str = "UnitaryGate";
+pub const STORE_INSTR_CLASS_NAME: &str = "Store";
 pub const PAULI_PRODUCT_MEASUREMENT_GATE_CLASS_NAME: &str = "PauliProductMeasurement";
 pub const PAULI_PRODUCT_ROTATION_GATE_CLASS_NAME: &str = "PauliProductRotationGate";
 
@@ -302,6 +303,7 @@ pub(crate) fn gate_class_name(py: Python, op: &PackedOperation) -> Result<String
             Ok(String::from(PAULI_PRODUCT_ROTATION_GATE_CLASS_NAME))
         }
         OperationRef::ControlFlow(inst) => Ok(inst.name().to_string()),
+        OperationRef::Store(_store) => Ok(STORE_INSTR_CLASS_NAME.to_string()),
         OperationRef::CustomOperation(_) => {
             Err(PyTypeError::new_err("Custom gates from rust are not classes.").into())
         }

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -900,7 +900,8 @@ pub(crate) fn get_circuit_type_key(
         | OperationRef::Unitary(_) => Ok(CircuitInstructionType::Gate),
         OperationRef::StandardInstruction(_)
         | OperationRef::ControlFlow(_)
-        | OperationRef::PauliProductMeasurement(_) => Ok(CircuitInstructionType::Instruction),
+        | OperationRef::PauliProductMeasurement(_)
+        | OperationRef::Store(_) => Ok(CircuitInstructionType::Instruction),
         OperationRef::PyCustom(PyInstruction { kind, ob, .. }) => {
             caller.attach("Python-defined operations", |py| {
                 let ob = ob.bind(py);

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -517,6 +517,7 @@ fn replace_node(
                     PauliBased::PauliProductRotation(rotation.clone()).into()
                 }
                 OperationRef::CustomOperation(_) => inner_node.op.clone(),
+                OperationRef::Store(store) => store.clone().into(),
             };
             let new_params: Option<Parameters<_>> = inner_node.params.as_deref().cloned();
             dag.apply_operation_back(
@@ -585,6 +586,7 @@ fn replace_node(
                     PauliBased::PauliProductRotation(rotation.clone()).into()
                 }
                 OperationRef::CustomOperation(_) => inner_node.op.clone(),
+                OperationRef::Store(store) => store.clone().into(),
             };
 
             let mut new_params: Option<Parameters<_>> = inner_node.params.as_deref().cloned();

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -809,6 +809,7 @@ fn extract_definition(op: &PackedOperation, params: &[Param]) -> PyResult<Option
             | StandardInstruction::Barrier(_)
             | StandardInstruction::Delay(_) => Ok(None),
         },
+        OperationRef::Store(_) => Ok(None),
         OperationRef::ControlFlow(_) => Ok(None),
         OperationRef::CustomOperation(custom_gate) => Ok(custom_gate.definition(params)),
     }
@@ -958,6 +959,7 @@ fn synthesize_op_using_plugins(
         OperationRef::PauliProductRotation(rotation) => {
             rotation.create_py_op(py, label)?.into_any()
         }
+        OperationRef::Store(store) => store.create_py_op(py, label)?.into_any(),
         OperationRef::CustomOperation(_) => {
             return Err(PyNotImplementedError::new_err(
                 "Custom Operations from Rust cannot be exposed to Python.",


### PR DESCRIPTION
This commit adds a Rust native representation of the store instruction. While the instruction logically fits under the StandardInstruction type it is added a as a new variant on the PackedOperation struct because it is too wide to fit in the StandardInstruction data on PackedOperation which is limited. The store type needs to contain two Expr objects so that requires a layer of pointer indirection to fit in PackedOperation. We need to do the bit packing for pointer types on PackedOperation which precludes using it in StandardInstruction.

This commit adds the data model support for the store instruction to Rust. It doesn't move any of the UI around interacting with or creating the Store instructions to Rust. For example, the input type checking still when creating a new instruction that validates the lhs is a l-value and the rhs is a valid type only exists in Python as of this commit. The goal of this PR was to move the source of truth for the data to Rust not to provide an interface for it to Rust. As this is sufficient to remove the python data dependency from CircuitData and DAGCircuit around dealing with store instructions.

This also does not include C support for the instruction that will be a future PR.

Fixes #16895

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
