### PR TITLE
Refactor `mcx.rs` functions in rust to use `synth_mcx_explicit`

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -332,18 +332,8 @@ pub fn synth_mcx_n_dirty_i15(
     relative_phase: bool,
     action_only: bool,
 ) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 0 {
-        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
-        circuit.x(0)?;
-        Ok(circuit)
-    } else if num_controls == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
-        circuit.cx(0, 1)?;
-        Ok(circuit)
-    } else if num_controls == 2 {
-        Ok(ccx())
-    } else if num_controls == 3 && !relative_phase {
-        Ok(c3x())
+    if num_controls <= 2 || (num_controls == 3 && !relative_phase) {
+        synth_mcx_explicit(num_controls)
     } else {
         let num_ancillas = num_controls - 2;
         let num_qubits = num_controls + 1 + num_ancillas;
@@ -417,20 +407,8 @@ pub fn synth_mcx_mcp_noaux(
     py: Python,
     num_controls: usize,
 ) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 0 {
-        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
-        circuit.x(0)?;
-        Ok(circuit)
-    } else if num_controls == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
-        circuit.cx(0, 1)?;
-        Ok(circuit)
-    } else if num_controls == 2 {
-        Ok(ccx())
-    } else if num_controls == 3 {
-        Ok(c3x())
-    } else if num_controls == 4 {
-        c4x()
+    if num_controls <= 4 {
+        synth_mcx_explicit(num_controls)
     } else {
         let num_qubits = (num_controls + 1) as u32;
         let target = num_controls as u32;
@@ -485,20 +463,8 @@ pub fn synth_mcx_mcp_noaux(
 /// 2. Iten et al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
 ///    [arXiv:1501.06911] (https://arxiv.org/abs/1501.06911).
 pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 0 {
-        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
-        circuit.x(0)?;
-        Ok(circuit)
-    } else if num_controls == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
-        circuit.cx(0, 1)?;
-        Ok(circuit)
-    } else if num_controls == 2 {
-        Ok(ccx())
-    } else if num_controls == 3 {
-        Ok(c3x())
-    } else if num_controls == 4 {
-        c4x()
+    if num_controls <= 4 {
+        synth_mcx_explicit(num_controls)
     } else {
         // k >= 5: 1-clean-ancilla construction (Barenco et al. 1995, Lemma 7.3)
         // decompose the gate into two halves and add 2 qubits, target and ancilla
@@ -581,16 +547,9 @@ pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, Circuit
 ///    relative-phase Toffoli gates with an application to multiple control Toffoli optimization",
 ///    [arXiv:1508.03273] (https://arxiv.org/pdf/1508.03273).
 pub fn synth_mcx_n_clean_m15(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 0 {
-        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
-        circuit.x(0)?;
-        Ok(circuit)
-    } else if num_controls == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
-        circuit.cx(0, 1)?;
-        Ok(circuit)
-    } else if num_controls == 2 {
-        Ok(ccx())
+    if num_controls <= 2 {
+        // should we use <-4 ? explicit cases are better then m15
+        synth_mcx_explicit(num_controls)
     } else {
         let num_qubits = 2 * num_controls - 1;
         let num_instructions = 2 * num_controls - 3;
@@ -1057,16 +1016,13 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
 /// 1. Huang and Palsberg, *Compiling Conditional Quantum Gates without Using Helper Qubits*, PLDI (2024),
 ///    https://dl.acm.org/doi/10.1145/3656436.
 pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
-    let n = num_controls + 1;
-
-    let mut circuit = CircuitData::with_capacity(n as u32, 0, 0, Param::Float(0.0))?;
-
-    // Handle small cases explicitly
-    if n == 1 {
-        circuit.x(0)?;
-    } else if n == 2 {
-        circuit.cx(0, 1)?;
+    // Handle small cases explicitly.
+    // should we use <=4? explicit cases are better than hp24
+    if num_controls <= 2 {
+        synth_mcx_explicit(num_controls).map_err(Into::into)
     } else {
+        let n: usize = num_controls + 1;
+        let mut circuit = CircuitData::with_capacity(n as u32, 0, 0, Param::Float(0.0))?;
         circuit.h(num_controls as u32)?;
 
         // The construction described in Fig.7 of the paper only works for even values of n.
@@ -1130,9 +1086,8 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
         }
 
         circuit.h(num_controls as u32)?;
+        Ok(circuit)
     }
-
-    Ok(circuit)
 }
 
 /// Synthesize a multi-controlled X gate with :math:`k` controls using the relation

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -263,22 +263,28 @@ impl CircuitDataForSynthesis for CircuitData {
 }
 
 /// Efficient synthesis for 4-controlled X-gate.
-pub fn c4x() -> Result<CircuitData, CircuitDataError> {
-    let mut circuit = CircuitData::with_capacity(5, 0, 0, Param::Float(0.0))?;
-    circuit.h(4)?;
-    circuit.cp(PI2, 3, 4)?;
-    circuit.h(4)?;
-    circuit.compose(&rc3x(), &[Qubit(0), Qubit(1), Qubit(2), Qubit(3)], &[])?;
-    circuit.h(4)?;
-    circuit.cp(-PI2, 3, 4)?;
-    circuit.h(4)?;
-    circuit.compose(
-        &rc3x().inverse()?,
-        &[Qubit(0), Qubit(1), Qubit(2), Qubit(3)],
-        &[],
-    )?;
-    circuit.compose(&c3sx(), &[Qubit(0), Qubit(1), Qubit(2), Qubit(4)], &[])?;
-    Ok(circuit)
+pub fn c4x() -> CircuitData {
+    let mut circuit = CircuitData::with_capacity(5, 0, 0, Param::Float(0.0)).unwrap();
+    circuit.h(4).unwrap();
+    circuit.cp(PI2, 3, 4).unwrap();
+    circuit.h(4).unwrap();
+    circuit
+        .compose(&rc3x(), &[Qubit(0), Qubit(1), Qubit(2), Qubit(3)], &[])
+        .unwrap();
+    circuit.h(4).unwrap();
+    circuit.cp(-PI2, 3, 4).unwrap();
+    circuit.h(4).unwrap();
+    circuit
+        .compose(
+            &rc3x().inverse().unwrap(),
+            &[Qubit(0), Qubit(1), Qubit(2), Qubit(3)],
+            &[],
+        )
+        .unwrap();
+    circuit
+        .compose(&c3sx(), &[Qubit(0), Qubit(1), Qubit(2), Qubit(4)], &[])
+        .unwrap();
+    circuit
 }
 
 /// Adds gates of the "action gadget" to the circuit
@@ -548,7 +554,8 @@ pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, Circuit
 ///    [arXiv:1508.03273] (https://arxiv.org/pdf/1508.03273).
 pub fn synth_mcx_n_clean_m15(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
     if num_controls <= 2 {
-        // should we use <-4 ? explicit cases are better then m15
+        // for k=3,4 this function produce circuits with less CX gates comparing to the explicit
+        // versions (although a bit larger) so we do not route them to synth_mcx_explicit
         synth_mcx_explicit(num_controls)
     } else {
         let num_qubits = 2 * num_controls - 1;
@@ -1017,7 +1024,7 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
 ///    https://dl.acm.org/doi/10.1145/3656436.
 pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     // Handle small cases explicitly.
-    // should we use <=4? explicit cases are better than hp24
+    // should we use <=4? explicit cases are better than hp24 (fewer CX gates)
     if num_controls <= 1 {
         synth_mcx_explicit(num_controls).map_err(Into::into)
     } else {
@@ -1164,7 +1171,7 @@ fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitData
         }
         2 => Ok(ccx()),
         3 => Ok(c3x()),
-        4 => c4x(),
+        4 => Ok(c4x()),
         _ => unreachable!(),
     }
 }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -10,10 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pyo3::prelude::*;
 use pyo3::types::PyAnyMethods;
 use pyo3::{PyResult, Python};
-use qiskit_circuit::circuit_data::{CircuitData, CircuitDataError, PyCircuitData};
+use qiskit_circuit::circuit_data::{CircuitData, CircuitDataError};
 use qiskit_circuit::operations::{
     Operation, OperationRef, Param, PyInstruction, PyOpKind, StandardGate, multiply_param,
 };
@@ -33,9 +32,8 @@ pub fn ccx() -> CircuitData {
 }
 
 /// Definition circuit for C3X.
-#[pyfunction]
-pub fn c3x() -> PyCircuitData {
-    StandardGate::C3X.definition(&[]).unwrap().into()
+pub fn c3x() -> CircuitData {
+    StandardGate::C3X.definition(&[]).unwrap()
 }
 
 /// Definition circuit for RCCX.
@@ -265,8 +263,7 @@ impl CircuitDataForSynthesis for CircuitData {
 }
 
 /// Efficient synthesis for 4-controlled X-gate.
-#[pyfunction]
-pub fn c4x() -> Result<PyCircuitData, CircuitDataError> {
+pub fn c4x() -> Result<CircuitData, CircuitDataError> {
     let mut circuit = CircuitData::with_capacity(5, 0, 0, Param::Float(0.0))?;
     circuit.h(4)?;
     circuit.cp(PI2, 3, 4)?;
@@ -281,7 +278,7 @@ pub fn c4x() -> Result<PyCircuitData, CircuitDataError> {
         &[],
     )?;
     circuit.compose(&c3sx(), &[Qubit(0), Qubit(1), Qubit(2), Qubit(4)], &[])?;
-    Ok(circuit.into())
+    Ok(circuit)
 }
 
 /// Adds gates of the "action gadget" to the circuit
@@ -346,7 +343,7 @@ pub fn synth_mcx_n_dirty_i15(
     } else if num_controls == 2 {
         Ok(ccx())
     } else if num_controls == 3 && !relative_phase {
-        Ok(c3x().into())
+        Ok(c3x())
     } else {
         let num_ancillas = num_controls - 2;
         let num_qubits = num_controls + 1 + num_ancillas;
@@ -431,9 +428,9 @@ pub fn synth_mcx_mcp_noaux(
     } else if num_controls == 2 {
         Ok(ccx())
     } else if num_controls == 3 {
-        Ok(c3x().into())
+        Ok(c3x())
     } else if num_controls == 4 {
-        c4x().map(Into::into)
+        c4x()
     } else {
         let num_qubits = (num_controls + 1) as u32;
         let target = num_controls as u32;
@@ -499,9 +496,9 @@ pub fn synth_mcx_1_clean_b95(num_controls: usize) -> Result<CircuitData, Circuit
     } else if num_controls == 2 {
         Ok(ccx())
     } else if num_controls == 3 {
-        Ok(c3x().into())
+        Ok(c3x())
     } else if num_controls == 4 {
-        Ok(c4x()?.into())
+        c4x()
     } else {
         // k >= 5: 1-clean-ancilla construction (Barenco et al. 1995, Lemma 7.3)
         // decompose the gate into two halves and add 2 qubits, target and ancilla
@@ -1211,8 +1208,8 @@ fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitData
             Ok(circuit)
         }
         2 => Ok(ccx()),
-        3 => Ok(c3x().into()),
-        4 => Ok(c4x()?.into()),
+        3 => Ok(c3x()),
+        4 => c4x(),
         _ => unreachable!(),
     }
 }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1018,7 +1018,7 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
 pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     // Handle small cases explicitly.
     // should we use <=4? explicit cases are better than hp24
-    if num_controls <= 2 {
+    if num_controls <= 1 {
         synth_mcx_explicit(num_controls).map_err(Into::into)
     } else {
         let n: usize = num_controls + 1;

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -1153,7 +1153,7 @@ pub fn synth_mcx_noaux_sp22(num_ctrl_qubits: usize) -> Result<CircuitData, Circu
 /// # Returns
 ///
 /// The synthesized quantum circuit.
-fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
+pub fn synth_mcx_explicit(num_ctrl_qubits: usize) -> Result<CircuitData, CircuitDataError> {
     assert!(
         num_ctrl_qubits <= 4,
         "synth_mcx_explicit called with num_ctrl_qubits = {num_ctrl_qubits}, expected <= 4"

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -78,7 +78,7 @@ fn py_c3x() -> PyResult<PyCircuitData> {
 #[pyfunction]
 #[pyo3(name = "c4x")]
 fn py_c4x() -> PyResult<PyCircuitData> {
-    Ok(c4x()?.into())
+    Ok(c4x().into())
 }
 
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -69,9 +69,21 @@ fn py_synth_mcx_noaux_sp22(num_controls: usize) -> PyResult<PyCircuitData> {
     Ok(synth_mcx_noaux_sp22(num_controls)?.into())
 }
 
+#[pyfunction]
+#[pyo3(name = "c3x")]
+fn py_c3x() -> PyResult<PyCircuitData> {
+    Ok(c3x().into())
+}
+
+#[pyfunction]
+#[pyo3(name = "c4x")]
+fn py_c4x() -> PyResult<PyCircuitData> {
+    Ok(c4x()?.into())
+}
+
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(c3x, m)?)?;
-    m.add_function(wrap_pyfunction!(c4x, m)?)?;
+    m.add_function(wrap_pyfunction!(py_c3x, m)?)?;
+    m.add_function(wrap_pyfunction!(py_c4x, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_dirty_i15, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;

--- a/crates/synthesis/src/multi_controlled/mod.rs
+++ b/crates/synthesis/src/multi_controlled/mod.rs
@@ -11,8 +11,8 @@
 // that they have been altered from the originals.
 
 use mcx::{
-    c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_n_clean_m15,
-    synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_sp22,
+    c3x, c4x, synth_mcp_noaux_sp22, synth_mcx_1_clean_b95, synth_mcx_explicit,
+    synth_mcx_n_clean_m15, synth_mcx_n_dirty_i15, synth_mcx_noaux_hp24, synth_mcx_noaux_sp22,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -81,9 +81,16 @@ fn py_c4x() -> PyResult<PyCircuitData> {
     Ok(c4x().into())
 }
 
+#[pyfunction]
+#[pyo3(name = "synth_mcx_explicit")]
+fn py_synth_mcx_explicit(num_controls: usize) -> PyResult<PyCircuitData> {
+    Ok(synth_mcx_explicit(num_controls)?.into())
+}
+
 pub fn multi_controlled(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_c3x, m)?)?;
     m.add_function(wrap_pyfunction!(py_c4x, m)?)?;
+    m.add_function(wrap_pyfunction!(py_synth_mcx_explicit, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_n_dirty_i15, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_noaux_hp24, m)?)?;
     m.add_function(wrap_pyfunction!(py_synth_mcx_1_clean_b95, m)?)?;

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -21,6 +21,7 @@ from qiskit.circuit.library import HGate, CU1Gate
 from qiskit._accelerate.synthesis.multi_controlled import (
     c3x as c3x_rs,
     c4x as c4x_rs,
+    synth_mcx_explicit as synth_mcx_explicit_rs,
     synth_mcx_n_dirty_i15 as synth_mcx_n_dirty_i15_rs,
     synth_mcx_noaux_hp24 as synth_mcx_noaux_hp24_rs,
     synth_mcx_n_clean_m15 as synth_mcx_n_clean_m15_rs,
@@ -76,26 +77,8 @@ def synth_mcx_n_dirty_i15(
 
 
 def _synth_mcx_special_cases(num_ctrl_qubits: int) -> QuantumCircuit:
-    """Internal function that produces default MCX circuits when num_ctrl_qubits is 0, 1, or 2."""
-    if num_ctrl_qubits == 0:
-        qc = QuantumCircuit(1)
-        qc.x(0)
-        return qc
-
-    elif num_ctrl_qubits == 1:
-        qc = QuantumCircuit(2)
-        qc.cx(0, 1)
-        return qc
-
-    elif num_ctrl_qubits == 2:
-        qc = QuantumCircuit(3)
-        qc.ccx(0, 1, 2)
-        return qc
-
-    else:
-        raise QiskitError(
-            "_synth_mcx_special_cases should be called with only 0, 1, or 2 controls."
-        )
+    """Internal function that produces default MCX circuits when num_ctrl_qubits is <=4."""
+    return QuantumCircuit._from_circuit_data(synth_mcx_explicit_rs(num_ctrl_qubits))
 
 
 def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:


### PR DESCRIPTION
1. `c3x()` and `c4x()` are now pure Rust and return `CircuitData` directly. 
2. `synth_mcx_*` functions in `mcx.rs` now use `synth_mcx_explicit` instead of replicating the explicit cases for k<=4. 
This is pure refactoring, no logic had changed. 

Beyond refactoring:
Three functions apply explicit gates only for smaller k. I analyzed the result circuits against the explicit and compared `num_qubits`, cx count and the output unitary. 

(1) `synth_mcx_noaux_hp24` applies explicit only `k<=1`, however it seems explicit are better for `k<=4`, so we can consider changing it:
```
=== synth_mcx_noaux_hp24 ===
   k | CX (fn) | CX (exp) | qubits (fn) | qubits (exp) | equivalent
  ---+---------+----------+-------------+--------------+--------
   0 |       0 |        0 |           1 |            1 | OK
   1 |       1 |        1 |           2 |            2 | OK
   2 |      10 |        6 |           3 |            3 | OK
   3 |      32 |       14 |           4 |            4 | OK
   4 |      52 |       36 |           5 |            5 | OK
```

(2) `synth_mcx_n_clean_m15` applies them for `k<=2` 
In this case the algorithm produce larger circuits but with less CX gates, so we can leave it as is.
```
  k | CX (fn) | CX (exp) | qubits (fn) | qubits (exp) | equivalent
  ---+---------+----------+-------------+--------------+--------
   0 |       0 |        0 |           1 |            1 | OK
   1 |       1 |        1 |           2 |            2 | OK
   2 |       6 |        6 |           3 |            3 | OK
   3 |      12 |       14 |           5 |            4 | OK
   4 |      18 |       36 |           7 |            5 | OK

```

(3)`synth_mcx_n_dirty_i15` use
`if num_controls <= 2 || (num_controls == 3 && !relative_phase)`. This should stay as is.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by:
- [ ] Some submitted code was generated by:

