### PR TITLE
QPY: keep anonymous bit identity across subcircuits (#15482)

### DIFF
--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -400,6 +400,13 @@ macro_rules! create_bit_object {
                     BitInfo::Anonymous { .. } => None,
                 }
             }
+            pub fn get_anonymous_uid(&self) -> Option<u64> {
+                match &self.0 {
+                    BitInfo::Owned{ .. } => None,
+                    BitInfo::Anonymous {uid, ..} => Some(*uid)
+                }
+
+            }
 
             /// Create `count` new anonymous bits, returned as an iterator.
             ///

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -142,7 +142,7 @@ fn deserialize_standard_instruction(
 
 pub fn unpack_condition(
     condition_pack: &formats::ConditionPack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<Option<Condition>, QpyError> {
     match &condition_pack.data {
         ConditionData::None => Ok(None),
@@ -219,7 +219,7 @@ fn recognize_instruction_type(
 type InstructionBits = (Interned<[Qubit]>, Interned<[Clbit]>);
 fn get_instruction_bits(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<InstructionBits, QpyError> {
     let mut qubit_indices = Vec::new();
     let mut clbit_indices = Vec::new();
@@ -257,7 +257,7 @@ fn get_instruction_bits(
 // necessarily the "usual" instruction parameters modeled in rust using Operations::Param
 pub fn get_instruction_values(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
     endian: ValueEndian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     let inst_params: Vec<GenericValue> = instruction
@@ -273,7 +273,7 @@ pub fn get_instruction_values(
 // converts a list of generic values to the params format expected for a PackedInstruction params
 pub fn instruction_values_to_params(
     values: Vec<GenericValue>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<Option<Box<Parameters<Block>>>, QpyError> {
     // currently QPY has no dedicated representation for blocks, only for py circuit objects
     // so we use the following heuristic: if all the NON-NULL elements of `values` are circuits
@@ -333,7 +333,7 @@ pub fn instruction_values_to_params(
 
 fn unpack_annotations(
     packed_annotations: &Option<formats::InstructionsAnnotationPack>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<Vec<Py<PyAny>>, QpyError> {
     if let Some(annotations_vec) = packed_annotations {
         annotations_vec
@@ -354,7 +354,7 @@ fn unpack_annotations(
 pub fn unpack_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
     custom_instructions: &HashMap<String, CustomCircuitInstructionData>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<PackedInstruction, QpyError> {
     let label = (!instruction.label.is_empty()).then(|| Box::new(instruction.label.clone()));
     let instruction_type = recognize_instruction_type(instruction, custom_instructions);
@@ -412,7 +412,7 @@ pub fn unpack_instruction(
 
 fn unpack_standard_gate(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let op = if let Some(gate) =
         standard_gate_from_gate_class_name(instruction.gate_class_name.as_str())
@@ -431,7 +431,7 @@ fn unpack_standard_gate(
 
 fn unpack_standard_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let op = if let Some(std_instruction) = deserialize_standard_instruction(instruction) {
         // TODO: can we avoid this call? {
@@ -476,7 +476,7 @@ fn unpack_store(
 
 fn unpack_pauli_product_measurement(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 3 {
         return Err(QpyError::InvalidParameter(
@@ -527,7 +527,7 @@ fn unpack_pauli_product_measurement(
 
 fn unpack_pauli_product_rotation(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 3 {
         return Err(QpyError::InvalidParameter(
@@ -561,7 +561,7 @@ fn unpack_pauli_product_rotation(
 
 fn unpack_unitary(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let GenericValue::NumpyObject(bytes) = unpack_generic_value(
         &instruction.params[0],
@@ -600,7 +600,7 @@ fn unpack_unitary(
 
 fn unpack_control_flow(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let mut param_values: Vec<GenericValue> = Vec::new(); // Params for control structures hold the control flow blocks
     // Convert Python class names (e.g., "IfElseOp") to snake_case (e.g., "if_else")
@@ -947,7 +947,7 @@ fn unpack_transpile_layout<'py>(
 
 fn read_custom_instructions(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<HashMap<String, CustomCircuitInstructionData>, QpyError> {
     let mut result = HashMap::new();
     for operation in &packed_circuit.custom_instructions.custom_instructions {
@@ -973,6 +973,8 @@ fn read_custom_instructions(
                     qpy_data.use_symengine,
                     qpy_data.annotation_handler.child()?,
                     qpy_data.caller,
+                    qpy_data.qubit_uid_table,
+                    qpy_data.clbit_uid_table,
                 )?
                 .into();
                 let py_circuit = qpy_data.caller.attach(
@@ -1003,7 +1005,7 @@ fn read_custom_instructions(
 
 fn add_standalone_vars(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(), QpyError> {
     let mut index: u16 = 0;
     for packed_var in &packed_circuit.standalone_vars {
@@ -1063,7 +1065,7 @@ fn add_standalone_vars(
 
 fn add_registers_and_bits(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(), QpyError> {
     let num_qubits = packed_circuit.header.num_qubits as usize;
     let num_clbits = packed_circuit.header.num_clbits as usize;
@@ -1187,21 +1189,64 @@ fn add_registers_and_bits(
         }
     }
     // First pass is done. Now add Anonymous bits that are not part of any register
-    let final_qubit_list: Vec<ShareableQubit> = qubits
-        .iter()
-        .map(|element| match element {
-            Some(qubit) => qubit.clone(),
-            None => ShareableQubit::new_anonymous(),
-        })
-        .collect();
-    let final_clbit_list: Vec<ShareableClbit> = clbits
-        .iter()
-        .map(|element| match element {
-            Some(clbit) => clbit.clone(),
-            None => ShareableClbit::new_anonymous(),
-        })
-        .collect();
-
+    let final_qubit_list: Vec<ShareableQubit> = if qpy_data.version >= 18 {
+        qubits
+            .iter()
+            .zip(packed_circuit.header.qubits_info.iter())
+            .map(|(element, info)| match element {
+                Some(qubit) => Ok(qubit.clone()), // registered
+                None => match info {
+                    // anonymus
+                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_data
+                        .qubit_uid_table
+                        .entry(*uid)
+                        .or_insert_with(ShareableQubit::new_anonymous)
+                        .clone()),
+                    formats::BitInfoPack::Registered => Err(QpyError::InvalidRegister(
+                        "Bit info marks index as registered, but it has no owning register"
+                            .to_owned(),
+                    )),
+                },
+            })
+            .collect::<Result<Vec<_>, QpyError>>()?
+    } else {
+        qubits
+            .iter()
+            .map(|element| match element {
+                Some(qubit) => qubit.clone(),
+                None => ShareableQubit::new_anonymous(),
+            })
+            .collect()
+    };
+    let final_clbit_list: Vec<ShareableClbit> = if qpy_data.version >= 18 {
+        clbits
+            .iter()
+            .zip(packed_circuit.header.clbits_info.iter())
+            .map(|(element, info)| match element {
+                Some(clbit) => Ok(clbit.clone()), // registered
+                None => match info {
+                    // anonymus
+                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_data
+                        .clbit_uid_table
+                        .entry(*uid)
+                        .or_insert_with(ShareableClbit::new_anonymous)
+                        .clone()),
+                    formats::BitInfoPack::Registered => Err(QpyError::InvalidRegister(
+                        "Bit info marks index as registered, but it has no owning register"
+                            .to_owned(),
+                    )),
+                },
+            })
+            .collect::<Result<Vec<_>, QpyError>>()?
+    } else {
+        clbits
+            .iter()
+            .map(|element| match element {
+                Some(clbit) => clbit.clone(),
+                None => ShareableClbit::new_anonymous(),
+            })
+            .collect()
+    };
     // We collected owning registers to qregs, cregs and added all remaining bits and can now deal with the non-standalone registers
     for raw_register in non_standalone_registers {
         match raw_register {
@@ -1299,12 +1344,14 @@ fn add_registers_and_bits(
     Ok(())
 }
 
-pub(crate) fn unpack_circuit(
+pub(crate) fn unpack_circuit<'u>(
     packed_circuit: &QPYCircuit,
     version: u8,
     use_symengine: bool,
     annotation_handler: AnnotationHandler,
     caller: QpyCaller,
+    qubit_uid_table: &'u mut HashMap<u64, ShareableQubit>,
+    clbit_uid_table: &'u mut HashMap<u64, ShareableClbit>,
 ) -> Result<CircuitData, QpyError> {
     let instruction_capacity = packed_circuit.instructions.len();
     // create an empty circuit; we'll fill data as we go along
@@ -1335,6 +1382,8 @@ pub(crate) fn unpack_circuit(
             })
             .unwrap_or_default(),
         annotation_handler,
+        qubit_uid_table,
+        clbit_uid_table,
     };
     if let Some(annotation_headers) = &packed_circuit.annotation_headers {
         let annotation_deserializers_data: Vec<(String, Bytes)> = annotation_headers
@@ -1372,7 +1421,7 @@ pub fn wrap_conditional_gate(
     qubits: Interned<[Qubit]>,
     clbits: Interned<[Clbit]>,
     params: Option<Box<Parameters<Block>>>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> PyResult<(PackedOperation, Option<Box<Parameters<Block>>>)> {
     use qiskit_circuit::circuit_data::CircuitData;
     use qiskit_circuit::operations::Param;

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -62,6 +62,7 @@ use crate::py_methods::{
     STORE_INSTR_CLASS_NAME, UNITARY_GATE_CLASS_NAME, deserialize_pauli_evolution_gate,
     py_convert_from_generic_value, unpack_custom_instruction, unpack_py_instruction,
 };
+use crate::value::QPYGlobalData;
 use crate::value::{
     BitType, CircuitInstructionType, ExpressionType, ExpressionVarDeclaration, GenericValue,
     ParamRegisterValue, QPYReadData, QpyCaller, RegisterType, ValueEndian, ValueType,
@@ -142,12 +143,14 @@ fn deserialize_standard_instruction(
 
 pub fn unpack_condition(
     condition_pack: &formats::ConditionPack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<Option<Condition>, QpyError> {
     match &condition_pack.data {
         ConditionData::None => Ok(None),
         ConditionData::Expression(exp_pack) => {
-            let exp_value = unpack_generic_value(exp_pack, qpy_data, ValueEndian::Big)?;
+            let exp_value =
+                unpack_generic_value(exp_pack, qpy_data, qpy_global_data, ValueEndian::Big)?;
             match exp_value {
                 GenericValue::Expression(exp) => Ok(Some(Condition::Expr(exp.clone()))),
                 _ => Err(QpyError::InvalidExpression(
@@ -219,7 +222,7 @@ fn recognize_instruction_type(
 type InstructionBits = (Interned<[Qubit]>, Interned<[Clbit]>);
 fn get_instruction_bits(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<InstructionBits, QpyError> {
     let mut qubit_indices = Vec::new();
     let mut clbit_indices = Vec::new();
@@ -257,14 +260,15 @@ fn get_instruction_bits(
 // necessarily the "usual" instruction parameters modeled in rust using Operations::Param
 pub fn get_instruction_values(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
     endian: ValueEndian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     let inst_params: Vec<GenericValue> = instruction
         .params
         .iter()
         .map(|packed_param: &formats::GenericDataPack| {
-            unpack_generic_value(packed_param, qpy_data, endian)
+            unpack_generic_value(packed_param, qpy_data, qpy_global_data, endian)
         })
         .collect::<Result<_, QpyError>>()?;
     Ok(inst_params)
@@ -273,7 +277,7 @@ pub fn get_instruction_values(
 // converts a list of generic values to the params format expected for a PackedInstruction params
 pub fn instruction_values_to_params(
     values: Vec<GenericValue>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<Option<Box<Parameters<Block>>>, QpyError> {
     // currently QPY has no dedicated representation for blocks, only for py circuit objects
     // so we use the following heuristic: if all the NON-NULL elements of `values` are circuits
@@ -333,7 +337,7 @@ pub fn instruction_values_to_params(
 
 fn unpack_annotations(
     packed_annotations: &Option<formats::InstructionsAnnotationPack>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<Vec<Py<PyAny>>, QpyError> {
     if let Some(annotations_vec) = packed_annotations {
         annotations_vec
@@ -354,22 +358,29 @@ fn unpack_annotations(
 pub fn unpack_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
     custom_instructions: &HashMap<String, CustomCircuitInstructionData>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<PackedInstruction, QpyError> {
     let label = (!instruction.label.is_empty()).then(|| Box::new(instruction.label.clone()));
     let instruction_type = recognize_instruction_type(instruction, custom_instructions);
     let (op, parameter_values) = match instruction_type {
-        InstructionType::StandardGate => unpack_standard_gate(instruction, qpy_data)?,
-        InstructionType::StandardInstruction => unpack_standard_instruction(instruction, qpy_data)?,
+        InstructionType::StandardGate => {
+            unpack_standard_gate(instruction, qpy_data, qpy_global_data)?
+        }
+        InstructionType::StandardInstruction => {
+            unpack_standard_instruction(instruction, qpy_data, qpy_global_data)?
+        }
         InstructionType::PauliProductMeasurement => {
-            unpack_pauli_product_measurement(instruction, qpy_data)?
+            unpack_pauli_product_measurement(instruction, qpy_data, qpy_global_data)?
         }
         InstructionType::PauliProductRotation => {
-            unpack_pauli_product_rotation(instruction, qpy_data)?
+            unpack_pauli_product_rotation(instruction, qpy_data, qpy_global_data)?
         }
-        InstructionType::Unitary => unpack_unitary(instruction, qpy_data)?,
-        InstructionType::ControlFlow => unpack_control_flow(instruction, qpy_data)?,
-        InstructionType::Store => unpack_store(instruction, qpy_data)?,
+        InstructionType::Unitary => unpack_unitary(instruction, qpy_data, qpy_global_data)?,
+        InstructionType::ControlFlow => {
+            unpack_control_flow(instruction, qpy_data, qpy_global_data)?
+        }
+        InstructionType::Store => unpack_store(instruction, qpy_data, qpy_global_data)?,
         InstructionType::Custom => {
             QpyCaller::Python.attach("Python custom instruction unpacking", |py| {
                 unpack_custom_instruction(
@@ -377,21 +388,23 @@ pub fn unpack_instruction(
                     instruction,
                     label.as_deref(),
                     qpy_data,
+                    qpy_global_data,
                     custom_instructions,
                 )
             })?
         }
-        InstructionType::Python => QpyCaller::Python
-            .attach("Python instruction unpacking", |py| {
-                unpack_py_instruction(py, instruction, label.as_deref(), qpy_data)
-            })?,
+        InstructionType::Python => {
+            QpyCaller::Python.attach("Python instruction unpacking", |py| {
+                unpack_py_instruction(py, instruction, label.as_deref(), qpy_data, qpy_global_data)
+            })?
+        }
     };
     let (qubits, clbits) = get_instruction_bits(instruction, qpy_data)?;
     let params = instruction_values_to_params(parameter_values, qpy_data)?;
 
     // Check if this is a non-control-flow instruction with a condition
     // If so, wrap it in an IfElseOp (for backwards compatibility with old QPY versions)
-    let condition = unpack_condition(&instruction.condition, qpy_data)?;
+    let condition = unpack_condition(&instruction.condition, qpy_data, qpy_global_data)?;
     let (op, params) = match condition {
         Some(cond) if !matches!(instruction_type, InstructionType::ControlFlow) => {
             wrap_conditional_gate(instruction, op, cond, qubits, clbits, params, qpy_data)?
@@ -412,7 +425,8 @@ pub fn unpack_instruction(
 
 fn unpack_standard_gate(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let op = if let Some(gate) =
         standard_gate_from_gate_class_name(instruction.gate_class_name.as_str())
@@ -424,14 +438,19 @@ fn unpack_standard_gate(
             instruction.gate_class_name
         )));
     };
-    let param_values =
-        get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
+    let param_values = get_instruction_values(
+        instruction,
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::LittleForV17AndBelow,
+    )?;
     Ok((op, param_values))
 }
 
 fn unpack_standard_instruction(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let op = if let Some(std_instruction) = deserialize_standard_instruction(instruction) {
         // TODO: can we avoid this call? {
@@ -442,29 +461,42 @@ fn unpack_standard_instruction(
             instruction.gate_class_name
         )));
     };
-    let param_values =
-        get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
+    let param_values = get_instruction_values(
+        instruction,
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::LittleForV17AndBelow,
+    )?;
     Ok((op, param_values))
 }
 
 fn unpack_store(
     instruction: &formats::CircuitInstructionV2Pack,
     qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 2 {
         return Err(QpyError::InvalidParameter(
             "Store operations should have exactly 2 parameters".to_string(),
         ));
     }
-    let GenericValue::Expression(lvalue) =
-        unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?
+    let GenericValue::Expression(lvalue) = unpack_generic_value(
+        &instruction.params[0],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?
     else {
         return Err(QpyError::InvalidExpression(
             "could not determine expression for instruction's lvalue".to_string(),
         ));
     };
-    let GenericValue::Expression(rvalue) =
-        unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?
+    let GenericValue::Expression(rvalue) = unpack_generic_value(
+        &instruction.params[1],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?
     else {
         return Err(QpyError::InvalidExpression(
             "could not determine expression for store instruction's rvalue".to_string(),
@@ -476,14 +508,20 @@ fn unpack_store(
 
 fn unpack_pauli_product_measurement(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 3 {
         return Err(QpyError::InvalidParameter(
             "Pauli Product Measurement should have exactly 3 parameters".to_string(),
         ));
     }
-    let z_values = unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?;
+    let z_values = unpack_generic_value(
+        &instruction.params[0],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?;
     let z: Vec<bool> = z_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(format!(
             "Pauli product measurement z parameter should be a boolean or integer vector, but got {:?}",
@@ -491,14 +529,24 @@ fn unpack_pauli_product_measurement(
         ))
     })?;
 
-    let x_values = unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?;
+    let x_values = unpack_generic_value(
+        &instruction.params[1],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?;
     let x: Vec<bool> = x_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(format!(
             "Pauli product measurement x parameter should be a boolean or integer vector, but got {:?}",
             x_values
         ))
     })?;
-    let neg_value = unpack_generic_value(&instruction.params[2], qpy_data, ValueEndian::Big)?;
+    let neg_value = unpack_generic_value(
+        &instruction.params[2],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?;
     let neg = match neg_value {
         GenericValue::NumpyObject(bytes) => {
             let npy = NpyFile::new(Cursor::new(&bytes.0))?;
@@ -527,20 +575,31 @@ fn unpack_pauli_product_measurement(
 
 fn unpack_pauli_product_rotation(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     if instruction.params.len() != 3 {
         return Err(QpyError::InvalidParameter(
             "No angle for pauli product rotation".to_string(),
         ));
     }
-    let z_values = unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?;
+    let z_values = unpack_generic_value(
+        &instruction.params[0],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?;
     let z = z_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(
             "Pauli product rotation z parameter should be a boolean vector".to_string(),
         )
     })?;
-    let x_values = unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?;
+    let x_values = unpack_generic_value(
+        &instruction.params[1],
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::Big,
+    )?;
     let x = x_values.to_boolean_vec().ok_or_else(|| {
         QpyError::InvalidParameter(
             "Pauli product rotation x parameter should be a boolean vector".to_string(),
@@ -549,6 +608,7 @@ fn unpack_pauli_product_rotation(
     let angle_value = unpack_generic_value(
         &instruction.params[2],
         qpy_data,
+        qpy_global_data,
         ValueEndian::LittleForV17AndBelow,
     )?;
     let angle = generic_value_to_param(&angle_value)?;
@@ -561,11 +621,13 @@ fn unpack_pauli_product_rotation(
 
 fn unpack_unitary(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let GenericValue::NumpyObject(bytes) = unpack_generic_value(
         &instruction.params[0],
         qpy_data,
+        qpy_global_data,
         ValueEndian::LittleForV17AndBelow,
     )?
     else {
@@ -600,7 +662,8 @@ fn unpack_unitary(
 
 fn unpack_control_flow(
     instruction: &formats::CircuitInstructionV2Pack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let mut param_values: Vec<GenericValue> = Vec::new(); // Params for control structures hold the control flow blocks
     // Convert Python class names (e.g., "IfElseOp") to snake_case (e.g., "if_else")
@@ -627,11 +690,16 @@ fn unpack_control_flow(
                 .iter()
                 .skip(1)
                 .map(|param| {
-                    unpack_generic_value(param, qpy_data, ValueEndian::LittleForV17AndBelow)
+                    unpack_generic_value(
+                        param,
+                        qpy_data,
+                        qpy_global_data,
+                        ValueEndian::LittleForV17AndBelow,
+                    )
                 })
                 .collect::<Result<_, QpyError>>()?;
             let duration_value = if let Some(duration_pack) = instruction.params.first() {
-                unpack_duration_value(duration_pack, qpy_data)?
+                unpack_duration_value(duration_pack, qpy_data, qpy_global_data)?
             } else {
                 return Err(QpyError::MissingData(
                     "Box control flow instruction missing parameters".to_string(),
@@ -652,7 +720,7 @@ fn unpack_control_flow(
         ControlFlowType::ContinueLoop => ControlFlow::ContinueLoop,
         ControlFlowType::ForLoop => {
             let mut instruction_values =
-                get_instruction_values(instruction, qpy_data, ValueEndian::Big)?;
+                get_instruction_values(instruction, qpy_data, qpy_global_data, ValueEndian::Big)?;
             param_values = instruction_values.split_off(2);
             let [GenericValue::CircuitData(circuit)] = param_values.as_slice() else {
                 return Err(QpyError::DeserializationError(
@@ -706,20 +774,22 @@ fn unpack_control_flow(
             }
         }
         ControlFlowType::IfElse => {
-            let condition = unpack_condition(&instruction.condition, qpy_data)?
+            let condition = unpack_condition(&instruction.condition, qpy_data, qpy_global_data)?
                 .ok_or_else(|| QpyError::MissingData("if else condition is missing".to_string()))?;
-            param_values = get_instruction_values(instruction, qpy_data, ValueEndian::Big)?;
+            param_values =
+                get_instruction_values(instruction, qpy_data, qpy_global_data, ValueEndian::Big)?;
             ControlFlow::IfElse { condition }
         }
         ControlFlowType::WhileLoop => {
-            let condition = unpack_condition(&instruction.condition, qpy_data)?
+            let condition = unpack_condition(&instruction.condition, qpy_data, qpy_global_data)?
                 .ok_or_else(|| QpyError::MissingData("if else condition is missing".to_string()))?;
-            param_values = get_instruction_values(instruction, qpy_data, ValueEndian::Big)?;
+            param_values =
+                get_instruction_values(instruction, qpy_data, qpy_global_data, ValueEndian::Big)?;
             ControlFlow::While { condition }
         }
         ControlFlowType::SwitchCase => {
             let mut instruction_values =
-                get_instruction_values(instruction, qpy_data, ValueEndian::Big)?;
+                get_instruction_values(instruction, qpy_data, qpy_global_data, ValueEndian::Big)?;
             let (target_value, case_label_list) = if instruction_values.len() < 3 {
                 // we follow the python way of storing switch params
                 // the first param is the target, the next param is the cases specifier
@@ -947,7 +1017,8 @@ fn unpack_transpile_layout<'py>(
 
 fn read_custom_instructions(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<HashMap<String, CustomCircuitInstructionData>, QpyError> {
     let mut result = HashMap::new();
     for operation in &packed_circuit.custom_instructions.custom_instructions {
@@ -960,6 +1031,7 @@ fn read_custom_instructions(
                             py,
                             &operation.data,
                             qpy_data,
+                            qpy_global_data,
                         )?))
                     })
             } else {
@@ -973,8 +1045,7 @@ fn read_custom_instructions(
                     qpy_data.use_symengine,
                     qpy_data.annotation_handler.child()?,
                     qpy_data.caller,
-                    qpy_data.qubit_uid_table,
-                    qpy_data.clbit_uid_table,
+                    qpy_global_data,
                 )?
                 .into();
                 let py_circuit = qpy_data.caller.attach(
@@ -1005,7 +1076,7 @@ fn read_custom_instructions(
 
 fn add_standalone_vars(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<(), QpyError> {
     let mut index: u16 = 0;
     for packed_var in &packed_circuit.standalone_vars {
@@ -1065,7 +1136,8 @@ fn add_standalone_vars(
 
 fn add_registers_and_bits(
     packed_circuit: &formats::QPYCircuit,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(), QpyError> {
     let num_qubits = packed_circuit.header.num_qubits as usize;
     let num_clbits = packed_circuit.header.num_clbits as usize;
@@ -1197,7 +1269,7 @@ fn add_registers_and_bits(
                 Some(qubit) => Ok(qubit.clone()), // registered
                 None => match info {
                     // anonymus
-                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_data
+                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_global_data
                         .qubit_uid_table
                         .entry(*uid)
                         .or_insert_with(ShareableQubit::new_anonymous)
@@ -1226,7 +1298,7 @@ fn add_registers_and_bits(
                 Some(clbit) => Ok(clbit.clone()), // registered
                 None => match info {
                     // anonymus
-                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_data
+                    formats::BitInfoPack::Anonymous { uid } => Ok(qpy_global_data
                         .clbit_uid_table
                         .entry(*uid)
                         .or_insert_with(ShareableClbit::new_anonymous)
@@ -1344,14 +1416,13 @@ fn add_registers_and_bits(
     Ok(())
 }
 
-pub(crate) fn unpack_circuit<'u>(
+pub(crate) fn unpack_circuit(
     packed_circuit: &QPYCircuit,
     version: u8,
     use_symengine: bool,
     annotation_handler: AnnotationHandler,
     caller: QpyCaller,
-    qubit_uid_table: &'u mut HashMap<u64, ShareableQubit>,
-    clbit_uid_table: &'u mut HashMap<u64, ShareableClbit>,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<CircuitData, QpyError> {
     let instruction_capacity = packed_circuit.instructions.len();
     // create an empty circuit; we'll fill data as we go along
@@ -1382,8 +1453,6 @@ pub(crate) fn unpack_circuit<'u>(
             })
             .unwrap_or_default(),
         annotation_handler,
-        qubit_uid_table,
-        clbit_uid_table,
     };
     if let Some(annotation_headers) = &packed_circuit.annotation_headers {
         let annotation_deserializers_data: Vec<(String, Bytes)> = annotation_headers
@@ -1400,14 +1469,21 @@ pub(crate) fn unpack_circuit<'u>(
         packed_circuit.header.global_phase_type,
         &packed_circuit.header.global_phase_data,
         &mut qpy_data,
+        qpy_global_data,
         ValueEndian::Big,
     )?)?;
     qpy_data.circuit_data.set_global_phase_param(global_phase)?;
     add_standalone_vars(packed_circuit, &mut qpy_data)?;
-    add_registers_and_bits(packed_circuit, &mut qpy_data)?;
-    let custom_instructions = read_custom_instructions(packed_circuit, &mut qpy_data)?;
+    add_registers_and_bits(packed_circuit, &mut qpy_data, qpy_global_data)?;
+    let custom_instructions =
+        read_custom_instructions(packed_circuit, &mut qpy_data, qpy_global_data)?;
     for instruction in &packed_circuit.instructions {
-        let inst = unpack_instruction(instruction, &custom_instructions, &mut qpy_data)?;
+        let inst = unpack_instruction(
+            instruction,
+            &custom_instructions,
+            &mut qpy_data,
+            qpy_global_data,
+        )?;
         qpy_data.circuit_data.push(inst)?;
     }
     Ok(qpy_data.circuit_data)
@@ -1421,7 +1497,7 @@ pub fn wrap_conditional_gate(
     qubits: Interned<[Qubit]>,
     clbits: Interned<[Clbit]>,
     params: Option<Box<Parameters<Block>>>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> PyResult<(PackedOperation, Option<Box<Parameters<Block>>>)> {
     use qiskit_circuit::circuit_data::CircuitData;
     use qiskit_circuit::operations::Param;

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -899,6 +899,18 @@ fn pack_classical_register(
     }
 }
 
+fn pack_anonymous_bits_info<T>(
+    bits: &[T],
+    get_anonymous_uid: impl Fn(&T) -> Option<u64>,
+) -> Vec<formats::BitInfoPack> {
+    bits.iter()
+        .map(|bit| match get_anonymous_uid(bit) {
+            Some(uid) => formats::BitInfoPack::Anonymous { uid },
+            None => formats::BitInfoPack::Registered,
+        })
+        .collect()
+}
+
 fn pack_circuit_header(
     circuit_name: Option<String>,
     metadata: Bytes,
@@ -912,6 +924,14 @@ fn pack_circuit_header(
     let qregs = pack_quantum_registers(qpy_data.circuit_data, qpy_data.version);
     let cregs = pack_classical_registers(qpy_data.circuit_data, qpy_data.version);
     let mut registers = qregs;
+    let qubits_info = pack_anonymous_bits_info(
+        qpy_data.circuit_data.qubits().objects(),
+        ShareableQubit::get_anonymous_uid,
+    );
+    let clbits_info = pack_anonymous_bits_info(
+        qpy_data.circuit_data.clbits().objects(),
+        ShareableClbit::get_anonymous_uid,
+    );
     registers.extend(cregs);
     let header = formats::CircuitHeaderV12Pack {
         num_qubits: qpy_data.circuit_data.num_qubits() as u32,
@@ -926,6 +946,8 @@ fn pack_circuit_header(
         global_phase_type: global_phase_data.type_key,
         metadata,
         registers,
+        qubits_info,
+        clbits_info,
     };
 
     Ok(header)
@@ -1190,17 +1212,20 @@ fn pack_custom_instruction(
                 &definition.data,
                 qpy_data.version,
             )?)?;
-            Some(serialize(&pack_circuit(
-                &definition.data,
-                ExtraCircuitData {
-                    name: definition.name,
-                    metadata,
-                    layout,
-                },
-                qpy_data.version,
-                qpy_data.annotation_handler.child()?,
-                qpy_data.caller,
-            )?)?)
+            Some(serialize_with_args(
+                &pack_circuit(
+                    &definition.data,
+                    ExtraCircuitData {
+                        name: definition.name,
+                        metadata,
+                        layout,
+                    },
+                    qpy_data.version,
+                    qpy_data.annotation_handler.child()?,
+                    qpy_data.caller,
+                )?,
+                (qpy_data.version,),
+            )?)
         }
         CircuitInstructionType::AnnotatedOperation => {
             base_gate = inst.ob.bind(py).getattr("base_op")?.clone();
@@ -1226,7 +1251,7 @@ fn pack_custom_instruction(
                     qpy_data.annotation_handler.child()?,
                     qpy_data.caller,
                 )
-                .and_then(|fmt| serialize(&fmt))
+                .and_then(|fmt| serialize_with_args(&fmt, (qpy_data.version,)))
             })
             .transpose()?,
     };

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -138,7 +138,7 @@ pub(crate) fn pack_expression_var(
 pub(crate) fn unpack_expression_var(
     var_type_pack: ExpressionTypePack,
     var_element_pack: ExpressionVarElementPack,
-    qpy_data: &QPYReadData,
+    qpy_data: &QPYReadData<'_>,
 ) -> Result<Var, QpyError> {
     let ty = unpack_expression_type(var_type_pack);
     match var_element_pack {

--- a/crates/qpy/src/expr.rs
+++ b/crates/qpy/src/expr.rs
@@ -138,7 +138,7 @@ pub(crate) fn pack_expression_var(
 pub(crate) fn unpack_expression_var(
     var_type_pack: ExpressionTypePack,
     var_element_pack: ExpressionVarElementPack,
-    qpy_data: &QPYReadData<'_>,
+    qpy_data: &QPYReadData,
 ) -> Result<Var, QpyError> {
     let ty = unpack_expression_type(var_type_pack);
     match var_element_pack {

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -1012,7 +1012,7 @@ pub struct MappingItem {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
-#[br(import(qpy_read_data:&QPYReadData<'_>))]
+#[br(import(qpy_read_data:&QPYReadData))]
 #[bw(import(qpy_write_data: &'a QPYWriteData<'a>))]
 pub struct ExpressionPack<'a> {
     #[br(parse_with = read_expression, args(qpy_read_data))]

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -109,6 +109,12 @@ pub struct CircuitHeaderV12Pack {
     pub metadata: Bytes,
     #[br(count = num_registers, args { inner: (version,) })]
     pub registers: Vec<RegisterPack>,
+    #[br(if(version >=18), count = num_qubits)]
+    #[bw(if(version >=18))]
+    pub qubits_info: Vec<BitInfoPack>,
+    #[br(if(version >=18), count = num_clbits)]
+    #[bw(if(version >=18))]
+    pub clbits_info: Vec<BitInfoPack>,
 }
 
 #[binrw]
@@ -169,6 +175,16 @@ pub struct CircuitInstructionV2Pack {
     pub params: Vec<GenericDataPack>,
     #[br(if(has_annotations(extras_key)))]
     pub annotations: Option<InstructionsAnnotationPack>,
+}
+
+#[binrw]
+#[brw(big)]
+#[derive(Debug)]
+pub enum BitInfoPack {
+    #[brw(magic = 0u8)]
+    Registered,
+    #[brw(magic = 1u8)]
+    Anonymous { uid: u64 },
 }
 
 // To save space, the extras key encoded data about the existence of annotations
@@ -996,7 +1012,7 @@ pub struct MappingItem {
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
-#[br(import(qpy_read_data: &QPYReadData))]
+#[br(import(qpy_read_data:&QPYReadData<'_>))]
 #[bw(import(qpy_write_data: &'a QPYWriteData<'a>))]
 pub struct ExpressionPack<'a> {
     #[br(parse_with = read_expression, args(qpy_read_data))]

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -31,6 +31,7 @@ use crate::circuit_writer::{pack_circuit, pack_layout};
 use crate::error::QpyError;
 use crate::formats::{LayoutV2Pack, QPYCircuit, QPYFileHeader};
 use crate::py_methods::{py_circuit_data_to_quantum_circuit, serialize_metadata};
+use crate::value::QPYGlobalData;
 use crate::value::{
     ProgramType, QpyCaller, SymbolicEncoding, deserialize, deserialize_with_args, serialize,
     serialize_with_args,
@@ -329,16 +330,17 @@ pub fn load_qpy(
                 raw_circuit,
                 (qpy_file_header.qpy_version,),
             )?;
-            let mut qubit_uid_table = HashMap::new();
-            let mut clbit_uid_table = HashMap::new();
+            let mut qpy_global_data = QPYGlobalData {
+                qubit_uid_table: HashMap::new(),
+                clbit_uid_table: HashMap::new(),
+            };
             let circuit_data = unpack_circuit(
                 &packed_circuit,
                 qpy_file_header.qpy_version,
                 use_symengine,
                 annotation_handler.child()?,
                 caller,
-                &mut qubit_uid_table,
-                &mut clbit_uid_table,
+                &mut qpy_global_data,
             )?;
             circuits.push(LoadedCircuit {
                 circuit_data,
@@ -355,8 +357,10 @@ pub fn load_qpy(
                 inner: (qpy_file_header.qpy_version,),
             },
         )?;
-        let mut qubit_uid_table = HashMap::new();
-        let mut clbit_uid_table = HashMap::new();
+        let mut qpy_global_data = QPYGlobalData {
+            qubit_uid_table: HashMap::new(),
+            clbit_uid_table: HashMap::new(),
+        };
         for packed_circuit in packed_qpy_circuits {
             let circuit_data = unpack_circuit(
                 &packed_circuit,
@@ -364,8 +368,7 @@ pub fn load_qpy(
                 use_symengine,
                 annotation_handler.child()?,
                 caller,
-                &mut qubit_uid_table,
-                &mut clbit_uid_table,
+                &mut qpy_global_data,
             )?;
             circuits.push(LoadedCircuit {
                 circuit_data,

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -17,6 +17,7 @@
 // including headers, circuit tables, and multiple circuits.
 
 use binrw::{BinRead, Endian, VecArgs};
+use hashbrown::HashMap;
 use pyo3::PyResult;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
@@ -328,12 +329,16 @@ pub fn load_qpy(
                 raw_circuit,
                 (qpy_file_header.qpy_version,),
             )?;
+            let mut qubit_uid_table = HashMap::new();
+            let mut clbit_uid_table = HashMap::new();
             let circuit_data = unpack_circuit(
                 &packed_circuit,
                 qpy_file_header.qpy_version,
                 use_symengine,
                 annotation_handler.child()?,
                 caller,
+                &mut qubit_uid_table,
+                &mut clbit_uid_table,
             )?;
             circuits.push(LoadedCircuit {
                 circuit_data,
@@ -350,6 +355,8 @@ pub fn load_qpy(
                 inner: (qpy_file_header.qpy_version,),
             },
         )?;
+        let mut qubit_uid_table = HashMap::new();
+        let mut clbit_uid_table = HashMap::new();
         for packed_circuit in packed_qpy_circuits {
             let circuit_data = unpack_circuit(
                 &packed_circuit,
@@ -357,6 +364,8 @@ pub fn load_qpy(
                 use_symengine,
                 annotation_handler.child()?,
                 caller,
+                &mut qubit_uid_table,
+                &mut clbit_uid_table,
             )?;
             circuits.push(LoadedCircuit {
                 circuit_data,

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -240,7 +240,7 @@ fn pack_parameter_replay_entry(
 
 pub(crate) fn unpack_parameter_expression(
     pack: &formats::ParameterExpressionPack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<ParameterExpression, QpyError> {
     let uuid_map = pack.symbol_table_data.iter().try_fold(
         HashMap::new(),
@@ -523,7 +523,7 @@ pub(crate) fn pack_parameter_vector(
 /// definitions of this vector that we've seen.
 pub(crate) fn unpack_parameter_vector(
     pack: &formats::ParameterVectorElementPack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<Symbol, QpyError> {
     let pack = match pack {
         formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -9,7 +9,7 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
-use crate::value::ValueEndian;
+use crate::value::{QPYGlobalData, ValueEndian};
 use binrw::Endian;
 use num_complex::Complex64;
 use qiskit_circuit::operations::Param;
@@ -240,7 +240,8 @@ fn pack_parameter_replay_entry(
 
 pub(crate) fn unpack_parameter_expression(
     pack: &formats::ParameterExpressionPack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<ParameterExpression, QpyError> {
     let uuid_map = pack.symbol_table_data.iter().try_fold(
         HashMap::new(),
@@ -449,6 +450,7 @@ pub(crate) fn unpack_parameter_expression(
                             item.item_type,
                             &item.item_bytes,
                             qpy_data,
+                            qpy_global_data,
                             ValueEndian::Big,
                         )?)?;
                         Ok((sym, replacement))
@@ -523,7 +525,7 @@ pub(crate) fn pack_parameter_vector(
 /// definitions of this vector that we've seen.
 pub(crate) fn unpack_parameter_vector(
     pack: &formats::ParameterVectorElementPack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<Symbol, QpyError> {
     let pack = match pack {
         formats::ParameterVectorElementPack::V18(formats::ParameterVectorElementV18Pack {

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -602,7 +602,7 @@ pub fn unpack_py_instruction(
     py: Python,
     instruction: &formats::CircuitInstructionV2Pack,
     label: Option<&String>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
     let mut instruction_values =
@@ -760,7 +760,7 @@ pub fn unpack_custom_instruction(
     py: Python,
     instruction: &formats::CircuitInstructionV2Pack,
     label: Option<&String>,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
     custom_instructions_map: &HashMap<String, CustomCircuitInstructionData>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
@@ -898,7 +898,7 @@ pub fn unpack_custom_instruction(
 pub fn deserialize_pauli_evolution_gate(
     py: Python,
     data: &Bytes,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<Py<PyAny>, QpyError> {
     let json = py.import("json")?;
     let evo_synth_library = py.import("qiskit.synthesis.evolution")?;

--- a/crates/qpy/src/py_methods.rs
+++ b/crates/qpy/src/py_methods.rs
@@ -46,6 +46,7 @@ use crate::circuit_writer::standard_instruction_class_name;
 use crate::error::QpyError;
 use crate::formats;
 use crate::params::generic_value_to_param;
+use crate::value::QPYGlobalData;
 use crate::value::{
     BitType, CircuitInstructionType, GenericValue, ModifierType, ParamRegisterValue, QPYReadData,
     QPYWriteData, ValueEndian, ValueType, deserialize_with_args, load_value,
@@ -602,11 +603,16 @@ pub fn unpack_py_instruction(
     py: Python,
     instruction: &formats::CircuitInstructionV2Pack,
     label: Option<&String>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
-    let mut instruction_values =
-        get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
+    let mut instruction_values = get_instruction_values(
+        instruction,
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::LittleForV17AndBelow,
+    )?;
     let mut py_params: Vec<Bound<PyAny>> = instruction_values
         .iter()
         .map(|value| -> Result<_, QpyError> {
@@ -655,8 +661,8 @@ pub fn unpack_py_instruction(
             gate_class.call1(PyTuple::new(py, args)?)?
         }
         "IfElseOp" | "WhileLoopOp" => {
-            let condition =
-                unpack_condition(&instruction.condition, qpy_data)?.ok_or_else(|| {
+            let condition = unpack_condition(&instruction.condition, qpy_data, qpy_global_data)?
+                .ok_or_else(|| {
                     QpyError::MissingData(
                         "This control flow gate requires a condition parameter".to_string(),
                     )
@@ -760,15 +766,20 @@ pub fn unpack_custom_instruction(
     py: Python,
     instruction: &formats::CircuitInstructionV2Pack,
     label: Option<&String>,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
     custom_instructions_map: &HashMap<String, CustomCircuitInstructionData>,
 ) -> Result<(PackedOperation, Vec<GenericValue>), QpyError> {
     let name = instruction.gate_class_name.clone();
     let custom_instruction = custom_instructions_map.get(&name).ok_or_else(|| {
         QpyError::MissingData("Custom instruction data not found for {name}".to_string())
     })?;
-    let instruction_values =
-        get_instruction_values(instruction, qpy_data, ValueEndian::LittleForV17AndBelow)?;
+    let instruction_values = get_instruction_values(
+        instruction,
+        qpy_data,
+        qpy_global_data,
+        ValueEndian::LittleForV17AndBelow,
+    )?;
     let py_params: Vec<Bound<PyAny>> = instruction_values
         .iter()
         .map(|value| -> Result<_, QpyError> {
@@ -831,8 +842,12 @@ pub fn unpack_custom_instruction(
                 (bool,),
             >(&custom_instruction.base_gate_raw, (false,))?
             .0;
-            let base_gate =
-                unpack_instruction(&packed_base_gate, custom_instructions_map, qpy_data)?;
+            let base_gate = unpack_instruction(
+                &packed_base_gate,
+                custom_instructions_map,
+                qpy_data,
+                qpy_global_data,
+            )?;
             // If open controls, we need to discard the control suffix when setting the name.
             if instruction.ctrl_state < (1u32 << instruction.num_ctrl_qubits) - 1 {
                 gate_class_name = match gate_class_name.rfind('_') {
@@ -869,8 +884,12 @@ pub fn unpack_custom_instruction(
                 (bool,),
             >(&custom_instruction.base_gate_raw, (false,))?
             .0;
-            let base_gate =
-                unpack_instruction(&packed_base_gate, custom_instructions_map, qpy_data)?;
+            let base_gate = unpack_instruction(
+                &packed_base_gate,
+                custom_instructions_map,
+                qpy_data,
+                qpy_global_data,
+            )?;
             let params = qpy_data
                 .circuit_data
                 .unpack_blocks_to_circuit_parameters(base_gate.params.as_deref());
@@ -898,7 +917,8 @@ pub fn unpack_custom_instruction(
 pub fn deserialize_pauli_evolution_gate(
     py: Python,
     data: &Bytes,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<Py<PyAny>, QpyError> {
     let json = py.import("json")?;
     let evo_synth_library = py.import("qiskit.synthesis.evolution")?;
@@ -956,6 +976,7 @@ pub fn deserialize_pauli_evolution_gate(
                     ValueType::NumpyObject,
                     &sparse_pauli_op_pack.data,
                     qpy_data,
+                    qpy_global_data,
                     ValueEndian::Big,
                 )?;
                 if let GenericValue::NumpyObject(op_raw_data) = data {
@@ -989,6 +1010,7 @@ pub fn deserialize_pauli_evolution_gate(
         packed_data.time_type,
         &packed_data.time_data,
         qpy_data,
+        qpy_global_data,
         ValueEndian::Big,
     )?;
     let py_time: Py<PyAny> = match time {

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -21,7 +21,7 @@ use hashbrown::HashMap;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
-use qiskit_circuit::bit::{ClassicalRegister, ShareableClbit};
+use qiskit_circuit::bit::{ClassicalRegister, ShareableClbit, ShareableQubit};
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::classical::expr::{Expr, Stretch, Var};
 use qiskit_circuit::classical::types::Type;
@@ -251,7 +251,7 @@ pub struct QPYWriteData<'a> {
 
 // Data that is needed globally while reading the circuit
 #[derive(Debug)]
-pub struct QPYReadData {
+pub struct QPYReadData<'u> {
     pub caller: QpyCaller,
     pub circuit_data: CircuitData,
     pub version: u8,
@@ -261,6 +261,8 @@ pub struct QPYReadData {
     pub vectors: HashMap<Uuid, Arc<SymbolVector>>,
     pub parameter_vectors: Vec<Arc<SymbolVector>>,
     pub annotation_handler: AnnotationHandler,
+    pub qubit_uid_table: &'u mut HashMap<u64, ShareableQubit>,
+    pub clbit_uid_table: &'u mut HashMap<u64, ShareableClbit>,
 }
 
 // this is how tags for various value types are encoded in a QPY file
@@ -638,7 +640,7 @@ impl<T: FromGenericValue> FromGenericValue for Vec<T> {
 pub(crate) fn load_value(
     type_key: ValueType,
     bytes: &Bytes,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
     endian: ValueEndian,
 ) -> Result<GenericValue, QpyError> {
     match type_key {
@@ -738,6 +740,8 @@ pub(crate) fn load_value(
                 qpy_data.use_symengine,
                 qpy_data.annotation_handler.child()?,
                 qpy_data.caller,
+                qpy_data.qubit_uid_table,
+                qpy_data.clbit_uid_table,
             )?;
             Ok(GenericValue::CircuitData(Box::new(circuit)))
         }
@@ -822,7 +826,10 @@ pub(crate) fn serialize_generic_value(
                 qpy_data.annotation_handler.child()?,
                 qpy_data.caller,
             )?;
-            (ValueType::Circuit, serialize(&packed_circuit)?)
+            (
+                ValueType::Circuit,
+                serialize_with_args(&packed_circuit, (qpy_data.version,))?,
+            )
         }
         GenericValue::NumpyObject(bytes) => (ValueType::NumpyObject, bytes.clone()),
         GenericValue::Range(py_range) => {
@@ -860,7 +867,7 @@ pub(crate) fn pack_generic_value(
 
 pub(crate) fn unpack_generic_value(
     value_pack: &GenericDataPack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
     endian: ValueEndian,
 ) -> Result<GenericValue, QpyError> {
     let result = load_value(value_pack.type_key, &value_pack.data, qpy_data, endian)?;
@@ -872,7 +879,7 @@ pub(crate) fn unpack_generic_value(
 /// share the 't' key.
 pub(crate) fn unpack_duration_value(
     value_pack: &GenericDataPack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<GenericValue, QpyError> {
     match value_pack.type_key {
         ValueType::Tuple => {
@@ -932,7 +939,7 @@ pub(crate) fn pack_generic_value_sequence(
 
 pub(crate) fn unpack_generic_value_sequence(
     value_seqeunce_pack: GenericDataSequencePack,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
     endian: ValueEndian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     value_seqeunce_pack
@@ -1001,7 +1008,7 @@ pub(crate) fn serialize_expression(exp: &Expr, qpy_data: &QPYWriteData) -> Resul
 
 pub(crate) fn deserialize_expression(
     raw_expression: &Bytes,
-    qpy_data: &QPYReadData,
+    qpy_data: &QPYReadData<'_>,
 ) -> Result<Expr, QpyError> {
     let (exp_pack, _) = deserialize_with_args::<formats::ExpressionPack, (&QPYReadData,)>(
         raw_expression,
@@ -1142,7 +1149,7 @@ pub(crate) fn serialize_param_register_value(
 
 pub(crate) fn load_param_register_value(
     bytes: &Bytes,
-    qpy_data: &mut QPYReadData,
+    qpy_data: &mut QPYReadData<'_>,
 ) -> Result<ParamRegisterValue, QpyError> {
     if qpy_data.version >= 18 {
         let (pack, _) = deserialize::<formats::ParamRegisterPack>(bytes)?;
@@ -1193,7 +1200,7 @@ pub(crate) fn clbit_index(
 }
 
 /// The clbit at `index` in the circuit being read.
-pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData) -> Result<ShareableClbit, QpyError> {
+pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData<'_>) -> Result<ShareableClbit, QpyError> {
     qpy_data
         .circuit_data
         .clbits()
@@ -1207,7 +1214,7 @@ pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData) -> Result<ShareableCl
 /// Uses the name-keyed [`CircuitData::cregs_data`] map rather than scanning `cregs()`.
 pub(crate) fn creg_by_name(
     name: &str,
-    qpy_data: &QPYReadData,
+    qpy_data: &QPYReadData<'_>,
 ) -> Result<ClassicalRegister, QpyError> {
     qpy_data
         .circuit_data

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -251,7 +251,7 @@ pub struct QPYWriteData<'a> {
 
 // Data that is needed globally while reading the circuit
 #[derive(Debug)]
-pub struct QPYReadData<'u> {
+pub struct QPYReadData {
     pub caller: QpyCaller,
     pub circuit_data: CircuitData,
     pub version: u8,
@@ -261,8 +261,12 @@ pub struct QPYReadData<'u> {
     pub vectors: HashMap<Uuid, Arc<SymbolVector>>,
     pub parameter_vectors: Vec<Arc<SymbolVector>>,
     pub annotation_handler: AnnotationHandler,
-    pub qubit_uid_table: &'u mut HashMap<u64, ShareableQubit>,
-    pub clbit_uid_table: &'u mut HashMap<u64, ShareableClbit>,
+}
+
+#[derive(Debug)]
+pub struct QPYGlobalData {
+    pub qubit_uid_table: HashMap<u64, ShareableQubit>,
+    pub clbit_uid_table: HashMap<u64, ShareableClbit>,
 }
 
 // this is how tags for various value types are encoded in a QPY file
@@ -640,7 +644,8 @@ impl<T: FromGenericValue> FromGenericValue for Vec<T> {
 pub(crate) fn load_value(
     type_key: ValueType,
     bytes: &Bytes,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
     endian: ValueEndian,
 ) -> Result<GenericValue, QpyError> {
     match type_key {
@@ -703,12 +708,14 @@ pub(crate) fn load_value(
                 formats::ParameterExpressionPack,
                 _,
             >(bytes, (qpy_data.version,))?;
-            let exp = unpack_parameter_expression(&parameter_expression_pack, qpy_data)?;
+            let exp =
+                unpack_parameter_expression(&parameter_expression_pack, qpy_data, qpy_global_data)?;
             Ok(GenericValue::ParameterExpression(Arc::new(exp)))
         }
         ValueType::Tuple => {
             let (elements_pack, _) = deserialize::<GenericDataSequencePack>(bytes)?;
-            let values = unpack_generic_value_sequence(elements_pack, qpy_data, endian)?;
+            let values =
+                unpack_generic_value_sequence(elements_pack, qpy_data, qpy_global_data, endian)?;
             Ok(GenericValue::Tuple(values))
         }
         ValueType::NumpyObject => Ok(GenericValue::NumpyObject(bytes.clone())),
@@ -740,8 +747,7 @@ pub(crate) fn load_value(
                 qpy_data.use_symengine,
                 qpy_data.annotation_handler.child()?,
                 qpy_data.caller,
-                qpy_data.qubit_uid_table,
-                qpy_data.clbit_uid_table,
+                qpy_global_data,
             )?;
             Ok(GenericValue::CircuitData(Box::new(circuit)))
         }
@@ -867,10 +873,17 @@ pub(crate) fn pack_generic_value(
 
 pub(crate) fn unpack_generic_value(
     value_pack: &GenericDataPack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
     endian: ValueEndian,
 ) -> Result<GenericValue, QpyError> {
-    let result = load_value(value_pack.type_key, &value_pack.data, qpy_data, endian)?;
+    let result = load_value(
+        value_pack.type_key,
+        &value_pack.data,
+        qpy_data,
+        qpy_global_data,
+        endian,
+    )?;
     Ok(result)
 }
 
@@ -879,14 +892,20 @@ pub(crate) fn unpack_generic_value(
 /// share the 't' key.
 pub(crate) fn unpack_duration_value(
     value_pack: &GenericDataPack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
 ) -> Result<GenericValue, QpyError> {
     match value_pack.type_key {
         ValueType::Tuple => {
             let duration = unpack_duration(deserialize::<DurationPack>(&value_pack.data)?.0);
             Ok(GenericValue::Duration(duration))
         }
-        _ => unpack_generic_value(value_pack, qpy_data, ValueEndian::LittleForV17AndBelow), // fallback (duration can also be expression)
+        _ => unpack_generic_value(
+            value_pack,
+            qpy_data,
+            qpy_global_data,
+            ValueEndian::LittleForV17AndBelow,
+        ), // fallback (duration can also be expression)
     }
 }
 
@@ -939,13 +958,14 @@ pub(crate) fn pack_generic_value_sequence(
 
 pub(crate) fn unpack_generic_value_sequence(
     value_seqeunce_pack: GenericDataSequencePack,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
+    qpy_global_data: &mut QPYGlobalData,
     endian: ValueEndian,
 ) -> Result<Vec<GenericValue>, QpyError> {
     value_seqeunce_pack
         .elements
         .iter()
-        .map(|data_pack| unpack_generic_value(data_pack, qpy_data, endian))
+        .map(|data_pack| unpack_generic_value(data_pack, qpy_data, qpy_global_data, endian))
         .collect()
 }
 
@@ -1008,7 +1028,7 @@ pub(crate) fn serialize_expression(exp: &Expr, qpy_data: &QPYWriteData) -> Resul
 
 pub(crate) fn deserialize_expression(
     raw_expression: &Bytes,
-    qpy_data: &QPYReadData<'_>,
+    qpy_data: &QPYReadData,
 ) -> Result<Expr, QpyError> {
     let (exp_pack, _) = deserialize_with_args::<formats::ExpressionPack, (&QPYReadData,)>(
         raw_expression,
@@ -1149,7 +1169,7 @@ pub(crate) fn serialize_param_register_value(
 
 pub(crate) fn load_param_register_value(
     bytes: &Bytes,
-    qpy_data: &mut QPYReadData<'_>,
+    qpy_data: &mut QPYReadData,
 ) -> Result<ParamRegisterValue, QpyError> {
     if qpy_data.version >= 18 {
         let (pack, _) = deserialize::<formats::ParamRegisterPack>(bytes)?;
@@ -1200,7 +1220,7 @@ pub(crate) fn clbit_index(
 }
 
 /// The clbit at `index` in the circuit being read.
-pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData<'_>) -> Result<ShareableClbit, QpyError> {
+pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData) -> Result<ShareableClbit, QpyError> {
     qpy_data
         .circuit_data
         .clbits()
@@ -1214,7 +1234,7 @@ pub(crate) fn clbit_at(index: u32, qpy_data: &QPYReadData<'_>) -> Result<Shareab
 /// Uses the name-keyed [`CircuitData::cregs_data`] map rather than scanning `cregs()`.
 pub(crate) fn creg_by_name(
     name: &str,
-    qpy_data: &QPYReadData<'_>,
+    qpy_data: &QPYReadData,
 ) -> Result<ClassicalRegister, QpyError> {
     qpy_data
         .circuit_data

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -614,8 +614,8 @@ corresponding index in the circuit, and is one of:
     }
 
 For a bit that is not part of any register, ``uid`` is an identifier that is unique within the
-payload being deserialized. It is used to recognize when the same anonymous bit is referenced
-more than one place in the payload -- for example, a bit shared between a circuit and the body
+circuit being deserialized. It is used to recognize when the same anonymous bit is referenced
+more than one place within that circuit -- for example, a bit shared between a circuit and the body
 of one of its control-flow instructions. Those references are reconstructed with same uid,
 representing the same object.
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -595,6 +595,30 @@ starting index of the register. The indices are then the range of length
 ``size`` from that starting index. For example, if the starting index is 5
 and the ``size`` is 10 the indices are 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.
 
+New qubits_info and clbits_info arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Version 18 adds two new arrays to the circuit header:
+``qubits_info`` and ``clbits_info`` . Each element describes the bit at the
+corresponding index in the circuit, and is one of:
+
+.. code-block:: c
+
+    struct {              // a bit that belongs to a register, tag == 0
+        uint8_t tag;
+    }
+
+    struct {              // an anonymous bit not owned by any register, tag == 1
+        uint8_t  tag;
+        uint64_t uid;
+    }
+
+For a bit that is not part of any register, ``uid`` is an identifier that is unique within the
+payload being deserialized. It is used to recognize when the same anonymous bit is referenced
+more than one place in the payload -- for example, a bit shared between a circuit and the body
+of one of its control-flow instructions. Those references are reconstructed with same uid,
+representing the same object.
+
 .. _qpy_version_17:
 
 Version 17

--- a/releasenotes/notes/qpy-subcircuit-bit-identity-9da7794291bfd0ea.yaml
+++ b/releasenotes/notes/qpy-subcircuit-bit-identity-9da7794291bfd0ea.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed :func:`.qpy.load` so that anonymous bits which are shared across circuit - 
+    (such as bits that used for :class:`.WhileLoopOp` or :class:`.IfElseOp`) are 
+    reconstructed as the same bit object, rather than distinct copies.
+
+    See `#15482 <https://github.com/Qiskit/qiskit/issues/15482>`__.

--- a/test/python/qpy/test_v18.py
+++ b/test/python/qpy/test_v18.py
@@ -14,9 +14,9 @@
 
 import io
 import struct
-
 from qiskit.circuit import (
     Qubit,
+    Clbit,
     ClassicalRegister,
     Parameter,
     ParameterVector,
@@ -43,27 +43,6 @@ def _dump(qc: QuantumCircuit, version: int) -> bytes:
 
 class TestV17VsV18(QiskitTestCase):
     """Verify the binary-level differences between QPY v17 and v18."""
-
-    def test_v18_smaller_than_v17_by_calibration_header(self):
-        """v18 output is exactly 2 bytes smaller than v17 (CalibrationsPack removed)."""
-        # Use raw bits because register sizes also shrink in QPY v18
-        qubits = [Qubit(), Qubit()]
-        qc = QuantumCircuit(qubits)
-        qc.h(0)
-        qc.cx(0, 1)
-
-        size17 = len(_dump(qc, 17))
-        size18 = len(_dump(qc, 18))
-        cal_header_size = struct.calcsize(formats.CALIBRATION_PACK)  # 2 bytes
-        empty_vector_table_size = struct.calcsize("!H")  # the num_vectors count alone
-
-        self.assertEqual(
-            size17 - size18,
-            cal_header_size - empty_vector_table_size,
-            f"Expected v18 to differ from v17 by "
-            f"{cal_header_size - empty_vector_table_size} bytes, "
-            f"got v17={size17} v18={size18} diff={size17 - size18}",
-        )
 
     def test_v18_smaller_than_v17_for_anonymous_qbits(self):
         """v18 output is exactly 1 bytes smaller than v17."""
@@ -337,3 +316,29 @@ class TestV18ParameterVectorTable(QiskitTestCase):
         with circuit.if_test((circuit.clbits[0], True)):
             circuit.rx(vector[1], 0)
         self.assertEqual(load(io.BytesIO(_dump(circuit, 18)))[0], circuit)
+
+
+class TestV18CircuitWithNestedReferencing(QiskitTestCase):
+    """Test that anonymous bits shared between a circuit and a control-flow block's body keep
+    their identity across a QPY roundtrip.
+    """
+
+    def test_nested_reference_after_load(self):
+        bits = [Qubit(), Clbit()]
+        circuit = QuantumCircuit(bits)
+        with circuit.while_loop(expr.logic_not(bits[1])):
+            circuit.x(0)
+
+        # Sanity - before the roundtrip, the inner and outer bits should be equal.
+        inner_circuit = circuit.data[0].operation.blocks[0]
+        self.assertEqual(circuit.qubits[0], inner_circuit.qubits[0])
+        self.assertEqual(circuit.clbits[0], inner_circuit.clbits[0])
+
+        bytes_io = io.BytesIO()
+        dump(circuit, bytes_io)
+        bytes_io.seek(0)
+        loaded_circuit = load(bytes_io)[0]
+        # Main check - after the roundtrip, the inner and outer equality should be preserved.
+        inner_circuit = loaded_circuit.data[0].operation.blocks[0]
+        self.assertEqual(loaded_circuit.qubits[0], inner_circuit.qubits[0])
+        self.assertEqual(loaded_circuit.clbits[0], inner_circuit.clbits[0])


### PR DESCRIPTION
When loading circuit whose control-flow blocks (while_loop, if_else, etc.) share anonymous bits with the outer circuit, QPY reconstructed those bits as separate copies so identity checks broke after a dump/load roundtrip.

At the original circuit, the two bits are condider as equal sinc they share uid. The fix makes sure that it will be preserved after the roundtrip.

On write, each bit's info is now packed as either a registered marker or an Anonymous{uid}, so all occurrences of the same bit carry the same id. On read, QPYReadData grows a qubit_uid_table/clbit_uid_table map from uid to the live bit object; the first time a uid is seen we build the bit, every later occurrence just clones the existing one out of the table.

QPYReadData is now lifetime-parameterized (QPYReadData<'u>) so it can hold &mut references to these tables and pass them down through nested unpack_circuit calls.

Places where versioned circuit was serialized with the plain serialize() helper instead of serialize_with_args(), which silently defaults the version argument to 0 and skips every version-gated field on write - switched to serialize_with_args.

Also removed test_v18_smaller_than_v17_by_calibration_header: it assumed v18 is smaller than v17 from dropping CalibrationsPack, but the new per-bit Anonymous{uid} tag added here so the test premise no longer holds.

Signed-off-by: Elad Venezian <eladv@il.ibm.com>

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
