### PR TITLE
Emit opaque structs before unions in generated _ctypes.py

### DIFF
--- a/crates/bindgen/src/render/ctypes.rs
+++ b/crates/bindgen/src/render/ctypes.rs
@@ -470,10 +470,15 @@ mod export {
         for item in &items.enums {
             writeln!(out, "{}", r#enum(item))?;
         }
+        // Python executes the file top to bottom, so each declaration must precede its first use: opaque
+        // structs depend on nothing, unions may point to them, and structs may hold a union by value.
+        for item in items.structs.iter().filter(|item| item.fields.is_none()) {
+            writeln!(out, "{}", r#struct(item))?;
+        }
         for item in &items.unions {
             writeln!(out, "{}", r#union(item))?;
         }
-        for item in &items.structs {
+        for item in items.structs.iter().filter(|item| item.fields.is_some()) {
             writeln!(out, "{}", r#struct(item))?;
         }
         for item in &items.functions {


### PR DESCRIPTION
Unions may reference opaque types, which were emitted after them during _ctypes.py generation, which is breaking the import.
As an improvement to the current situation, opaque structures are now declared before unions. So the current order is as follows:
enums -> opaque structs -> unions -> fully defined structs

Notice that the current fix doesn't solve all the possible "broken _ctypes dependencies" issues, just improves the current situation.


 Fix #16886
### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by Claude Opus:
- [ ] Some submitted code was generated by:
