### PR TITLE
Bug-Fix: BarrierBeforeFinalMeasurements can reorder measurements sharing the same Clbit and change circuit semantics

### DIFF
--- a/crates/transpiler/src/passes/barrier_before_final_measurement.rs
+++ b/crates/transpiler/src/passes/barrier_before_final_measurement.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use hashbrown::HashSet;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
@@ -133,18 +134,15 @@ pub fn run_barrier_before_final_measurements(
     if final_ops.is_empty() {
         return Ok(());
     }
-    let final_packed_ops: Vec<PackedInstruction> = final_ops
+
+    let final_ops: HashSet<NodeIndex> = final_ops.into_iter().collect();
+    let ordered_final_ops: Vec<NodeIndex> = dag
+        .topological_op_nodes(false)
+        .filter(|node| final_ops.contains(node))
+        .collect();
+    let final_packed_ops: Vec<PackedInstruction> = ordered_final_ops
         .into_iter()
-        .filter_map(|node| match dag.dag().node_weight(node) {
-            Some(weight) => {
-                let NodeType::Operation(_) = weight else {
-                    return None;
-                };
-                let res = dag.remove_op_node(node);
-                Some(res)
-            }
-            None => None,
-        })
+        .map(|node| dag.remove_op_node(node))
         .collect();
     let qargs: Vec<Qubit> = (0..dag.num_qubits() as u32).map(Qubit).collect();
     dag.apply_operation_back(

--- a/crates/transpiler/src/passes/barrier_before_final_measurement.rs
+++ b/crates/transpiler/src/passes/barrier_before_final_measurement.rs
@@ -13,7 +13,9 @@
 use hashbrown::HashSet;
 use pyo3::prelude::*;
 use rayon::prelude::*;
+use rustworkx_core::petgraph::algo::toposort;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
+use rustworkx_core::petgraph::visit::NodeFiltered;
 
 use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, DAGError, NodeType};
@@ -136,10 +138,9 @@ pub fn run_barrier_before_final_measurements(
     }
 
     let final_ops: HashSet<NodeIndex> = final_ops.into_iter().collect();
-    let ordered_final_ops: Vec<NodeIndex> = dag
-        .topological_op_nodes(false)
-        .filter(|node| final_ops.contains(node))
-        .collect();
+    let final_ops_dag = NodeFiltered(dag.dag(), |node: NodeIndex| final_ops.contains(&node));
+    let ordered_final_ops = toposort(&final_ops_dag, None)
+        .unwrap_or_else(|_| panic!("DAG should prevent itself from becoming cyclic"));
     let final_packed_ops: Vec<PackedInstruction> = ordered_final_ops
         .into_iter()
         .map(|node| dag.remove_op_node(node))

--- a/releasenotes/notes/fix-barrier-before-final-measurements-shared-clbit-order-311665a9c22a9aa2.yaml
+++ b/releasenotes/notes/fix-barrier-before-final-measurements-shared-clbit-order-311665a9c22a9aa2.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.BarrierBeforeFinalMeasurements` where inserting the barrier could
+    reorder final measurements that write to the same clbit, quietly changing what the circuit
+    computes.
+
+    Say a circuit measures qubit 1 into clbit 0, and then measures qubit 0 into clbit 0. The second
+    measurement overwrites the first, so the circuit finishes with qubit 0's result in clbit 0. The
+    pass could put those two measurements back in the opposite order, leaving qubit 1's result there
+    instead. Nothing raised an error and the circuit it handed back was perfectly valid, so the only
+    hint that anything was wrong was that the answers came out different.
+
+    This reached :func:`.transpile` too, since the pass runs as part of the routing stage in the
+    preset pass managers. Final measurements are now always put back in the order they had in the
+    original circuit.
+    Fixed `#16851 <https://github.com/Qiskit/qiskit/issues/16851>`__.

--- a/test/python/transpiler/test_barrier_before_final_measurements.py
+++ b/test/python/transpiler/test_barrier_before_final_measurements.py
@@ -158,6 +158,91 @@ class TestBarrierBeforeFinalMeasurements(QiskitTestCase):
 
         self.assertEqual(result, circuit_to_dag(expected))
 
+    def test_two_qregs_to_a_single_clbit(self):
+        """Two measurements in different qregs writing the *same* clbit keep their order.
+
+        The clbit carries a write-after-write dependency, so swapping the two measurements
+        changes which value c0 ends up holding.  Regression test of gh-16851.
+                                          |
+        q0:-------[m]------     q0:-------|------[m]--
+                   |                      |       |
+        q1:--[X]---|--[m]--  -> q1:--[X]--|--[m]--|---
+                   |   |                  |   |   |
+         c:--------.---.---      c:-----------.---.---
+        """
+        qr = QuantumRegister(2, "q")
+        cr = ClassicalRegister(1, "c")
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.x(qr[1])
+        circuit.measure(qr[1], cr[0])
+        circuit.measure(qr[0], cr[0])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.x(qr[1])
+        expected.barrier(qr)
+        expected.measure(qr[1], cr[0])
+        expected.measure(qr[0], cr[0])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
+    def test_three_qregs_to_a_single_clbit(self):
+        """Three measurements writing the same clbit keep their order.
+
+        The measurement order q2, q0, q1 is deliberately not the qubit order, so an
+        implementation that reinserts the final operations qubit-by-qubit produces
+        q0, q1, q2 instead.  Regression test of gh-16851.
+        """
+        qr = QuantumRegister(3, "q")
+        cr = ClassicalRegister(1, "c")
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.measure(qr[2], cr[0])
+        circuit.measure(qr[0], cr[0])
+        circuit.measure(qr[1], cr[0])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.barrier(qr)
+        expected.measure(qr[2], cr[0])
+        expected.measure(qr[0], cr[0])
+        expected.measure(qr[1], cr[0])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
+    def test_shared_clbit_across_an_existing_barrier(self):
+        """Measurements writing the same clbit keep their order across an existing barrier.
+
+        q0:-------|--[m]--     q0:--|-------|--[m]--
+                  |   |                     |   |
+        q1:--[m]--|---|---  -> q1:--|--[m]--|---|---
+              |   |   |                 |   |   |
+         c:---.-------.---      c:------.-------.---
+        """
+        qr = QuantumRegister(2, "q")
+        cr = ClassicalRegister(1, "c")
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.measure(qr[1], cr[0])
+        circuit.barrier(qr)
+        circuit.measure(qr[0], cr[0])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.barrier(qr)
+        expected.measure(qr[1], cr[0])
+        expected.barrier(qr)
+        expected.measure(qr[0], cr[0])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
     def test_determinism(self):
         """Test that the pass modifies the DAG in a deterministic manner.
 


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
BarrierBeforeFinalMeasurements can reverse the order of final measurements that act on different qubits but write to the same Clbit.
This changes the observable semantics of the circuit.



The failing test in the issue #16851 after this fix showed the expected output:
```
Before counts: {'0': 1024}
After counts:  {'0': 1024}
```

 
Fixes #16851
### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
