### PR TITLE
Warn of `synthesis` nuance for `PauliEvolutionGate`

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -102,7 +102,7 @@ class PauliEvolutionGate(Gate):
     .. warning::
 
         The ``synthesis`` argument exists for backwards compatibility. The transpiler may silently
-        invalidate the chosen synthesis strategy.
+        invalidate the chosen synthesis strategy during optimization.
 
     References:
 

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -101,8 +101,8 @@ class PauliEvolutionGate(Gate):
 
     .. warning::
 
-        The ``synthesis`` argument exists for backwards compatibility. The transpiler may silently
-        invalidate the chosen synthesis strategy during optimization.
+        The transpiler might silently drop the ``synthesis`` strategy during optimization,
+        for example, if two Pauli evolution gates are merged.
 
     References:
 

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -99,6 +99,10 @@ class PauliEvolutionGate(Gate):
         q_1: ┤1                         ├
              └──────────────────────────┘
 
+    .. warning::
+
+        The ``synthesis`` argument exists for backwards compatibility. The transpiler may silently
+        invalidate the chosen synthesis strategy.
 
     References:
 
@@ -131,12 +135,6 @@ class PauliEvolutionGate(Gate):
                 class docstring for an example.
             synthesis: A synthesis strategy. If None, the default synthesis is the Lie-Trotter
                 product formula with a single repetition.
-
-        .. warning::
-
-        This class is the mathematical Pauli Evolution operation. Thus, the `synthesis` argument
-        exists for backwards compatibility only. The transpiler may silently invalidate a chosen
-        synthesis strategy.
         """
 
         if isinstance(operator, list):

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -136,7 +136,6 @@ class PauliEvolutionGate(Gate):
             synthesis: A synthesis strategy. If None, the default synthesis is the Lie-Trotter
                 product formula with a single repetition.
         """
-
         if isinstance(operator, list):
             operator = [_to_sparse_op(op) for op in operator]
         else:

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -131,7 +131,14 @@ class PauliEvolutionGate(Gate):
                 class docstring for an example.
             synthesis: A synthesis strategy. If None, the default synthesis is the Lie-Trotter
                 product formula with a single repetition.
+
+        .. warning::
+
+        This class is the mathematical Pauli Evolution operation. Thus, the `synthesis` argument
+        exists for backwards compatibility only. The transpiler may silently invalidate a chosen
+        synthesis strategy.
         """
+
         if isinstance(operator, list):
             operator = [_to_sparse_op(op) for op in operator]
         else:


### PR DESCRIPTION
`PauliEvolutionGate` is the abstract, mathematical Pauli Evolution operation. The existence of the `synthesis` argument muddies this definition.

In theory, you could return `None` in `_merge_two_pauli_evolutions` if synthesis compatibility were detectable. However, this is not possible with the current model.

1. If you check the type with `type(self.synthesis) is type(other.synthesis)`, you may mistakenly say two concrete implementations with different values are compatible.
2. If you check the object with `self.synthesis is other.synthesis`, you could only detect compatibility if the caller binds their strategy before re-using it. This clearly leads to false negatives in `_merge_two_pauli_evolutions`.
3. `EvolutionSynthesis` does not require `__eq__`, so the values inside two `EvolutionSynthesis` instances are not comparable.

I discussed this with @mtreinish. We both agree that the solution here is to document the nuance that the transpiler may silently drop the synthesis strategy if two `PauliEvolutionGate` are merged.
 
closes #16871 

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:
