### PR TITLE
Add some macro helpers for `ProgramOp`

### DIFF
--- a/crates/providers/src/ops/binary.rs
+++ b/crates/providers/src/ops/binary.rs
@@ -48,23 +48,11 @@ macro_rules! elementwise_binary_op {
                 &self,
                 inputs: &[TensorType],
             ) -> Result<Vec<TensorType>, Self::Error> {
-                let [x, y] = inputs else {
-                    panic!(
-                        "{} expects 2 operands, got {}",
-                        self.full_name(),
-                        inputs.len()
-                    )
-                };
+                crate::unpack_operands!(self, inputs, [x, y]);
                 Ok(vec![elementwise_binary(x, y, $accepts)?])
             }
             fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-                let [x, y] = args else {
-                    panic!(
-                        "{} expects 2 operands, got {}",
-                        self.full_name(),
-                        args.len()
-                    )
-                };
+                crate::unpack_operands!(self, args, [x, y]);
                 // Coerce to the dtype inference promised, so that the tensors agree with the type
                 // the op was given when it was added. A cast to the dtype a tensor already has
                 // is free.

--- a/crates/providers/src/ops/bitwise.rs
+++ b/crates/providers/src/ops/bitwise.rs
@@ -50,23 +50,11 @@ macro_rules! bitwise_binary_op {
                 &self,
                 inputs: &[TensorType],
             ) -> Result<Vec<TensorType>, Self::Error> {
-                let [x, y] = inputs else {
-                    panic!(
-                        "{} expects 2 operands, got {}",
-                        self.full_name(),
-                        inputs.len()
-                    )
-                };
+                crate::unpack_operands!(self, inputs, [x, y]);
                 Ok(vec![elementwise_binary(x, y, is_bit)?])
             }
             fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-                let [x, y] = args else {
-                    panic!(
-                        "{} expects 2 operands, got {}",
-                        self.full_name(),
-                        args.len()
-                    )
-                };
+                crate::unpack_operands!(self, args, [x, y]);
                 check_dtype(0, x.dtype(), DType::Bit)?;
                 check_dtype(1, y.dtype(), DType::Bit)?;
                 Ok(vec![$eval_fn(x, y)?])
@@ -99,19 +87,11 @@ impl ProgramOp for BitwiseNot {
         true
     }
     fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
-        let [x] = inputs else {
-            panic!(
-                "{} expects 1 operand, got {}",
-                self.full_name(),
-                inputs.len()
-            )
-        };
+        crate::unpack_operands!(self, inputs, [x]);
         Ok(vec![elementwise_unary(x, is_bit)?])
     }
     fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-        let [x] = args else {
-            panic!("{} expects 1 operand, got {}", self.full_name(), args.len())
-        };
+        crate::unpack_operands!(self, args, [x]);
         check_dtype(0, x.dtype(), DType::Bit)?;
         let Tensor::Bit(arr) = x else {
             unreachable!("dtype checked above")
@@ -153,20 +133,12 @@ impl ProgramOp for Parity {
         true
     }
     fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
-        let [x] = inputs else {
-            panic!(
-                "{} expects 1 operand, got {}",
-                self.full_name(),
-                inputs.len()
-            )
-        };
+        crate::unpack_operands!(self, inputs, [x]);
         // Folding bits with exclusive-or leaves them bits, so the result dtype is the operand's.
         Ok(vec![reduce(x, self.axis, is_bit, |dtype| dtype)?])
     }
     fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-        let [x] = args else {
-            panic!("{} expects 1 operand, got {}", self.full_name(), args.len())
-        };
+        crate::unpack_operands!(self, args, [x]);
         check_dtype(0, x.dtype(), DType::Bit)?;
         check_axis(self.axis, x.shape().len())?;
         let Tensor::Bit(arr) = x else {

--- a/crates/providers/src/ops/program_op.rs
+++ b/crates/providers/src/ops/program_op.rs
@@ -17,6 +17,26 @@ use crate::tensor::{Tensor, TensorType};
 /// The [`ProgramOp::namespace`] of every op Qiskit defines.
 pub const QISKIT: &str = "qiskit";
 
+/// Destructure an op's operands into one binding each, panicking if the count is wrong.
+///
+/// The panic should be unreachable when the op is part of a
+/// [`ProgramFunction`](crate::ProgramFunction), because static analysis is done while inserting
+/// ops.
+#[macro_export]
+macro_rules! unpack_operands {
+    ($op:expr, $operands:expr, [$($name:ident),+ $(,)?]) => {
+        let operands = $operands;
+        let [$($name),+] = operands else {
+            panic!(
+                "{} expects {} operand(s), got {}",
+                $op.full_name(),
+                $op.arity(),
+                operands.len()
+            )
+        };
+    };
+}
+
 /// An atomic operation in a quantum program: a typed mapping from tensors to tensors.
 ///
 /// An op declares how many operands it takes ([`Self::arity`]) and how to derive its result types
@@ -184,4 +204,16 @@ where
     }
 
     Box::new(Erased(op))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ops::{Add, ProgramOp};
+    use crate::tensor::Tensor;
+
+    #[test]
+    #[should_panic(expected = "qiskit.add expects 2 operand(s), got 1")]
+    fn test_unpack_operands_names_the_op_and_the_arity_it_declares() {
+        let _ = Add.eval(&[Tensor::from([1.0_f64])]);
+    }
 }

--- a/crates/providers/src/ops/reduction.rs
+++ b/crates/providers/src/ops/reduction.rs
@@ -109,6 +109,45 @@ where
     }
 }
 
+/// Generate the [`ProgramOp`] implementation for a reduction along one axis.
+///
+/// Each reduction takes one operand, accepts every dtype, and folds along `self.axis`. They differ
+/// only in the dtype they produce and in the fold itself, so each op supplies `$result_dtype` and
+/// an inherent `fn reduce_axis(&self, x: &Tensor) -> Tensor`. `reduce_axis` may assume `self.axis`
+/// is in bounds for `x`.
+macro_rules! reduction_op {
+    ($name:ident, $op_name:literal, $result_dtype:expr) => {
+        impl ProgramOp for $name {
+            type Error = MathOpError;
+
+            fn name(&self) -> &str {
+                $op_name
+            }
+            fn namespace(&self) -> &str {
+                QISKIT
+            }
+            fn arity(&self) -> usize {
+                1
+            }
+            fn has_builtin_eval(&self) -> bool {
+                true
+            }
+            fn infer_output_types(
+                &self,
+                inputs: &[TensorType],
+            ) -> Result<Vec<TensorType>, Self::Error> {
+                crate::unpack_operands!(self, inputs, [x]);
+                Ok(vec![reduce(x, self.axis, any, $result_dtype)?])
+            }
+            fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
+                crate::unpack_operands!(self, args, [x]);
+                check_axis(self.axis, x.shape().len())?;
+                Ok(vec![self.reduce_axis(x)])
+            }
+        }
+    };
+}
+
 /// Mean of a tensor along a specified axis, removing that axis.
 ///
 /// Integer inputs are cast to `F64` before computing the mean. `F32` inputs
@@ -129,43 +168,14 @@ impl Mean {
     pub fn new(axis: usize) -> Self {
         Self { axis }
     }
-}
 
-impl ProgramOp for Mean {
-    type Error = MathOpError;
-
-    fn name(&self) -> &str {
-        "mean"
-    }
-    fn namespace(&self) -> &str {
-        QISKIT
-    }
-    fn arity(&self) -> usize {
-        1
-    }
-    fn has_builtin_eval(&self) -> bool {
-        true
-    }
-    fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
-        let [x] = inputs else {
-            panic!(
-                "{} expects 1 operand, got {}",
-                self.full_name(),
-                inputs.len()
-            )
-        };
-        Ok(vec![reduce(x, self.axis, any, mean_out_dtype)?])
-    }
-    fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-        let [x] = args else {
-            panic!("{} expects 1 operand, got {}", self.full_name(), args.len())
-        };
-        check_axis(self.axis, x.shape().len())?;
+    /// The mean of `x` along `self.axis`, which must be in bounds for `x`.
+    fn reduce_axis(&self, x: &Tensor) -> Tensor {
         // Every arm divides a sum by the reduced axis's length, which is what `ndarray::mean_axis`
         // computes, except that `mean_axis` returns `None` for a zero-length axis rather than
         // dividing by zero. See the degenerate-divisor convention on `Mean`.
         let n = x.shape()[self.axis];
-        let result = match x {
+        match x {
             Tensor::F32(a) => Tensor::F32((a.sum_axis(Axis(self.axis)) / n as f32).into_shared()),
             Tensor::F64(a) => Tensor::F64((a.sum_axis(Axis(self.axis)) / n as f64).into_shared()),
             Tensor::C64(a) => Tensor::C64(
@@ -180,10 +190,11 @@ impl ProgramOp for Mean {
                 };
                 Tensor::F64((a.sum_axis(Axis(self.axis)) / n as f64).into_shared())
             }
-        };
-        Ok(vec![result])
+        }
     }
 }
+
+reduction_op!(Mean, "mean", mean_out_dtype);
 
 /// Variance of a tensor along a specified axis, removing that axis.
 ///
@@ -206,47 +217,11 @@ impl Variance {
     pub fn new(axis: usize, ddof: f64) -> Self {
         Self { axis, ddof }
     }
-}
 
-impl ProgramOp for Variance {
-    type Error = MathOpError;
-
-    fn name(&self) -> &str {
-        "variance"
-    }
-    fn namespace(&self) -> &str {
-        QISKIT
-    }
-    fn arity(&self) -> usize {
-        1
-    }
-    fn has_builtin_eval(&self) -> bool {
-        true
-    }
-    fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
-        let [x] = inputs else {
-            panic!(
-                "{} expects 1 operand, got {}",
-                self.full_name(),
-                inputs.len()
-            )
-        };
-        Ok(vec![reduce(x, self.axis, any, real_out_dtype)?])
-    }
-    fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-        let [x] = args else {
-            panic!("{} expects 1 operand, got {}", self.full_name(), args.len())
-        };
-        check_axis(self.axis, x.shape().len())?;
-        Ok(vec![self.variance(x)])
-    }
-}
-
-impl Variance {
     /// The variance of `x` along `self.axis`, which [`Std`] takes the square root of.
     ///
     /// `self.axis` must be in bounds for `x`.
-    fn variance(&self, x: &Tensor) -> Tensor {
+    fn reduce_axis(&self, x: &Tensor) -> Tensor {
         match x {
             Tensor::F32(a) => {
                 let (n, ddof) = (a.shape()[self.axis] as f32, self.ddof as f32);
@@ -277,6 +252,8 @@ impl Variance {
     }
 }
 
+reduction_op!(Variance, "variance", real_out_dtype);
+
 /// Standard deviation of a tensor along a specified axis, removing that axis.
 ///
 /// This is the square root of [`Variance`]. See that type for details on `ddof`,
@@ -293,46 +270,18 @@ impl Std {
     pub fn new(axis: usize, ddof: f64) -> Self {
         Self { axis, ddof }
     }
-}
 
-impl ProgramOp for Std {
-    type Error = MathOpError;
-
-    fn name(&self) -> &str {
-        "std"
-    }
-    fn namespace(&self) -> &str {
-        QISKIT
-    }
-    fn arity(&self) -> usize {
-        1
-    }
-    fn has_builtin_eval(&self) -> bool {
-        true
-    }
-    fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
-        let [x] = inputs else {
-            panic!(
-                "{} expects 1 operand, got {}",
-                self.full_name(),
-                inputs.len()
-            )
-        };
-        Ok(vec![reduce(x, self.axis, any, real_out_dtype)?])
-    }
-    fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
-        let [x] = args else {
-            panic!("{} expects 1 operand, got {}", self.full_name(), args.len())
-        };
-        check_axis(self.axis, x.shape().len())?;
-        let result = match Variance::new(self.axis, self.ddof).variance(x) {
+    /// The standard deviation of `x` along `self.axis`, which must be in bounds for `x`.
+    fn reduce_axis(&self, x: &Tensor) -> Tensor {
+        match Variance::new(self.axis, self.ddof).reduce_axis(x) {
             Tensor::F32(v) => Tensor::F32(v.mapv(f32::sqrt).into_shared()),
             Tensor::F64(v) => Tensor::F64(v.mapv(f64::sqrt).into_shared()),
             other => unreachable!("a variance is real, got {:?}", other.dtype()),
-        };
-        Ok(vec![result])
+        }
     }
 }
+
+reduction_op!(Std, "std", real_out_dtype);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR adds a macro for unpacking operands that is generic enough for a bunch of 
nodes to use. It also adds a macro to help implement op nodes that perform reduction
along an axis, like `Mean`.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: claude opus 5

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>