### PR TITLE
Disable multiprocessing by default on Linux

### DIFF
--- a/qiskit/utils/parallel.py
+++ b/qiskit/utils/parallel.py
@@ -278,7 +278,9 @@ def parallel_map(task, values, task_args=(), task_kwargs=None, num_processes=Non
     multiprocessing with this function by either explicitly calling
     :func:`multiprocessing.set_start_method` to either ``"fork"`` or ``"forkserver"``,
     setting the environment variable ``QISKIT_PARALLEL=TRUE``, or setting
-    ``parallel_enabled`` in your user configuration file.
+    ``parallel`` in your user configuration file. You can find more details
+    on these configuration options here:
+    https://quantum.cloud.ibm.com/docs/en/guides/configure-qiskit-local
 
     Args:
         task (func): Function that is to be called for each value in ``values``.

--- a/qiskit/utils/parallel.py
+++ b/qiskit/utils/parallel.py
@@ -59,7 +59,6 @@ import functools
 import multiprocessing
 import os
 import platform
-import sys
 import warnings
 from concurrent.futures import ProcessPoolExecutor
 
@@ -88,9 +87,8 @@ def _physical_cpus_assuming_twofold_smt():
 def _parallel_default():
     # We default to False on `spawn`-based multiprocessing implementations, True on everything else.
     if (set_start_method := multiprocessing.get_start_method(allow_none=True)) is None:
-        # The method hasn't been explicitly set, but it would be badly behaved of us to set it for
-        # the user, so handle platform defaults.
-        return sys.platform not in ("darwin", "win32")
+        # The method hasn't been explicitly set, disable multiprocessing
+        return False
     return set_start_method in ("fork", "forkserver")
 
 
@@ -274,6 +272,13 @@ def parallel_map(task, values, task_args=(), task_kwargs=None, num_processes=Non
 
     This will parallelise the results if the number of ``values`` is greater than one and
     :func:`should_run_in_parallel` returns ``True``.  If not, it will run in serial.
+
+    By default multiprocessing will be disabled on all supported platforms when calling this
+    function due to issues mixing it with threading. You have to explicitly opt-in to use
+    multiprocessing with this function by either explicitly calling
+    :func:`multiprocessing.set_start_method` to either ``"fork"`` or ``"forkserver"``,
+    setting the environment variable ``QISKIT_PARALLEL=TRUE``, or setting
+    ``parallel_enabled`` in your user configuration file.
 
     Args:
         task (func): Function that is to be called for each value in ``values``.

--- a/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
+++ b/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
@@ -1,0 +1,26 @@
+---
+upgrade_misc:
+  - The use of :mod:`multiprocessing` with :func:`.parallel_map` to run Python
+    code in parrallel on Linux has been disabled by default. This also changes
+    the default multiprocessing behavior for functions that internally use
+    :func:`.parallel_map` such as :func:`.transpile` and :mod:`.PassManager.run`.
+    In previous releases on Linux systems it would default to running in parallel
+    however this has proven to be unreliable especially when mixing threading
+    with multiprocessing. This could result in deadlocks when downstream provider
+    packages, such as ``qiskit-ibm-runtime``, would use async Python. In general
+    the importance of leveraging multiprocessing for performance has significantly
+    diminished since Qiskit 1.0 as more of the library has enabled parallelism
+    via Rust and multithreading which was already mutually exclusive with
+    Python multiprocessing.
+
+    If you would continue to like to use multiprocessing with :func:`.parallel_map`
+    or other Qiskit functions using it internally you can explicitly opt-in to
+    enable multiprocessing. To explicitly enable multiprocessing on Linux (or any
+    platform) you can either set an explicit start method to ``"fork"`` or
+    ``"forkserver"`` using :func:`multiprocessing.set_start_method` (explcitily
+    setting ``"spawn"`` still disables multiprocessing by default because of the
+    extra overhead and complexities associated with it and you'll need to enable
+    multiprocessing with spawn using the other two options), set the environment
+    variable ``QISKIT_PARALLEL=TRUE``, or set ``parallel_enabled`` to ``True`` in
+    your `user configuration file <https://quantum.cloud.ibm.com/docs/en/guides/configure-qiskit-local#user-configuration-file>`__.
+

--- a/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
+++ b/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
@@ -21,6 +21,6 @@ upgrade_misc:
     setting ``"spawn"`` still disables multiprocessing by default because of the
     extra overhead and complexities associated with it and you'll need to enable
     multiprocessing with spawn using the other two options), set the environment
-    variable ``QISKIT_PARALLEL=TRUE``, or set ``parallel_enabled`` to ``True`` in
+    variable ``QISKIT_PARALLEL=TRUE``, or set ``parallel`` to ``True`` in
     your `user configuration file <https://quantum.cloud.ibm.com/docs/en/guides/configure-qiskit-local#user-configuration-file>`__.
 

--- a/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
+++ b/releasenotes/notes/disable-multiproc-by-default-linux-0075abdd0ac8a559.yaml
@@ -1,9 +1,9 @@
 ---
 upgrade_misc:
   - The use of :mod:`multiprocessing` with :func:`.parallel_map` to run Python
-    code in parrallel on Linux has been disabled by default. This also changes
+    code in parallel on Linux has been disabled by default. This also changes
     the default multiprocessing behavior for functions that internally use
-    :func:`.parallel_map` such as :func:`.transpile` and :mod:`.PassManager.run`.
+    :func:`.parallel_map` such as :func:`.transpile` and :meth:`.PassManager.run`.
     In previous releases on Linux systems it would default to running in parallel
     however this has proven to be unreliable especially when mixing threading
     with multiprocessing. This could result in deadlocks when downstream provider
@@ -13,11 +13,11 @@ upgrade_misc:
     via Rust and multithreading which was already mutually exclusive with
     Python multiprocessing.
 
-    If you would continue to like to use multiprocessing with :func:`.parallel_map`
+    If you would like to continue to use multiprocessing with :func:`.parallel_map`
     or other Qiskit functions using it internally you can explicitly opt-in to
     enable multiprocessing. To explicitly enable multiprocessing on Linux (or any
     platform) you can either set an explicit start method to ``"fork"`` or
-    ``"forkserver"`` using :func:`multiprocessing.set_start_method` (explcitily
+    ``"forkserver"`` using :func:`multiprocessing.set_start_method` (explicitly
     setting ``"spawn"`` still disables multiprocessing by default because of the
     extra overhead and complexities associated with it and you'll need to enable
     multiprocessing with spawn using the other two options), set the environment


### PR DESCRIPTION
This commit switches the default behavior of the parallel_map function to disable multiprocessing by default on all platforms. We have routinely faced issues on multiple platforms in the past around mixing multiprocessing and threading with Python. Historically these stem from the fork start method having numerous bugs in CPython and it's why macOS moved to using the spawn start method by default in Python 3.8. Spawn has it's own issues and that is why we disabled multiprocessing on that macOS at that time (and on windows which always defaulted to spawn). This was supposed be adressed in Python 3.14 with the use of forkserver by default on linux, but this is still causing issues when mixing threading in Python with multiprocessing. This was prompted by my attempts at testing code mixing async API interactions in qiskit-ibm-runtime with multiprocessing enabled transpilation of multiple circuits on Linux with Python 3.14 reliably resulted in deadlocks on the transpile call around the multiprocessing and it never would return.

When weighing these issues and also considering the evolution of Qiskit over the past few years and the broader of Rust (it is primarily a Rust library now) and Rust multithreading being used to enable performance via parallelism instead of Python multiprocessing the importance of multiprocessing has significantly decreased. Multiprocessing has now become more of a user challenge than the performance enabler it was in years past.

This change does not outright disable the possibility of using multiprocessing, it just means that the end user needs to explicitly opt-in to using it with the understanding that it is not simply a go-fast button that has nuance and issues around its usage.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
