### PR TITLE
fix(transpiler): preserve layout in OptimizeSwapBeforeMeasure

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -52,10 +52,13 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
                 # the node swap needs to be removed and, if a measure follows, needs to be adapted
                 swap_qargs = swap.qargs
                 measure_layer = DAGCircuit()
+                measure_layer.add_qubits(dag.qubits)
+                measure_layer.add_clbits(dag.clbits)
                 for qreg in dag.qregs.values():
                     measure_layer.add_qreg(qreg)
                 for creg in dag.cregs.values():
                     measure_layer.add_creg(creg)
+
                 for successor in list(dag.descendants(swap)):
                     if isinstance(successor, DAGOpNode) and isinstance(successor.op, Measure):
                         # replace measure node with a new one, where qargs is set with the "other"

--- a/releasenotes/notes/fix-optimize-swap-before-measure-with-anonymous-qubit-080b28aed45972ab.yaml
+++ b/releasenotes/notes/fix-optimize-swap-before-measure-with-anonymous-qubit-080b28aed45972ab.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.OptimizeSwapBeforeMeasure` that caused it to
+    retargets measurements to the wrong qubits when loose qubits preceded
+    the measured qubit.

--- a/releasenotes/notes/fix-optimize-swap-before-measure-with-anonymous-qubit-080b28aed45972ab.yaml
+++ b/releasenotes/notes/fix-optimize-swap-before-measure-with-anonymous-qubit-080b28aed45972ab.yaml
@@ -2,5 +2,6 @@
 fixes:
   - |
     Fixed a bug in :class:`.OptimizeSwapBeforeMeasure` that caused it to
-    retargets measurements to the wrong qubits when loose qubits preceded
+    retarget measurements to the wrong qubits when loose qubits preceded
     the measured qubit.
+    Fixes `#16874 <https://github.com/Qiskit/qiskit/issues/16874>`__.

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -15,6 +15,7 @@
 import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
+from qiskit.circuit import Qubit
 from qiskit.passmanager.flow_controllers import DoWhileController
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import OptimizeSwapBeforeMeasure, DAGFixedPoint
@@ -351,6 +352,35 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         after = pass_manager.run(circuit)
 
         self.assertEqual(expected, after)
+
+    def test_optimize_swap_with_anonymous_qubit_and_reg(self):
+        """Anonymous bit doesn't mess up the indices
+        0: ─────────────       0: ────────
+                     ┌─┐               ┌─┐
+        q_0: ──────X─┤M├     q_0: ─────┤M├
+             ┌───┐ │ └╥┘ ==>      ┌───┐└╥┘
+        q_1: ┤ X ├─X──╫─     q_1: ┤ X ├─╫─
+             └───┘    ║           └───┘ ║
+        c: 1/═════════╩═     c: 1/══════╩═
+                      0                 0
+        """
+        loose_q = Qubit()
+        qreg = QuantumRegister(2, "q")
+        creg = ClassicalRegister(1, "c")
+
+        # Qubit order: [loose_q, qreg[0], qreg[1]]
+        source = QuantumCircuit([loose_q], qreg, creg)
+
+        source.x(qreg[1])
+        source.swap(qreg[0], qreg[1])
+        source.measure(qreg[0], creg[0])
+
+        output = PassManager([OptimizeSwapBeforeMeasure()]).run(source.copy())
+        measurement = next(
+            instruction for instruction in output.data if instruction.operation.name == "measure"
+        )
+        measured_qubit_index = output.find_bit(measurement.qubits[0]).index
+        self.assertEqual(measured_qubit_index, 2)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -369,18 +369,18 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         creg = ClassicalRegister(1, "c")
 
         # Qubit order: [loose_q, qreg[0], qreg[1]]
-        source = QuantumCircuit([loose_q], qreg, creg)
+        circuit = QuantumCircuit([loose_q], qreg, creg)
+        circuit.x(qreg[1])
+        circuit.swap(qreg[0], qreg[1])
+        circuit.measure(qreg[0], creg[0])
 
-        source.x(qreg[1])
-        source.swap(qreg[0], qreg[1])
-        source.measure(qreg[0], creg[0])
+        expected = QuantumCircuit([loose_q], qreg, creg)
+        expected.x(qreg[1])
+        expected.measure(qreg[1], creg[0])
 
-        output = PassManager([OptimizeSwapBeforeMeasure()]).run(source.copy())
-        measurement = next(
-            instruction for instruction in output.data if instruction.operation.name == "measure"
-        )
-        measured_qubit_index = output.find_bit(measurement.qubits[0]).index
-        self.assertEqual(measured_qubit_index, 2)
+        after = PassManager([OptimizeSwapBeforeMeasure()]).run(circuit)
+
+        self.assertEqual(expected, after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When anonymous qubits preceded registered qubits,
OptimizeSwapBeforeMeasure retargeted measurements to the wrong qubit wires.

Fix this by adding the original qubits and clbits to the newly created measurement layer.

This fix https://github.com/Qiskit/qiskit/issues/16874
This fix is almost similar to https://github.com/Qiskit/qiskit/pull/16876. 


### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
