### PR TITLE
Add `ProgramFunction` to the providers crate

### DIFF
--- a/crates/providers/Cargo.toml
+++ b/crates/providers/Cargo.toml
@@ -8,13 +8,14 @@ license.workspace = true
 [lib]
 name = "qiskit_providers"
 
-[dev-dependencies]
-num-traits.workspace = true# = "0.2"
-
 [dependencies]
-rustworkx-core.workspace = true
 num-complex.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+num-traits.workspace = true
+# Only a test uses this, to check the promotion table against the dtype lattice as a graph.
+rustworkx-core.workspace = true
 
 [dependencies.approx]
 workspace = true

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -17,13 +17,21 @@
 //!
 //! - [`tensor`] is the value domain. A [`Tensor`](tensor::Tensor) is a dense array over one of a
 //!   fixed set of dtypes, and a [`TensorType`](tensor::TensorType) is its data-less counterpart.
-//! - [`ops`] holds the [`ProgramOp`] contract and the ops Qiskit defines. The set is
-//!   open: an op may be defined outside this crate, in its own namespace.
+//! - [`ops`] holds the [`ProgramOp`] contract and the ops Qiskit defines. The set is open: an
+//!   op may be defined outside this crate, in its own namespace.
+//! - [`program`] holds [`ProgramFunction`], one dataflow graph. Instructions are the only entity it holds:
+//!   a [`Value`] is an output slot of the instruction producing it, and a function's parameters and
+//!   results are instructions too, so every value has a producer.
 //! - [`data_tree`] holds [`DataTree`], the container for structured values.
 
 pub mod data_tree;
 pub mod ops;
+pub mod program;
 pub mod tensor;
 
 pub use data_tree::{ArityMismatch, DataTree, InvalidName, Name, PathEntry, TreeMatchError};
-pub use ops::{Constant, ProgramOp};
+pub use ops::{BoxedOpError, BoxedProgramOp, Constant, ErasedProgramOp, ProgramOp};
+pub use program::{
+    FunctionError, FunctionEvalError, InstructionId, InstructionRef, InstructionRole,
+    ProgramFunction, Signature, Value,
+};

--- a/crates/providers/src/ops/mod.rs
+++ b/crates/providers/src/ops/mod.rs
@@ -29,5 +29,7 @@ pub use binary::{Add, Divide, Multiply, Power, Remainder, Subtract};
 pub use bitwise::{BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, Parity};
 pub use constant::Constant;
 pub use error::MathOpError;
-pub use program_op::{ProgramOp, QISKIT};
+pub use program_op::{BoxedOpError, BoxedProgramOp, ErasedProgramOp, ProgramOp, QISKIT};
+
+pub(crate) use program_op::erase;
 pub use reduction::{Mean, Std, Variance};

--- a/crates/providers/src/ops/program_op.rs
+++ b/crates/providers/src/ops/program_op.rs
@@ -10,32 +10,43 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-//! The contract every op satisfies.
+//! Defines the contract of atomic units within a quantum program.
 
 use crate::tensor::{Tensor, TensorType};
 
 /// The [`ProgramOp::namespace`] of every op Qiskit defines.
 pub const QISKIT: &str = "qiskit";
 
-/// One step in a program function: a typed mapping from tensors to tensors.
+/// An atomic operation in a quantum program: a typed mapping from tensors to tensors.
 ///
-/// An op declares how many operands it takes ([`Self::arity`]) and how to derive its result
-/// types from theirs ([`Self::infer_output_types`]). Operands and results are flat and
-/// positional, and an op instance is monomorphic: given operand types it accepts, its result
-/// types are determined.
+/// An op declares how many operands it takes ([`Self::arity`]) and how to derive its result types
+/// from prospective input types ([`Self::infer_output_types`]). Operands and results are flat and
+/// positional, and inference is monomorphic: given operand types the op accepts, its result types
+/// are determined.
 ///
-/// The boolean [`Self::has_builtin_eval`] specifies whether [`Self::eval`] contains an implementation.
+/// An op may have a payload of its own, such as "which axis" information in
+/// [`Mean`](crate::ops::Mean), quantum circuit instances in [`ShotLoop`](crate::ops::ShotLoop), or
+/// a tensor in [`Constant`](crate::ops::Constant).
+///
+/// An op can optionally implement [`Self::eval`] to explicitly perform the tensor manipulation
+/// that it represents, declaring its choice to do so or not in [`Self::has_builtin_eval`].
+/// `QuantumProgram` offers call options to enable externally-defined evaluations.
+///
+/// An op defined outside this crate lives in its own [`Self::namespace`] and is treated like
+/// any other.
 pub trait ProgramOp {
     /// The error this op reports for a rejected operand type or a failed evaluation.
     type Error;
 
-    /// The name of this program op.
+    /// The name of this op within its namespace, `add` for instance.
     fn name(&self) -> &str;
 
-    /// The namespace this program op belongs to.
+    /// The namespace this op belongs to, [`QISKIT`] for one Qiskit defines.
     fn namespace(&self) -> &str;
 
-    /// The namespace and name as one string.
+    /// The namespace and name as one string, `qiskit.add` for instance.
+    ///
+    /// Backends dispatch on this value.
     fn full_name(&self) -> String {
         format!("{}.{}", self.namespace(), self.name())
     }
@@ -48,9 +59,14 @@ pub trait ProgramOp {
 
     /// Infer the types of this op's results from the types of its operands.
     ///
-    /// This runs when the op is added to a program function, and is therefore what makes a
-    /// built function well-typed: an operand type this op cannot accept must be reported as an
-    /// error here, naming the operand position at fault.
+    /// This runs when the op is added to a program function, and is the primary mechanism
+    /// to ensure all quantum programs and the functions they contain are well-defined at
+    /// all times. The inferred type returned by this method becomes the value type checked by
+    /// subsequent ops.
+    ///
+    /// When several ops happen to share output type inference rules, they are typically made
+    /// common in [`tensor::rules`](crate::tensor::rules). For example, binary arithmetic operations
+    /// share the same broadcasting and type promotion rules.
     ///
     /// # Panics
     ///
@@ -60,13 +76,112 @@ pub trait ProgramOp {
     /// Evaluate this op on `args`, returning one tensor per result.
     ///
     /// The returned tensors match, in count and type, what [`Self::infer_output_types`] promised
-    /// for the corresponding operand types. An error is a last resort: a division op, for
-    /// instance, returns non-finite values for a zero divisor rather than failing, because some
-    /// of the data from elsewhere in the program may still be usable. An op whose
-    /// [`Self::has_builtin_eval`] is false always returns an error.
+    /// for the corresponding operand types. Run time errors should be a last resort: a division op
+    /// returns non-finite values for a zero divisor rather than failing, because data from
+    /// elsewhere in the program may still be usable. An op whose [`Self::has_builtin_eval`] is
+    /// false always returns an error.
     ///
     /// # Panics
     ///
-    /// May panic if `args` does not match the operand types this op was type-checked against.
+    /// May panic if `args` does not correspond with a non-erroring input to
+    /// [`Self::infer_output_types`].
     fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error>;
+}
+
+/// The error of an op whose type inference or evaluation fails, type-erased.
+pub type BoxedOpError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// An owned [`ErasedProgramOp`].
+pub type BoxedProgramOp = Box<dyn ErasedProgramOp>;
+
+/// A type-erased [`ProgramOp`].
+pub trait ErasedProgramOp:
+    ProgramOp<Error = BoxedOpError> + Send + Sync + sealed::Clonable
+{
+}
+
+impl<O> ErasedProgramOp for O where
+    O: ProgramOp<Error = BoxedOpError> + Clone + Send + Sync + 'static
+{
+}
+
+impl ToOwned for dyn ErasedProgramOp {
+    type Owned = BoxedProgramOp;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.clone_dyn()
+    }
+}
+
+mod sealed {
+    use super::{BoxedOpError, BoxedProgramOp, ProgramOp};
+
+    /// Copying an op through a trait object.
+    ///
+    /// [`Clone`] is not dyn-compatible, because it returns `Self`. This trait is sealed and blanket
+    /// implemented, so an implementor supplies nothing but `Clone`.
+    #[diagnostic::on_unimplemented(
+        message = "Clone is required to store {Self} in a program function",
+        note = "Consider annotating {Self} with `#[derive(Clone)]`"
+    )]
+    pub trait Clonable {
+        fn clone_dyn(&self) -> BoxedProgramOp;
+    }
+
+    impl<O> Clonable for O
+    where
+        O: ProgramOp<Error = BoxedOpError> + Clone + Send + Sync + 'static,
+    {
+        fn clone_dyn(&self) -> BoxedProgramOp {
+            Box::new(self.clone())
+        }
+    }
+}
+
+/// Erase `op`'s error type, so that a program function can store it.
+pub(crate) fn erase<O>(op: O) -> BoxedProgramOp
+where
+    O: ProgramOp + Clone + Send + Sync + 'static,
+    O::Error: std::error::Error + Send + Sync + 'static,
+{
+    #[derive(Clone)]
+    struct Erased<O>(O);
+
+    impl<O> ProgramOp for Erased<O>
+    where
+        O: ProgramOp,
+        O::Error: std::error::Error + Send + Sync + 'static,
+    {
+        type Error = BoxedOpError;
+        fn name(&self) -> &str {
+            self.0.name()
+        }
+        fn namespace(&self) -> &str {
+            self.0.namespace()
+        }
+        // Forwarded rather than left to the default, so that an op overriding it keeps its
+        // own spelling once it is stored in a function.
+        fn full_name(&self) -> String {
+            self.0.full_name()
+        }
+        fn arity(&self) -> usize {
+            self.0.arity()
+        }
+        fn has_builtin_eval(&self) -> bool {
+            self.0.has_builtin_eval()
+        }
+        fn infer_output_types(
+            &self,
+            inputs: &[TensorType],
+        ) -> Result<Vec<TensorType>, BoxedOpError> {
+            self.0
+                .infer_output_types(inputs)
+                .map_err(|e| Box::new(e) as BoxedOpError)
+        }
+        fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, BoxedOpError> {
+            self.0.eval(args).map_err(|e| Box::new(e) as BoxedOpError)
+        }
+    }
+
+    Box::new(Erased(op))
 }

--- a/crates/providers/src/program/mod.rs
+++ b/crates/providers/src/program/mod.rs
@@ -1,0 +1,21 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! A whole computation: the dataflow graphs it is made of, and the entry point a caller reaches it
+//! through.
+
+mod program_function;
+
+pub use program_function::{
+    FunctionError, FunctionEvalError, InstructionId, InstructionRef, InstructionRole,
+    ProgramFunction, Signature, Value,
+};

--- a/crates/providers/src/program/program_function.rs
+++ b/crates/providers/src/program/program_function.rs
@@ -1,0 +1,1340 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::ops::{BoxedOpError, BoxedProgramOp, ProgramOp, QISKIT, erase};
+use crate::tensor::{Tensor, TensorType};
+
+/// A position within one instruction's ordered operands or results.
+type Slot = u16;
+
+/// An instruction's position in the function that holds it.
+///
+/// Ids are dense, are never reused, and are only meaningful within the function that issued them.
+/// They are also an evaluation order: every operand of an instruction is produced by a strictly
+/// lower id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct InstructionId(u32);
+
+impl InstructionId {
+    /// The underlying index, for use as a dense array subscript.
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Display for InstructionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// One tensor value: an output slot of the instruction that produces it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Value {
+    instruction: InstructionId,
+    slot: Slot,
+}
+
+impl Value {
+    /// The instruction that produces this value.
+    pub fn instruction(self) -> InstructionId {
+        self.instruction
+    }
+
+    /// Which of that instruction's results this value is.
+    pub fn slot(self) -> usize {
+        self.slot as usize
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.slot == 0 {
+            write!(f, "%{}", self.instruction)
+        } else {
+            write!(f, "%{}.{}", self.instruction, self.slot)
+        }
+    }
+}
+
+/// What part an instruction plays in its function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstructionRole {
+    /// A function input, supplied by the caller.
+    Parameter,
+    /// An operation, with a [`ProgramOp`].
+    Op,
+    /// A function output.
+    Result,
+}
+
+/// The types a function consumes and produces, positionally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    /// The type of each parameter, in declaration order.
+    pub inputs: Vec<TensorType>,
+    /// The type of each declared result, in declaration order.
+    pub outputs: Vec<TensorType>,
+}
+
+/// The evaluation content of an instruction.
+enum InstructionBody {
+    Parameter,
+    Op(BoxedProgramOp),
+    Result,
+}
+
+impl InstructionBody {
+    fn name(&self) -> &str {
+        match self {
+            Self::Parameter => "parameter",
+            Self::Op(op) => op.name(),
+            Self::Result => "result",
+        }
+    }
+
+    fn namespace(&self) -> &str {
+        match self {
+            Self::Parameter | Self::Result => QISKIT,
+            Self::Op(op) => op.namespace(),
+        }
+    }
+
+    fn full_name(&self) -> String {
+        match self {
+            Self::Parameter | Self::Result => format!("{}.{}", self.namespace(), self.name()),
+            Self::Op(op) => op.full_name(),
+        }
+    }
+
+    fn role(&self) -> InstructionRole {
+        match self {
+            Self::Parameter => InstructionRole::Parameter,
+            Self::Op(_) => InstructionRole::Op,
+            Self::Result => InstructionRole::Result,
+        }
+    }
+
+    fn arity(&self) -> usize {
+        match self {
+            Self::Parameter => 0,
+            Self::Op(op) => op.arity(),
+            Self::Result => 1,
+        }
+    }
+
+    fn has_builtin_eval(&self) -> bool {
+        match self {
+            Self::Parameter | Self::Result => true,
+            Self::Op(op) => op.has_builtin_eval(),
+        }
+    }
+}
+
+/// One instruction of a function: what it is, what it reads, and what it produces.
+struct ProgramInstruction {
+    body: InstructionBody,
+    /// The values this instruction consumes, in operand order. There are always
+    /// [`InstructionBody::arity`] of them, so a half-wired instruction cannot be represented, and
+    /// this is the only record of how the function is connected.
+    operands: Vec<Value>,
+    /// The types inference produced for this instruction's results, one per result.
+    output_types: Vec<TensorType>,
+}
+
+/// A read-only view of one instruction of a [`ProgramFunction`].
+///
+/// This holds the function as well as the instruction, because an instruction's operand types live
+/// on the instructions that produce them and so cannot be read from the instruction alone.
+#[derive(Clone, Copy)]
+pub struct InstructionRef<'a> {
+    function: &'a ProgramFunction,
+    id: InstructionId,
+}
+
+impl<'a> InstructionRef<'a> {
+    fn instruction(&self) -> &'a ProgramInstruction {
+        &self.function.instructions[self.id.index()]
+    }
+
+    /// This instruction's position in its function, which is its identity.
+    pub fn id(&self) -> InstructionId {
+        self.id
+    }
+
+    /// What part this instruction plays: an operation, or one end of the function's boundary.
+    pub fn role(&self) -> InstructionRole {
+        self.instruction().body.role()
+    }
+
+    /// This instruction's type name within its namespace, `add` for instance.
+    pub fn name(&self) -> &'a str {
+        self.instruction().body.name()
+    }
+
+    /// The namespace this instruction's type belongs to, [`QISKIT`](crate::ops::QISKIT) for an op
+    /// Qiskit defines.
+    pub fn namespace(&self) -> &'a str {
+        self.instruction().body.namespace()
+    }
+
+    /// The name that categorizes this instruction and that a backend dispatches on, `qiskit.add`
+    /// for instance. Allocates; [`Self::name`] and [`Self::namespace`] do not.
+    pub fn full_name(&self) -> String {
+        self.instruction().body.full_name()
+    }
+
+    /// Whether Qiskit can evaluate this instruction in-process.
+    pub fn has_builtin_eval(&self) -> bool {
+        self.instruction().body.has_builtin_eval()
+    }
+
+    /// The values this instruction consumes, in operand order.
+    pub fn operands(&self) -> &'a [Value] {
+        &self.instruction().operands
+    }
+
+    /// The type of each operand, read from the instruction that produces it.
+    pub fn operand_types(&self) -> impl Iterator<Item = &'a TensorType> {
+        let function = self.function;
+        self.instruction()
+            .operands
+            .iter()
+            .map(move |&value| function.type_of(value).expect("an operand always exists"))
+    }
+
+    /// The values this instruction produces, in result order.
+    pub fn outputs(&self) -> impl Iterator<Item = Value> + 'a {
+        let instruction = self.id;
+        (0..self.instruction().output_types.len() as Slot)
+            .map(move |slot| Value { instruction, slot })
+    }
+
+    /// The type of each value this instruction produces, in result order.
+    pub fn output_types(&self) -> &'a [TensorType] {
+        &self.instruction().output_types
+    }
+}
+
+/// Why an instruction or a result could not be added to a [`ProgramFunction`].
+#[derive(Debug, Error)]
+pub enum FunctionError {
+    /// An operand names a value this function has not produced.
+    #[error("operand {operand}: {value} was not produced by this function")]
+    UnknownOperand { operand: usize, value: Value },
+
+    /// A declared result names a value this function has not produced.
+    #[error("{0} was not produced by this function")]
+    UnknownValue(Value),
+
+    /// The operand count does not match the instruction's declared [`ProgramOp::arity`].
+    #[error("{full_name} takes {expected} operand(s), got {actual}")]
+    OperandArity {
+        full_name: String,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// The instruction rejected the types of the values wired to it. This is the build-time
+    /// counterpart of a run-time dtype or shape error.
+    #[error("{full_name} rejected its operand types")]
+    TypeError {
+        full_name: String,
+        #[source]
+        source: BoxedOpError,
+    },
+}
+
+/// Why [`ProgramFunction::eval`] could not produce results.
+#[derive(Debug, Error)]
+pub enum FunctionEvalError {
+    /// The argument count does not match the number of declared parameters.
+    #[error("expected {expected} argument(s), got {actual}")]
+    ArgumentArity { expected: usize, actual: usize },
+
+    /// An argument does not satisfy the type this (monomorphic) function declares for that
+    /// parameter.
+    #[error("argument {parameter}: expected {expected}, got {actual}")]
+    ArgumentTypeMismatch {
+        parameter: usize,
+        expected: TensorType,
+        actual: TensorType,
+    },
+
+    /// The function contains an instruction Qiskit has no in-process implementation of.
+    #[error("instruction {instruction} ({full_name}) has no built-in implementation")]
+    NoBuiltinEval {
+        instruction: InstructionId,
+        full_name: String,
+    },
+
+    /// An instruction returned an error from its [`ProgramOp::eval`].
+    #[error("evaluating instruction {instruction} ({full_name})")]
+    InstructionFailed {
+        instruction: InstructionId,
+        full_name: String,
+        #[source]
+        source: BoxedOpError,
+    },
+
+    /// An instruction's `eval` returned a different number of tensors than its type inference
+    /// promised when it was added. This is a bug in the instruction; it cannot be caught
+    /// statically, because instructions are stored type-erased.
+    #[error("instruction {instruction} returned {actual} result(s), expected {expected}")]
+    ResultArityMismatch {
+        instruction: InstructionId,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+/// A tensor dataflow of instructions.
+///
+/// Each instruction can have one of three roles:
+///  * parameter: an input to the function specifying exactly one tensor demanded at call time
+///  * result: an output to the function specifying one tensor the function returns
+///  * op: some atomic operation represented as a [`ProgramOp`]
+///
+/// Each instruction has some number of operands, and an instruction can only be added when values
+/// exist in the graph to assign to the operands; the first instruction added must have arity `0`,
+/// such as a parameter or [`Constant`](crate::ops::Constant) instruction. Values are specified
+/// using [`Value`] which is a struct containing the index of an existing instruction along with an
+/// index of one of its output slots.
+///
+/// Type compatibility of values and the operands of the instructions that act on them is checked
+/// when adding the instruction. This implies that a `ProgramFunction` cannot be malformed by
+/// construction. Also by construction, this data model is SSA compliant and the stored instruction
+/// order is topological with respect to evaluation.
+pub struct ProgramFunction {
+    /// Every instruction, indexed by [`InstructionId`].
+    instructions: Vec<ProgramInstruction>,
+    /// Indices of all parameter instructions in declaration order.
+    parameters: Vec<InstructionId>,
+    /// Indices of all result instructions in declaration order. Two of them may read one value.
+    results: Vec<InstructionId>,
+}
+
+impl Default for ProgramFunction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProgramFunction {
+    /// Construct a new, empty function.
+    pub fn new() -> Self {
+        Self {
+            instructions: Vec::new(),
+            parameters: Vec::new(),
+            results: Vec::new(),
+        }
+    }
+
+    /// Declare a parameter of the given type, returning its value.
+    pub fn add_parameter(&mut self, ty: TensorType) -> Value {
+        let id = self.push(InstructionBody::Parameter, Vec::new(), vec![ty]);
+        self.parameters.push(id);
+        Value {
+            instruction: id,
+            slot: 0,
+        }
+    }
+
+    /// Apply `op` to `operands`, returning the values it produces in result order.
+    pub fn add_op<O>(&mut self, op: O, operands: &[Value]) -> Result<Vec<Value>, FunctionError>
+    where
+        O: ProgramOp + Clone + Send + Sync + 'static,
+        O::Error: std::error::Error + Send + Sync + 'static,
+    {
+        self.add_boxed_op(erase(op), operands)
+    }
+
+    /// Apply a boxed op, returning the values it produces in result order.
+    pub fn add_boxed_op(
+        &mut self,
+        op: BoxedProgramOp,
+        operands: &[Value],
+    ) -> Result<Vec<Value>, FunctionError> {
+        if operands.len() != op.arity() {
+            return Err(FunctionError::OperandArity {
+                full_name: op.full_name(),
+                expected: op.arity(),
+                actual: operands.len(),
+            });
+        }
+
+        let mut operand_types = Vec::with_capacity(operands.len());
+        for (operand, &value) in operands.iter().enumerate() {
+            let Some(ty) = self.type_of(value) else {
+                return Err(FunctionError::UnknownOperand { operand, value });
+            };
+            operand_types.push(ty.clone());
+        }
+
+        let output_types =
+            op.infer_output_types(&operand_types)
+                .map_err(|source| FunctionError::TypeError {
+                    full_name: op.full_name(),
+                    source,
+                })?;
+
+        let id = self.push(InstructionBody::Op(op), operands.to_vec(), output_types);
+        Ok(self
+            .instruction(id)
+            .expect("the instruction was just pushed")
+            .outputs()
+            .collect())
+    }
+
+    /// Declare `value` as the next result of this function.
+    pub fn add_result(&mut self, value: Value) -> Result<(), FunctionError> {
+        if self.type_of(value).is_none() {
+            return Err(FunctionError::UnknownValue(value));
+        }
+        let id = self.push(InstructionBody::Result, vec![value], Vec::new());
+        self.results.push(id);
+        Ok(())
+    }
+
+    /// Append an instruction, returning the id it was given.
+    fn push(
+        &mut self,
+        body: InstructionBody,
+        operands: Vec<Value>,
+        output_types: Vec<TensorType>,
+    ) -> InstructionId {
+        debug_assert_eq!(
+            operands.len(),
+            body.arity(),
+            "an instruction stores exactly as many operands as its arity"
+        );
+        let id = InstructionId(self.instructions.len() as u32);
+        self.instructions.push(ProgramInstruction {
+            body,
+            operands,
+            output_types,
+        });
+        id
+    }
+
+    /// The type of `value`, or `None` if it does not belong to this function.
+    pub fn type_of(&self, value: Value) -> Option<&TensorType> {
+        self.instructions
+            .get(value.instruction.index())?
+            .output_types
+            .get(value.slot())
+    }
+
+    /// The parameter instructions, in declaration order.
+    pub fn parameters(&self) -> &[InstructionId] {
+        &self.parameters
+    }
+
+    /// The result instructions, in declaration order.
+    pub fn results(&self) -> &[InstructionId] {
+        &self.results
+    }
+
+    /// The value of each parameter, in declaration order.
+    pub fn parameter_values(&self) -> impl Iterator<Item = Value> + '_ {
+        self.parameters.iter().map(|&instruction| Value {
+            instruction,
+            slot: 0,
+        })
+    }
+
+    /// The value each result returns, in declaration order.
+    pub fn result_values(&self) -> impl Iterator<Item = Value> + '_ {
+        self.results
+            .iter()
+            .map(|&instruction| self.instructions[instruction.index()].operands[0])
+    }
+
+    /// This function's type contract: the types of its parameters and of its results.
+    pub fn signature(&self) -> Signature {
+        Signature {
+            inputs: self.value_types(self.parameter_values()),
+            outputs: self.value_types(self.result_values()),
+        }
+    }
+
+    /// A view of the instruction with the given id, or `None`.
+    pub fn instruction(&self, id: InstructionId) -> Option<InstructionRef<'_>> {
+        (id.index() < self.instructions.len()).then_some(InstructionRef { function: self, id })
+    }
+
+    /// The number of instructions in this function, boundary instructions included.
+    pub fn instruction_count(&self) -> usize {
+        self.instructions.len()
+    }
+
+    /// Iterate over every instruction, in topological order.
+    pub fn iter_instructions(&self) -> impl Iterator<Item = InstructionRef<'_>> {
+        (0..self.instructions.len() as u32).map(|id| InstructionRef {
+            function: self,
+            id: InstructionId(id),
+        })
+    }
+
+    /// Whether Qiskit can evaluate every instruction of this function in-process.
+    pub fn has_builtin_eval(&self) -> bool {
+        self.first_without_builtin_eval().is_none()
+    }
+
+    /// Evaluate this function against `args`, one per parameter in declaration order.
+    ///
+    /// Walks the instructions in storage order, which is topological, over a single dense
+    /// environment, releasing each intermediate once its last consumer has run.
+    pub fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, FunctionEvalError> {
+        // The function is monomorphic, so its declared parameter types are the only ones its
+        // instructions were built for. Checking them here names the argument the caller supplied.
+        self.check_argument_types(args)?;
+        if let Some(instruction) = self.first_without_builtin_eval() {
+            return Err(FunctionEvalError::NoBuiltinEval {
+                instruction: instruction.id(),
+                full_name: instruction.full_name(),
+            });
+        }
+
+        let offsets = self.value_offsets();
+        let last_use = self.last_use(&offsets);
+        let flat = |value: Value| offsets[value.instruction.index()] as usize + value.slot();
+
+        let total = *offsets.last().expect("offsets always end with the total");
+        let mut env: Vec<Option<Tensor>> = vec![None; total as usize];
+        let mut outputs: Vec<Option<Tensor>> = vec![None; self.results.len()];
+        let mut next_result = 0;
+
+        for (position, instruction) in self.instructions.iter().enumerate() {
+            let id = InstructionId(position as u32);
+            match &instruction.body {
+                InstructionBody::Parameter => {
+                    // Parameters are the sources of the dataflow: their values come from the caller,
+                    // in the order the parameters were declared.
+                    let parameter = self
+                        .parameters
+                        .iter()
+                        .position(|&declared| declared == id)
+                        .expect("a parameter instruction is always in `parameters`");
+                    env[offsets[position] as usize] = Some(args[parameter].clone());
+                }
+                InstructionBody::Op(op) => {
+                    // Every operand is present: it was produced by an earlier instruction, and it
+                    // cannot have been released, because this instruction's use of it is at or
+                    // before its last.
+                    let operands: Vec<Tensor> = instruction
+                        .operands
+                        .iter()
+                        .map(|&value| {
+                            env[flat(value)]
+                                .clone()
+                                .expect("an operand is produced before its consumer runs")
+                        })
+                        .collect();
+
+                    let results = op.eval(&operands).map_err(|source| {
+                        FunctionEvalError::InstructionFailed {
+                            instruction: id,
+                            full_name: op.full_name(),
+                            source,
+                        }
+                    })?;
+                    if results.len() != instruction.output_types.len() {
+                        return Err(FunctionEvalError::ResultArityMismatch {
+                            instruction: id,
+                            expected: instruction.output_types.len(),
+                            actual: results.len(),
+                        });
+                    }
+                    for (slot, tensor) in results.into_iter().enumerate() {
+                        env[offsets[position] as usize + slot] = Some(tensor);
+                    }
+                }
+                InstructionBody::Result => {
+                    outputs[next_result] = env[flat(instruction.operands[0])].clone();
+                    next_result += 1;
+                }
+            }
+
+            // A result instruction is an ordinary final consumer, so nothing here has to make an
+            // exception for a value the function returns.
+            for &value in &instruction.operands {
+                if last_use[flat(value)] == Some(position) {
+                    env[flat(value)] = None;
+                }
+            }
+            for slot in 0..instruction.output_types.len() {
+                let index = offsets[position] as usize + slot;
+                if last_use[index] == Some(position) {
+                    env[index] = None;
+                }
+            }
+        }
+
+        Ok(outputs
+            .into_iter()
+            .map(|tensor| tensor.expect("every result instruction runs"))
+            .collect())
+    }
+
+    /// The first instruction Qiskit has no in-process implementation of.
+    ///
+    /// [`Self::eval`] consults this before computing anything, so a function that needs a backend
+    /// fails at the top rather than part-way through a walk that has produced intermediates.
+    fn first_without_builtin_eval(&self) -> Option<InstructionRef<'_>> {
+        self.iter_instructions()
+            .find(|instruction| !instruction.has_builtin_eval())
+    }
+
+    /// The types of `values`, which must all belong to this function.
+    fn value_types(&self, values: impl Iterator<Item = Value>) -> Vec<TensorType> {
+        values
+            .map(|value| {
+                self.type_of(value)
+                    .expect("a boundary value always exists")
+                    .clone()
+            })
+            .collect()
+    }
+
+    /// Validate that every argument satisfies its parameter's declared type.
+    fn check_argument_types(&self, args: &[Tensor]) -> Result<(), FunctionEvalError> {
+        if args.len() != self.parameters.len() {
+            return Err(FunctionEvalError::ArgumentArity {
+                expected: self.parameters.len(),
+                actual: args.len(),
+            });
+        }
+        for (parameter, (arg, value)) in args.iter().zip(self.parameter_values()).enumerate() {
+            let expected = self.type_of(value).expect("a parameter always exists");
+            if !arg.matches(expected) {
+                return Err(FunctionEvalError::ArgumentTypeMismatch {
+                    parameter,
+                    expected: expected.clone(),
+                    actual: arg.tensor_type(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Where each instruction's block of values starts in a dense environment, with the total
+    /// appended.
+    ///
+    /// This is the flat value numbering [`Self::eval`] uses, derived when it is needed rather than
+    /// stored: an instruction's values are already grouped by their producer, so the offsets are
+    /// one prefix sum away.
+    fn value_offsets(&self) -> Vec<u32> {
+        let mut offsets = Vec::with_capacity(self.instructions.len() + 1);
+        let mut total = 0;
+        for instruction in &self.instructions {
+            offsets.push(total);
+            total += instruction.output_types.len() as u32;
+        }
+        offsets.push(total);
+        offsets
+    }
+
+    /// For each value, the instruction position after which nothing needs it.
+    ///
+    /// Lets [`Self::eval`] release a tensor as soon as its final consumer has run, so that peak
+    /// memory is the working set rather than every intermediate the walk ever produced. A value
+    /// nothing goes on to consume dies where it is produced, which is what keeps an unused result
+    /// from being held for the whole walk.
+    fn last_use(&self, offsets: &[u32]) -> Vec<Option<usize>> {
+        let total = *offsets.last().expect("offsets always end with the total");
+        let mut last = vec![None; total as usize];
+        for (position, instruction) in self.instructions.iter().enumerate() {
+            for slot in 0..instruction.output_types.len() {
+                last[offsets[position] as usize + slot] = Some(position);
+            }
+            // A consumer overwrites the producer's own position, which is strictly later.
+            for &value in &instruction.operands {
+                last[offsets[value.instruction.index()] as usize + value.slot()] = Some(position);
+            }
+        }
+        last
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ops::{Add, Constant, Mean};
+    use crate::tensor::{DType, Dim};
+
+    /// The type of a 1-D `F64` tensor of `len` elements.
+    fn f64_1d(len: usize) -> TensorType {
+        TensorType {
+            dtype: DType::F64,
+            shape: vec![Dim::Fixed(len)],
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Building and evaluating
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn a_function_adds_two_parameters_and_evaluates() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(3));
+        let y = function.add_parameter(f64_1d(3));
+        let sum = function.add_op(Add, &[x, y]).unwrap();
+        assert_eq!(sum.len(), 1);
+        function.add_result(sum[0]).unwrap();
+
+        let results = function
+            .eval(&[
+                Tensor::from([1.0_f64, 2.0, 3.0]),
+                Tensor::from([10.0_f64, 20.0, 30.0]),
+            ])
+            .unwrap();
+
+        assert_eq!(results, vec![Tensor::from([11.0_f64, 22.0, 33.0])]);
+    }
+
+    #[test]
+    fn a_signature_is_available_without_evaluating() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        let y = function.add_parameter(f64_1d(2));
+        let sum = function.add_op(Add, &[x, y]).unwrap()[0];
+        let mean = function.add_op(Mean::new(0), &[sum]).unwrap()[0];
+        function.add_result(mean).unwrap();
+
+        assert_eq!(
+            function.signature(),
+            Signature {
+                inputs: vec![f64_1d(2), f64_1d(2)],
+                outputs: vec![TensorType {
+                    dtype: DType::F64,
+                    shape: vec![],
+                }],
+            }
+        );
+        assert_eq!(function.type_of(sum), Some(&f64_1d(2)));
+    }
+
+    #[test]
+    fn parameters_and_results_are_positional() {
+        // The two parameters have distinct types, so the order in which they reach the instruction
+        // is observable in the result.
+        let mut function = ProgramFunction::new();
+        let short = function.add_parameter(f64_1d(1));
+        let long = function.add_parameter(f64_1d(2));
+        assert_eq!(
+            function.parameter_values().collect::<Vec<_>>(),
+            vec![short, long]
+        );
+
+        // Both results name the same value, which is allowed, and a parameter may be returned
+        // directly.
+        function.add_result(long).unwrap();
+        function.add_result(long).unwrap();
+        function.add_result(short).unwrap();
+        assert_eq!(
+            function.result_values().collect::<Vec<_>>(),
+            vec![long, long, short]
+        );
+
+        let results = function
+            .eval(&[Tensor::from([1.0_f64]), Tensor::from([2.0_f64, 3.0])])
+            .unwrap();
+        assert_eq!(
+            results,
+            vec![
+                Tensor::from([2.0_f64, 3.0]),
+                Tensor::from([2.0_f64, 3.0]),
+                Tensor::from([1.0_f64]),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_value_may_be_consumed_more_than_once() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        let doubled = function.add_op(Add, &[x, x]).unwrap()[0];
+        let quadrupled = function.add_op(Add, &[doubled, doubled]).unwrap()[0];
+        function.add_result(quadrupled).unwrap();
+
+        assert_eq!(
+            function.eval(&[Tensor::from([1.0_f64, 2.0])]).unwrap(),
+            vec![Tensor::from([4.0_f64, 8.0])]
+        );
+    }
+
+    #[test]
+    fn an_instruction_whose_results_nothing_uses_does_not_disturb_the_rest() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        function.add_op(Mean::new(0), &[x]).unwrap();
+        let sum = function.add_op(Add, &[x, x]).unwrap()[0];
+        function.add_result(sum).unwrap();
+
+        assert_eq!(
+            function.eval(&[Tensor::from([1.0_f64, 2.0])]).unwrap(),
+            vec![Tensor::from([2.0_f64, 4.0])]
+        );
+    }
+
+    #[test]
+    fn reducing_a_zero_length_axis_yields_a_non_finite_value() {
+        // A zero-length axis divides by zero. Failing the whole program over it would be worse than
+        // handing back a value the caller can see is not a number.
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(0));
+        let mean = function.add_op(Mean::new(0), &[x]).unwrap()[0];
+        function.add_result(mean).unwrap();
+
+        let results = function
+            .eval(&[Tensor::from(&[] as &[f64])])
+            .expect("an empty reduction is not an error");
+        let [Tensor::F64(mean)] = &results[..] else {
+            panic!("expected one F64 result, got {results:?}")
+        };
+        assert!(mean.iter().all(|value| value.is_nan()));
+    }
+
+    #[test]
+    fn a_function_can_be_sent_between_threads() {
+        // A job drives evaluation and is where all concurrency lives, so it must be able to hold one.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ProgramFunction>();
+    }
+
+    #[test]
+    fn a_constant_holds_one_tensor() {
+        let mut function = ProgramFunction::new();
+        let two = function
+            .add_op(Constant::new(Tensor::from([2.0_f64, 2.0])), &[])
+            .unwrap();
+        assert_eq!(two.len(), 1);
+        let x = function.add_parameter(f64_1d(2));
+        let sum = function.add_op(Add, &[x, two[0]]).unwrap()[0];
+        function.add_result(sum).unwrap();
+
+        assert_eq!(
+            function.eval(&[Tensor::from([1.0_f64, 10.0])]).unwrap(),
+            vec![Tensor::from([3.0_f64, 12.0])]
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Instructions, values, and roles
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn an_op_name_carries_its_namespace() {
+        assert_eq!(Add.full_name(), "qiskit.add");
+        assert_eq!(Elsewhere.full_name(), "vendor.elsewhere");
+    }
+
+    #[test]
+    fn a_function_reports_the_instructions_it_holds() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        function.add_op(Add, &[x, x]).unwrap();
+        let second = function.add_op(Add, &[x, x]).unwrap()[0];
+        function.add_result(second).unwrap();
+
+        // An instruction has no name of its own, so the shape of a built function is pinned by
+        // counting instructions per type rather than by looking one up.
+        assert_eq!(
+            function
+                .iter_instructions()
+                .filter(|instruction| instruction.full_name() == "qiskit.add")
+                .count(),
+            2
+        );
+        // Boundary instructions are instructions, so they are counted too: one parameter, two adds,
+        // one result.
+        assert_eq!(function.instruction_count(), 4);
+
+        let add = function
+            .iter_instructions()
+            .find(|instruction| instruction.name() == "add")
+            .unwrap();
+        assert_eq!(add.role(), InstructionRole::Op);
+        assert_eq!(add.operands(), &[x, x]);
+        assert_eq!(add.outputs().count(), 1);
+        assert!(add.has_builtin_eval());
+    }
+
+    #[test]
+    fn a_functions_boundary_is_made_of_instructions() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        let sum = function.add_op(Add, &[x, x]).unwrap()[0];
+        function.add_result(sum).unwrap();
+
+        let roles: Vec<InstructionRole> = function
+            .iter_instructions()
+            .map(|instruction| instruction.role())
+            .collect();
+        assert_eq!(
+            roles,
+            vec![
+                InstructionRole::Parameter,
+                InstructionRole::Op,
+                InstructionRole::Result
+            ]
+        );
+
+        // A boundary instruction is named like any other, so a consumer matching on type names sees
+        // it.
+        let names: Vec<String> = function
+            .iter_instructions()
+            .map(|instruction| instruction.full_name())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["qiskit.parameter", "qiskit.add", "qiskit.result"]
+        );
+
+        // A parameter produces its value and consumes nothing; a result is the other way
+        // round.
+        let parameter = function.instruction(function.parameters()[0]).unwrap();
+        assert!(parameter.operands().is_empty());
+        assert_eq!(parameter.output_types(), &[f64_1d(2)]);
+
+        let result = function.instruction(function.results()[0]).unwrap();
+        assert_eq!(result.operands(), &[sum]);
+        assert!(result.output_types().is_empty());
+    }
+
+    #[test]
+    fn a_value_names_the_instruction_and_slot_that_produced_it() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        let sum = function.add_op(Add, &[x, x]).unwrap()[0];
+
+        assert_eq!(x.instruction(), function.parameters()[0]);
+        assert_eq!(x.slot(), 0);
+        assert_eq!(
+            sum.instruction().index(),
+            1,
+            "the add is the second instruction"
+        );
+        assert_eq!(sum.to_string(), "%1");
+
+        // An operand's type is read through the instruction that produced it rather than stored
+        // twice.
+        let add = function.instruction(sum.instruction()).unwrap();
+        assert_eq!(
+            add.operand_types().collect::<Vec<_>>(),
+            vec![&f64_1d(2), &f64_1d(2)]
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Build-time rejections
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn the_wrong_operand_count_is_rejected() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(1));
+
+        let Err(err) = function.add_op(Add, &[x]) else {
+            panic!("a one-operand add is rejected")
+        };
+        assert_eq!(err.to_string(), "qiskit.add takes 2 operand(s), got 1");
+    }
+
+    #[test]
+    fn an_unknown_operand_is_rejected_naming_its_position() {
+        let mut known = ProgramFunction::new();
+        let x = known.add_parameter(f64_1d(1));
+
+        // A value is only meaningful within the function that issued it, so one from elsewhere is
+        // simply unknown here.
+        let mut other = ProgramFunction::new();
+        other.add_parameter(f64_1d(1));
+        let stranger = other.add_parameter(f64_1d(1));
+
+        let Err(err) = known.add_op(Add, &[x, stranger]) else {
+            panic!("an operand from another function is rejected")
+        };
+        assert_eq!(
+            err.to_string(),
+            "operand 1: %1 was not produced by this function"
+        );
+    }
+
+    #[test]
+    fn an_unknown_result_is_rejected() {
+        let mut known = ProgramFunction::new();
+        let mut other = ProgramFunction::new();
+        let stranger = other.add_parameter(f64_1d(1));
+
+        let Err(err) = known.add_result(stranger) else {
+            panic!("a result from another function is rejected")
+        };
+        assert!(matches!(err, FunctionError::UnknownValue(value) if value == stranger));
+    }
+
+    #[test]
+    fn a_rejected_operand_type_is_reported_when_the_instruction_is_added() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(3));
+        let y = function.add_parameter(f64_1d(4));
+
+        let Err(err) = function.add_op(Add, &[x, y]) else {
+            panic!("shapes that do not broadcast are rejected")
+        };
+        let FunctionError::TypeError { full_name, source } = &err else {
+            panic!("expected a type error, got {err}")
+        };
+        assert_eq!(full_name, "qiskit.add", "the op is named");
+        assert_eq!(
+            source.to_string(),
+            "shapes [3] and [4] are not broadcast-compatible",
+            "both operand shapes are named"
+        );
+    }
+
+    #[test]
+    fn a_dtype_the_instruction_cannot_compute_is_rejected_when_the_instruction_is_added() {
+        // An instruction accepts only the dtypes its implementation covers, so a function that
+        // type-checks cannot then fail on a dtype as it runs.
+        let mut function = ProgramFunction::new();
+        let bit = function.add_parameter(TensorType {
+            dtype: DType::Bit,
+            shape: vec![Dim::Fixed(2)],
+        });
+
+        let Err(err) = function.add_op(Add, &[bit, bit]) else {
+            panic!("`add` has no Bit implementation, so a Bit operand is rejected")
+        };
+        let FunctionError::TypeError { source, .. } = &err else {
+            panic!("expected a type error, got {err}")
+        };
+        assert_eq!(
+            source.to_string(),
+            "operands of dtype Bit and Bit promote to Bit, which is not supported"
+        );
+    }
+
+    #[test]
+    fn a_reduction_out_of_bounds_axis_is_reported_when_the_instruction_is_added() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(3));
+
+        let Err(err) = function.add_op(Mean::new(1), &[x]) else {
+            panic!("an out-of-bounds axis is rejected")
+        };
+        let FunctionError::TypeError { source, .. } = &err else {
+            panic!("expected a type error, got {err}")
+        };
+        assert_eq!(
+            source.to_string(),
+            "axis 1 is out of bounds for tensor with 1 dimension(s)"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Coercion
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn arithmetic_promotes_its_operand_dtypes() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(3));
+        let y = function.add_parameter(TensorType {
+            dtype: DType::F32,
+            shape: vec![Dim::Fixed(3)],
+        });
+        let sum = function.add_op(Add, &[x, y]).unwrap()[0];
+        function.add_result(sum).unwrap();
+
+        assert_eq!(
+            function.type_of(sum),
+            Some(&f64_1d(3)),
+            "F32 and F64 promote to F64"
+        );
+        assert_eq!(
+            function
+                .eval(&[
+                    Tensor::from([1.0_f64, 2.0, 3.0]),
+                    Tensor::from([10.0_f32, 20.0, 30.0]),
+                ])
+                .unwrap(),
+            vec![Tensor::from([11.0_f64, 22.0, 33.0])]
+        );
+    }
+
+    #[test]
+    fn arithmetic_broadcasts_its_operand_shapes() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(3));
+        let y = function.add_parameter(f64_1d(1));
+        let sum = function.add_op(Add, &[x, y]).unwrap()[0];
+        function.add_result(sum).unwrap();
+
+        assert_eq!(function.type_of(sum), Some(&f64_1d(3)));
+        assert_eq!(
+            function
+                .eval(&[Tensor::from([1.0_f64, 2.0, 3.0]), Tensor::from([10.0_f64])])
+                .unwrap(),
+            vec![Tensor::from([11.0_f64, 12.0, 13.0])]
+        );
+    }
+
+    #[test]
+    fn averaging_a_bit_tensor_yields_a_float() {
+        // The flagship post-processing step: shots come back as bits and a mean of them is a
+        // probability. A global promotion rule could not express this, so it is the reduce family's.
+        let mut function = ProgramFunction::new();
+        let shots = function.add_parameter(TensorType {
+            dtype: DType::Bit,
+            shape: vec![Dim::Fixed(4)],
+        });
+        let mean = function.add_op(Mean::new(0), &[shots]).unwrap()[0];
+        function.add_result(mean).unwrap();
+
+        assert_eq!(
+            function.type_of(mean),
+            Some(&TensorType {
+                dtype: DType::F64,
+                shape: vec![],
+            })
+        );
+        let results = function
+            .eval(&[Tensor::from([1_u8, 0, 1, 1]).cast(DType::Bit)])
+            .unwrap();
+        let [Tensor::F64(mean)] = &results[..] else {
+            panic!("expected one F64 result, got {results:?}")
+        };
+        assert_eq!(mean.iter().copied().collect::<Vec<f64>>(), vec![0.75]);
+    }
+
+    #[test]
+    fn two_bounded_axes_cannot_be_combined() {
+        // Nothing proves their true sizes agree, and the sizes post-selection produces are
+        // exponentially unlikely to. Refusing here beats a shape error after the data was paid for.
+        let bounded = TensorType {
+            dtype: DType::F64,
+            shape: vec![Dim::Bounded { max: 8 }],
+        };
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(bounded.clone());
+        let y = function.add_parameter(bounded);
+
+        let Err(err) = function.add_op(Add, &[x, y]) else {
+            panic!("two bounded axes cannot be paired up")
+        };
+        let FunctionError::TypeError { source, .. } = &err else {
+            panic!("expected a type error, got {err}")
+        };
+        assert_eq!(
+            source.to_string(),
+            "shape [<=8] has an axis whose size is only bounded above, where a true size is required"
+        );
+    }
+
+    #[test]
+    fn a_bounded_axis_broadcasts_against_a_fixed_one() {
+        // Post-selected data against a per-register constant is what bounded dynamism is for.
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(TensorType {
+            dtype: DType::F64,
+            shape: vec![Dim::Bounded { max: 8 }, Dim::Fixed(2)],
+        });
+        let y = function.add_parameter(f64_1d(2));
+        let scaled = function.add_op(Add, &[x, y]).unwrap()[0];
+
+        assert_eq!(
+            function.type_of(scaled),
+            Some(&TensorType {
+                dtype: DType::F64,
+                shape: vec![Dim::Bounded { max: 8 }, Dim::Fixed(2)],
+            })
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Evaluation-time rejections
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn the_wrong_argument_count_is_rejected() {
+        let mut function = ProgramFunction::new();
+        function.add_parameter(f64_1d(1));
+        function.add_parameter(f64_1d(1));
+
+        let Err(err) = function.eval(&[Tensor::from([1.0_f64])]) else {
+            panic!("one argument for two parameters is rejected")
+        };
+        assert_eq!(err.to_string(), "expected 2 argument(s), got 1");
+    }
+
+    #[test]
+    fn an_argument_of_the_wrong_type_is_rejected_naming_both_types() {
+        let mut function = ProgramFunction::new();
+        function.add_parameter(f64_1d(3));
+
+        let Err(err) = function.eval(&[Tensor::from([1.0_f64, 2.0])]) else {
+            panic!("an argument of the wrong shape is rejected")
+        };
+        assert_eq!(
+            err.to_string(),
+            "argument 0: expected F64[3], got F64[2]",
+            "both the declared and the supplied type are named"
+        );
+    }
+
+    #[test]
+    fn a_bounded_parameter_admits_any_argument_within_its_bound() {
+        // A declared type constrains an argument rather than equalling it, so a bounded axis is
+        // usable: an argument shorter than the bound is what a bounded axis is for.
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(TensorType {
+            dtype: DType::F64,
+            shape: vec![Dim::Bounded { max: 4 }],
+        });
+        let doubled = function.add_op(Elsewhere, &[x]).unwrap()[0];
+        function.add_result(doubled).unwrap();
+
+        // `Elsewhere` has no built-in implementation, so evaluation stops at the locality check, which
+        // is past the argument check under test here.
+        for len in 0..=4 {
+            let arg = Tensor::from(vec![1.0_f64; len].as_slice());
+            assert!(
+                matches!(
+                    function.eval(&[arg]),
+                    Err(FunctionEvalError::NoBuiltinEval { .. })
+                ),
+                "an argument of length {len} is within the bound of 4"
+            );
+        }
+
+        let Err(err) = function.eval(&[Tensor::from([1.0_f64; 5])]) else {
+            panic!("an argument past the bound is rejected")
+        };
+        assert_eq!(err.to_string(), "argument 0: expected F64[<=4], got F64[5]");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Locality
+    // ---------------------------------------------------------------------------
+
+    /// An op defined outside the crate, in its own namespace, with no in-process
+    /// implementation — which is how a backend contributes work Qiskit cannot perform itself.
+    #[derive(Clone)]
+    struct Elsewhere;
+
+    /// The error [`Elsewhere`] returns when asked to evaluate itself.
+    #[derive(Debug)]
+    struct NoImplementation;
+
+    impl fmt::Display for NoImplementation {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "vendor.elsewhere has no in-process implementation")
+        }
+    }
+
+    impl std::error::Error for NoImplementation {}
+
+    impl ProgramOp for Elsewhere {
+        type Error = NoImplementation;
+
+        fn name(&self) -> &str {
+            "elsewhere"
+        }
+
+        fn namespace(&self) -> &str {
+            "vendor"
+        }
+
+        fn arity(&self) -> usize {
+            1
+        }
+
+        fn has_builtin_eval(&self) -> bool {
+            false
+        }
+
+        fn infer_output_types(
+            &self,
+            inputs: &[TensorType],
+        ) -> Result<Vec<TensorType>, Self::Error> {
+            Ok(vec![inputs[0].clone()])
+        }
+
+        fn eval(&self, _args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
+            Err(NoImplementation)
+        }
+    }
+
+    #[test]
+    fn a_function_of_built_in_instructions_is_locally_evaluable() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(1));
+        assert!(
+            function.has_builtin_eval(),
+            "an empty function has nothing that cannot run"
+        );
+        function.add_op(Add, &[x, x]).unwrap();
+        assert!(function.has_builtin_eval());
+    }
+
+    #[test]
+    fn one_instruction_without_a_built_in_implementation_makes_the_function_not_locally_evaluable()
+    {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(1));
+        let out = function.add_op(Elsewhere, &[x]).unwrap()[0];
+        function.add_result(out).unwrap();
+
+        assert!(!function.has_builtin_eval());
+
+        let Err(err) = function.eval(&[Tensor::from([1.0_f64])]) else {
+            panic!("a function with no built-in implementation cannot be evaluated")
+        };
+        let FunctionEvalError::NoBuiltinEval {
+            instruction,
+            full_name,
+        } = &err
+        else {
+            panic!("expected a locality error, got {err}")
+        };
+        assert_eq!(
+            *instruction,
+            out.instruction(),
+            "the offending instruction is named"
+        );
+        assert_eq!(full_name, "vendor.elsewhere");
+    }
+
+    #[test]
+    fn an_instruction_defined_outside_the_crate_is_type_checked_like_any_other() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(4));
+        let out = function.add_op(Elsewhere, &[x]).unwrap()[0];
+
+        assert_eq!(function.type_of(out), Some(&f64_1d(4)));
+
+        let Err(err) = function.add_op(Elsewhere, &[x, x]) else {
+            panic!("a two-operand call to a unary instruction is rejected")
+        };
+        assert_eq!(
+            err.to_string(),
+            "vendor.elsewhere takes 1 operand(s), got 2"
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the concept of `ProgramFunction` to the providers crate.
A program function is a list of instructions and a manifest of which 
instructions correspond to parameters/inputs of the function, and 
which correspond to results/outputs.

An instruction has one of four types of body:
 1. an operation, as defined by the `ProgramOp` trait
 2. a call to another function (not implemented in this PR, but in #16931)
 3. an input specification to the function
 4. a result specification of the function

Each instruction owns operands as  `Vec<Value>`, where a value is a tuple referencing a previous instruction and one of its output slots. An instruction also contains a `Vec<TensorType>` 
specifying all of its outputs. Instructions are type checked at insertion time: it should not be possible to add an instruction that has invalid arity wrt to its operands, or have operands 
whose types are not acceptable to the operation of the instruction.

Quantum functions have SSA discipline: every value is defined exactly once, and every use refers unambiguously to a single definition. Def-use chains are easy to construct.

We require type erasure to place instances of different implementers of the op trait in the same vec: this PR adds those type erasures as well.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: claude opus 5

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>