### PR TITLE
Fix control-flow builder overloads for static type checkers

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -7230,10 +7230,9 @@ class QuantumCircuit:
                 qc.measure(0, 0)
 
         Args:
-            condition (Tuple[Union[ClassicalRegister, Clbit], int]): An equality condition to be
-                checked prior to executing ``body``. The left-hand side of the condition must be a
-                :obj:`~ClassicalRegister` or a :obj:`~Clbit`, and the right-hand side must be an
-                integer or boolean.
+            condition (expr.Expr | Tuple[Union[ClassicalRegister, Clbit], int]): A condition to be
+                checked prior to executing ``body``.  Either an :class:`~.expr.Expr` of ``Bool()``
+                type, or the legacy two-tuple equality form ``(register_or_bit, value)``.
             body (Optional[QuantumCircuit]): The loop body to be repeatedly executed.  Omit this to
                 use the context-manager mode.
             qubits (Optional[Sequence[Qubit]]): The circuit qubits over which the loop body should
@@ -7426,11 +7425,10 @@ class QuantumCircuit:
                 qc.z(2)
 
         Args:
-            condition (Tuple[Union[ClassicalRegister, Clbit], int]): A condition to be evaluated in
-                real time during circuit execution, which, if true, will trigger the evaluation of
-                ``true_body``. Can be specified as either a tuple of a ``ClassicalRegister`` to be
-                tested for equality with a given ``int``, or as a tuple of a ``Clbit`` to be
-                compared to either a ``bool`` or an ``int``.
+            condition (expr.Expr | Tuple[Union[ClassicalRegister, Clbit], int]): A condition to be
+                evaluated in real time during circuit execution which, if true, will trigger the
+                evaluation of ``true_body``.  Either an :class:`~.expr.Expr` of ``Bool()`` type, or
+                the legacy two-tuple equality form ``(register_or_bit, value)``.
             true_body (Optional[QuantumCircuit]): The circuit body to be run if ``condition`` is
                 true.
             qubits (Optional[Sequence[QubitSpecifier]]): The circuit qubits over which the if/else
@@ -7504,11 +7502,10 @@ class QuantumCircuit:
                     qc.x(0)
 
         Args:
-            condition: A condition to be evaluated in real time at circuit execution, which,
-                if true, will trigger the evaluation of ``true_body``. Can be
-                specified as either a tuple of a ``ClassicalRegister`` to be
-                tested for equality with a given ``int``, or as a tuple of a
-                ``Clbit`` to be compared to either a ``bool`` or an ``int``.
+            condition: A condition to be evaluated in real time at circuit execution which, if
+                true, will trigger the evaluation of ``true_body``.  Either an
+                :class:`~.expr.Expr` of ``Bool()`` type, or the legacy two-tuple equality form
+                ``(register_or_bit, value)``.
             true_body: The circuit body to be run if ``condition`` is true.
             false_body: The circuit to be run if ``condition`` is false.
             qubits: The circuit qubits over which the if/else should be run.
@@ -7582,8 +7579,9 @@ class QuantumCircuit:
                     qc.cx(0, 1)
 
         Args:
-            target (Union[ClassicalRegister, Clbit]): The classical value to switch one.  This must
-                be integer-like.
+            target (expr.Expr | Union[ClassicalRegister, Clbit]): The classical value to switch on.
+                Either an :class:`~.expr.Expr` of ``Uint(n)`` or ``Bool()`` type, or a
+                :obj:`~ClassicalRegister` or :obj:`~Clbit`.
             cases (Iterable[Tuple[typing.Any, QuantumCircuit]]): A sequence of case specifiers.
                 Each tuple defines one case body (the second item).  The first item of the tuple can
                 be either a single integer value, the special value :data:`.CASE_DEFAULT`, or a

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -7189,11 +7189,11 @@ class QuantumCircuit:
     def while_loop(
         self,
         condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr,
-        body: None,
-        qubits: None,
-        clbits: None,
+        body: None = ...,
+        qubits: None = ...,
+        clbits: None = ...,
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> WhileLoopContext: ...
 
     @typing.overload
@@ -7204,7 +7204,7 @@ class QuantumCircuit:
         qubits: Sequence[QubitSpecifier],
         clbits: Sequence[ClbitSpecifier],
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> InstructionSet: ...
 
     def while_loop(self, condition, body=None, qubits=None, clbits=None, *, label=None):
@@ -7274,12 +7274,12 @@ class QuantumCircuit:
     def for_loop(
         self,
         indexset: Iterable[int],
-        loop_parameter: Parameter | expr.Var | None,
-        body: None,
-        qubits: None,
-        clbits: None,
+        loop_parameter: Parameter | expr.Var | None = ...,
+        body: None = ...,
+        qubits: None = ...,
+        clbits: None = ...,
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> ForLoopContext: ...
 
     @typing.overload
@@ -7291,7 +7291,7 @@ class QuantumCircuit:
         qubits: Sequence[QubitSpecifier],
         clbits: Sequence[ClbitSpecifier],
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> InstructionSet: ...
 
     def for_loop(
@@ -7370,12 +7370,14 @@ class QuantumCircuit:
         )
 
     @typing.overload
-    def if_test(self, condition: tuple[ClassicalRegister | Clbit, int]) -> IfContext: ...
+    def if_test(
+        self, condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr
+    ) -> IfContext: ...
 
     @typing.overload
     def if_test(
         self,
-        condition: tuple[ClassicalRegister | Clbit, int],
+        condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr,
         true_body: QuantumCircuit,
         qubits: Sequence[QubitSpecifier],
         clbits: Sequence[ClbitSpecifier],
@@ -7473,7 +7475,9 @@ class QuantumCircuit:
 
     def if_else(
         self,
-        condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | tuple[Clbit, bool],
+        condition: (
+            tuple[ClassicalRegister, int] | tuple[Clbit, int] | tuple[Clbit, bool] | expr.Expr
+        ),
         true_body: QuantumCircuit,
         false_body: QuantumCircuit,
         qubits: Sequence[QubitSpecifier],
@@ -7531,23 +7535,23 @@ class QuantumCircuit:
     @typing.overload
     def switch(
         self,
-        target: ClbitSpecifier | ClassicalRegister,
-        cases: None,
-        qubits: None,
-        clbits: None,
+        target: ClbitSpecifier | ClassicalRegister | expr.Expr,
+        cases: None = ...,
+        qubits: None = ...,
+        clbits: None = ...,
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> SwitchContext: ...
 
     @typing.overload
     def switch(
         self,
-        target: ClbitSpecifier | ClassicalRegister,
+        target: ClbitSpecifier | ClassicalRegister | expr.Expr,
         cases: Iterable[tuple[typing.Any, QuantumCircuit]],
         qubits: Sequence[QubitSpecifier],
         clbits: Sequence[ClbitSpecifier],
         *,
-        label: str | None,
+        label: str | None = ...,
     ) -> InstructionSet: ...
 
     def switch(self, target, cases=None, qubits=None, clbits=None, *, label=None):


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

This fixes some typing issues with the use of `@typing.overload` for control flow operations, which I discovered using pyright.  In particular, it is required to mark optional parameters with `= ...` in these overloads to avoid type errors; marking them as `= None` in the implementation is insufficient.

This also adds `expr.Expr` as an argument where it is accepted and updates docstrings accordingly.

See the individual commit messages for a bit more LLM-generated description.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: Claude Opus 5 (1M context)
- [x] Some submitted code was generated by: Claude Opus 5 (1M context)

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
