### PR TITLE
Add call nodes to QuantumFunction

### DIFF
--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -35,5 +35,6 @@ pub use data_tree::{ArityMismatch, DataTree, InvalidName, Name, PathEntry, TreeM
 pub use ops::{BoxedOpError, BoxedProgramOp, Constant, ErasedProgramOp, ProgramOp};
 pub use program::{
     FunctionError, FunctionEvalError, FunctionId, InstructionId, InstructionRef, InstructionRole,
-    ProgramError, ProgramEvalError, ProgramFunction, QuantumProgram, Signature, Value,
+    InstructionView, ProgramError, ProgramEvalError, ProgramFunction, QuantumProgram, Signature,
+    Value,
 };

--- a/crates/providers/src/program/mod.rs
+++ b/crates/providers/src/program/mod.rs
@@ -18,6 +18,6 @@ mod quantum_program;
 
 pub use program_function::{
     FunctionError, FunctionEvalError, InstructionId, InstructionRef, InstructionRole,
-    ProgramFunction, Signature, Value,
+    InstructionView, ProgramFunction, Signature, Value,
 };
 pub use quantum_program::{FunctionId, ProgramError, ProgramEvalError, QuantumProgram};

--- a/crates/providers/src/program/program_function.rs
+++ b/crates/providers/src/program/program_function.rs
@@ -14,7 +14,8 @@ use std::fmt;
 
 use thiserror::Error;
 
-use crate::ops::{BoxedOpError, BoxedProgramOp, ProgramOp, QISKIT, erase};
+use super::quantum_program::FunctionId;
+use crate::ops::{BoxedOpError, BoxedProgramOp, ErasedProgramOp, ProgramOp, QISKIT, erase};
 use crate::tensor::{Tensor, TensorType};
 
 /// A position within one instruction's ordered operands or results.
@@ -77,8 +78,85 @@ pub enum InstructionRole {
     Parameter,
     /// An operation, with a [`ProgramOp`].
     Op,
+    /// A call to another function of the same program.
+    Call,
     /// A function output.
     Result,
+}
+
+/// What an instruction is, and what it holds.
+///
+/// An instruction has a [`ProgramOp`] only in the [`Op`](Self::Op) case and a callee only in the
+/// [`Call`](Self::Call) case, so this answers what [`InstructionRole`] answers and hands over the
+/// payload as well.
+#[derive(Clone, Copy)]
+pub enum InstructionView<'a> {
+    /// A function input, supplied by the caller.
+    Parameter,
+    /// An operation applying this op.
+    Op(&'a (dyn ErasedProgramOp + 'static)),
+    /// A call to this function of the same program.
+    Call(FunctionId),
+    /// A function output.
+    Result,
+}
+
+impl<'a> InstructionView<'a> {
+    /// What part the instruction plays, without its payload.
+    pub fn role(self) -> InstructionRole {
+        match self {
+            Self::Parameter => InstructionRole::Parameter,
+            Self::Op(_) => InstructionRole::Op,
+            Self::Call(_) => InstructionRole::Call,
+            Self::Result => InstructionRole::Result,
+        }
+    }
+
+    fn name(self) -> &'a str {
+        match self {
+            Self::Parameter => "parameter",
+            Self::Op(op) => op.name(),
+            Self::Call(_) => "call",
+            Self::Result => "result",
+        }
+    }
+
+    fn namespace(self) -> &'a str {
+        match self {
+            Self::Parameter | Self::Call(_) | Self::Result => QISKIT,
+            Self::Op(op) => op.namespace(),
+        }
+    }
+
+    fn full_name(self) -> String {
+        match self {
+            Self::Parameter | Self::Call(_) | Self::Result => {
+                format!("{}.{}", self.namespace(), self.name())
+            }
+            Self::Op(op) => op.full_name(),
+        }
+    }
+
+    /// How many operands the instruction takes, or `None` when only the callee settles that. A call
+    /// takes one operand per parameter of the function it names.
+    fn arity(self) -> Option<usize> {
+        match self {
+            Self::Parameter => Some(0),
+            Self::Op(op) => Some(op.arity()),
+            Self::Call(_) => None,
+            Self::Result => Some(1),
+        }
+    }
+
+    fn has_builtin_eval(self) -> bool {
+        match self {
+            Self::Parameter | Self::Result => true,
+            Self::Op(op) => op.has_builtin_eval(),
+            // A call is evaluated by the program holding its callee, so a function that contains
+            // one cannot be evaluated on its own.
+            Self::Call(_) => false,
+        }
+    }
 }
 
 /// The types a function consumes and produces, positionally.
@@ -94,52 +172,18 @@ pub struct Signature {
 enum InstructionBody {
     Parameter,
     Op(BoxedProgramOp),
+    Call(FunctionId),
     Result,
 }
 
 impl InstructionBody {
-    fn name(&self) -> &str {
+    /// What this instruction is, and what it holds.
+    fn view(&self) -> InstructionView<'_> {
         match self {
-            Self::Parameter => "parameter",
-            Self::Op(op) => op.name(),
-            Self::Result => "result",
-        }
-    }
-
-    fn namespace(&self) -> &str {
-        match self {
-            Self::Parameter | Self::Result => QISKIT,
-            Self::Op(op) => op.namespace(),
-        }
-    }
-
-    fn full_name(&self) -> String {
-        match self {
-            Self::Parameter | Self::Result => format!("{}.{}", self.namespace(), self.name()),
-            Self::Op(op) => op.full_name(),
-        }
-    }
-
-    fn role(&self) -> InstructionRole {
-        match self {
-            Self::Parameter => InstructionRole::Parameter,
-            Self::Op(_) => InstructionRole::Op,
-            Self::Result => InstructionRole::Result,
-        }
-    }
-
-    fn arity(&self) -> usize {
-        match self {
-            Self::Parameter => 0,
-            Self::Op(op) => op.arity(),
-            Self::Result => 1,
-        }
-    }
-
-    fn has_builtin_eval(&self) -> bool {
-        match self {
-            Self::Parameter | Self::Result => true,
-            Self::Op(op) => op.has_builtin_eval(),
+            Self::Parameter => InstructionView::Parameter,
+            Self::Op(op) => InstructionView::Op(&**op),
+            Self::Call(callee) => InstructionView::Call(*callee),
+            Self::Result => InstructionView::Result,
         }
     }
 }
@@ -148,7 +192,7 @@ impl InstructionBody {
 struct ProgramInstruction {
     body: InstructionBody,
     /// The values this instruction consumes, in operand order. There are always
-    /// [`InstructionBody::arity`] of them, so a half-wired instruction cannot be represented, and
+    /// [`InstructionView::arity`] of them, so a half-wired instruction cannot be represented, and
     /// this is the only record of how the function is connected.
     operands: Vec<Value>,
     /// The types inference produced for this instruction's results, one per result.
@@ -177,29 +221,34 @@ impl<'a> InstructionRef<'a> {
 
     /// What part this instruction plays: an operation, or one end of the function's boundary.
     pub fn role(&self) -> InstructionRole {
-        self.instruction().body.role()
+        self.view().role()
     }
 
     /// This instruction's type name within its namespace, `add` for instance.
     pub fn name(&self) -> &'a str {
-        self.instruction().body.name()
+        self.view().name()
     }
 
     /// The namespace this instruction's type belongs to, [`QISKIT`](crate::ops::QISKIT) for an op
     /// Qiskit defines.
     pub fn namespace(&self) -> &'a str {
-        self.instruction().body.namespace()
+        self.view().namespace()
     }
 
     /// The name that categorizes this instruction and that a backend dispatches on, `qiskit.add`
     /// for instance. Allocates; [`Self::name`] and [`Self::namespace`] do not.
     pub fn full_name(&self) -> String {
-        self.instruction().body.full_name()
+        self.view().full_name()
     }
 
     /// Whether Qiskit can evaluate this instruction in-process.
     pub fn has_builtin_eval(&self) -> bool {
-        self.instruction().body.has_builtin_eval()
+        self.view().has_builtin_eval()
+    }
+
+    /// What this instruction is, and what it holds.
+    pub fn view(&self) -> InstructionView<'a> {
+        self.instruction().body.view()
     }
 
     /// The values this instruction consumes, in operand order.
@@ -256,6 +305,15 @@ pub enum FunctionError {
         #[source]
         source: BoxedOpError,
     },
+
+    /// An operand of a call does not satisfy the parameter type declared for the callee.
+    #[error("operand {operand} of the call to {callee}: expected {expected}, got {actual}")]
+    CallOperandType {
+        operand: usize,
+        callee: FunctionId,
+        expected: TensorType,
+        actual: TensorType,
+    },
 }
 
 /// Why [`ProgramFunction::eval`] could not produce results.
@@ -290,6 +348,16 @@ pub enum FunctionEvalError {
         source: BoxedOpError,
     },
 
+    /// A function reached through a call instruction failed. The chain of these leads from the
+    /// entry point to the function that could not be evaluated.
+    #[error("evaluating the call at instruction {instruction} to {callee}")]
+    CallFailed {
+        instruction: InstructionId,
+        callee: FunctionId,
+        #[source]
+        source: Box<FunctionEvalError>,
+    },
+
     /// An instruction's `eval` returned a different number of tensors than its type inference
     /// promised when it was added. This is a bug in the instruction; it cannot be caught
     /// statically, because instructions are stored type-erased.
@@ -303,9 +371,10 @@ pub enum FunctionEvalError {
 
 /// A tensor dataflow of instructions.
 ///
-/// Each instruction can have one of three roles:
+/// Each instruction can have one of four roles:
 ///  * parameter: an input to the function specifying exactly one tensor demanded at call time
 ///  * result: an output to the function specifying one tensor the function returns
+///  * call: a call to another function defined in a [`QuantumProgram`](super::QuantumProgram)
 ///  * op: some atomic operation represented as a [`ProgramOp`]
 ///
 /// Each instruction has some number of operands, and an instruction can only be added when values
@@ -316,8 +385,10 @@ pub enum FunctionEvalError {
 ///
 /// Type compatibility of values and the operands of the instructions that act on them is checked
 /// when adding the instruction. This implies that a `ProgramFunction` cannot be malformed by
-/// construction. Also by construction, this data model is SSA compliant and the stored instruction
-/// order is topological with respect to evaluation.
+/// construction. A call instruction is the exception: its contract is checked against the function
+/// it names when a [`QuantumProgram`](super::QuantumProgram) is assembled. Also by construction,
+/// this data model is SSA compliant and the stored instruction order is topological with respect to
+/// evaluation.
 pub struct ProgramFunction {
     /// Every instruction, indexed by [`InstructionId`].
     instructions: Vec<ProgramInstruction>,
@@ -399,6 +470,52 @@ impl ProgramFunction {
             .collect())
     }
 
+    /// Invoke `callee` on `operands`, returning the values it produces in result order.
+    ///
+    /// You must know the eventual function ID within a [`QuantumProgram`](super::QuantumProgram)
+    /// and its signature to call this method. Therefore, this method is most useful to callers who
+    /// are in the process of building a program. One function may be called from any number of
+    /// sites.
+    pub fn add_call(
+        &mut self,
+        callee: FunctionId,
+        signature: &Signature,
+        operands: &[Value],
+    ) -> Result<Vec<Value>, FunctionError> {
+        if operands.len() != signature.inputs.len() {
+            return Err(FunctionError::OperandArity {
+                full_name: InstructionView::Call(callee).full_name(),
+                expected: signature.inputs.len(),
+                actual: operands.len(),
+            });
+        }
+
+        for (operand, (&value, expected)) in operands.iter().zip(&signature.inputs).enumerate() {
+            let Some(actual) = self.type_of(value) else {
+                return Err(FunctionError::UnknownOperand { operand, value });
+            };
+            if !expected.admits(actual) {
+                return Err(FunctionError::CallOperandType {
+                    operand,
+                    callee,
+                    expected: expected.clone(),
+                    actual: actual.clone(),
+                });
+            }
+        }
+
+        let id = self.push(
+            InstructionBody::Call(callee),
+            operands.to_vec(),
+            signature.outputs.clone(),
+        );
+        Ok(self
+            .instruction(id)
+            .expect("the instruction was just pushed")
+            .outputs()
+            .collect())
+    }
+
     /// Declare `value` as the next result of this function.
     pub fn add_result(&mut self, value: Value) -> Result<(), FunctionError> {
         if self.type_of(value).is_none() {
@@ -416,9 +533,10 @@ impl ProgramFunction {
         operands: Vec<Value>,
         output_types: Vec<TensorType>,
     ) -> InstructionId {
-        debug_assert_eq!(
-            operands.len(),
-            body.arity(),
+        debug_assert!(
+            body.view()
+                .arity()
+                .is_none_or(|arity| operands.len() == arity),
             "an instruction stores exactly as many operands as its arity"
         );
         let id = InstructionId(self.instructions.len() as u32);
@@ -496,8 +614,10 @@ impl ProgramFunction {
 
     /// Evaluate this function against `args`, one per parameter in declaration order.
     ///
-    /// Walks the instructions in storage order, which is topological, over a single dense
-    /// environment, releasing each intermediate once its last consumer has run.
+    /// This eval method provides no mechanism to pass in external evaluation closures,
+    /// so will ultimately raise a runtime error if an instruction without a built-in evaluation
+    /// is encountered. This includes, for example, all function calls and the shot-loop
+    /// instruction.
     pub fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, FunctionEvalError> {
         // The function is monomorphic, so its declared parameter types are the only ones its
         // instructions were built for. Checking them here names the argument the caller supplied.
@@ -508,10 +628,49 @@ impl ProgramFunction {
                 full_name: instruction.full_name(),
             });
         }
+        self.walk(args, &[])
+    }
 
+    /// Evaluate this function against `args`, resolving each call instruction against `functions`.
+    ///
+    /// The caller establishes that every instruction this may reach has a built-in implementation,
+    /// and that `functions` holds the callee of every call instruction reached, since both are
+    /// properties of the whole program rather than of this function.
+    pub(super) fn eval_in(
+        &self,
+        args: &[Tensor],
+        functions: &[ProgramFunction],
+    ) -> Result<Vec<Tensor>, FunctionEvalError> {
+        self.check_argument_types(args)?;
+        self.walk(args, functions)
+    }
+
+    /// Walk the instructions in storage order, which is topological, over a single dense
+    /// environment, releasing each intermediate once its last consumer has run.
+    ///
+    /// A call's arguments are not checked against the callee's parameter types: assembling the
+    /// program established that those types admit the operand types wired to the call.
+    fn walk(
+        &self,
+        args: &[Tensor],
+        functions: &[ProgramFunction],
+    ) -> Result<Vec<Tensor>, FunctionEvalError> {
         let offsets = self.value_offsets();
         let last_use = self.last_use(&offsets);
         let flat = |value: Value| offsets[value.instruction.index()] as usize + value.slot();
+
+        // Every operand is present: it was produced by an earlier instruction, and it cannot have
+        // been released, because this instruction's use of it is at or before its last.
+        let gather = |operands: &[Value], env: &[Option<Tensor>]| -> Vec<Tensor> {
+            operands
+                .iter()
+                .map(|&value| {
+                    env[flat(value)]
+                        .clone()
+                        .expect("an operand is produced before its consumer runs")
+                })
+                .collect()
+        };
 
         let total = *offsets.last().expect("offsets always end with the total");
         let mut env: Vec<Option<Tensor>> = vec![None; total as usize];
@@ -532,19 +691,7 @@ impl ProgramFunction {
                     env[offsets[position] as usize] = Some(args[parameter].clone());
                 }
                 InstructionBody::Op(op) => {
-                    // Every operand is present: it was produced by an earlier instruction, and it
-                    // cannot have been released, because this instruction's use of it is at or
-                    // before its last.
-                    let operands: Vec<Tensor> = instruction
-                        .operands
-                        .iter()
-                        .map(|&value| {
-                            env[flat(value)]
-                                .clone()
-                                .expect("an operand is produced before its consumer runs")
-                        })
-                        .collect();
-
+                    let operands = gather(&instruction.operands, &env);
                     let results = op.eval(&operands).map_err(|source| {
                         FunctionEvalError::InstructionFailed {
                             instruction: id,
@@ -559,6 +706,24 @@ impl ProgramFunction {
                             actual: results.len(),
                         });
                     }
+                    for (slot, tensor) in results.into_iter().enumerate() {
+                        env[offsets[position] as usize + slot] = Some(tensor);
+                    }
+                }
+                InstructionBody::Call(callee) => {
+                    // Assembling the program checked this call against the function it names, so
+                    // the callee is present and its results land one per output slot.
+                    let arguments = gather(&instruction.operands, &env);
+                    let function = functions
+                        .get(callee.index())
+                        .expect("a call names a function of the program being evaluated");
+                    let results = function.walk(&arguments, functions).map_err(|source| {
+                        FunctionEvalError::CallFailed {
+                            instruction: id,
+                            callee: *callee,
+                            source: Box::new(source),
+                        }
+                    })?;
                     for (slot, tensor) in results.into_iter().enumerate() {
                         env[offsets[position] as usize + slot] = Some(tensor);
                     }
@@ -938,6 +1103,151 @@ mod test {
         assert_eq!(
             add.operand_types().collect::<Vec<_>>(),
             vec![&f64_1d(2), &f64_1d(2)]
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Calls
+    // ---------------------------------------------------------------------------
+
+    /// The signature `(F64[len]) -> (F64[len])`, which [`double_function`] in the program tests has.
+    fn double_signature(len: usize) -> Signature {
+        Signature {
+            inputs: vec![f64_1d(len)],
+            outputs: vec![f64_1d(len)],
+        }
+    }
+
+    #[test]
+    fn a_call_names_a_function_by_id_and_one_body_serves_several_sites() {
+        let callee = FunctionId::from_index(0);
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+        let once = function
+            .add_call(callee, &double_signature(2), &[x])
+            .unwrap();
+        assert_eq!(once.len(), 1, "one value per result the signature declares");
+        let twice = function
+            .add_call(callee, &double_signature(2), &once)
+            .unwrap()[0];
+        function.add_result(twice).unwrap();
+
+        let call = function.instruction(once[0].instruction()).unwrap();
+        assert_eq!(call.role(), InstructionRole::Call);
+        assert_eq!(call.full_name(), "qiskit.call");
+        assert!(matches!(call.view(), InstructionView::Call(named) if named == callee));
+        assert_eq!(call.operands(), &[x]);
+        assert_eq!(
+            call.output_types(),
+            &[f64_1d(2)],
+            "the declared result types are the call instruction's own"
+        );
+
+        // Both sites name the same function, and only a call instruction names one at all.
+        assert_eq!(
+            function
+                .iter_instructions()
+                .filter_map(named_callee)
+                .collect::<Vec<_>>(),
+            vec![callee, callee]
+        );
+        assert_eq!(
+            named_callee(function.instruction(x.instruction()).unwrap()),
+            None
+        );
+    }
+
+    /// The function `instruction` calls, for an instruction that calls one.
+    fn named_callee(instruction: InstructionRef<'_>) -> Option<FunctionId> {
+        match instruction.view() {
+            InstructionView::Call(callee) => Some(callee),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn a_call_operand_is_checked_against_the_parameter_declared_for_it() {
+        let callee = FunctionId::from_index(0);
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(2));
+
+        let Err(err) = function.add_call(callee, &double_signature(3), &[x]) else {
+            panic!("an F64[2] operand cannot fill an F64[3] parameter")
+        };
+        assert_eq!(
+            err.to_string(),
+            "operand 0 of the call to @0: expected F64[3], got F64[2]",
+            "the position, the callee, and both types are named"
+        );
+
+        let Err(err) = function.add_call(callee, &double_signature(2), &[x, x]) else {
+            panic!("a one-parameter signature takes one operand")
+        };
+        assert_eq!(err.to_string(), "qiskit.call takes 1 operand(s), got 2");
+
+        // A value from another function is unknown here, so long as this one has no instruction at
+        // its index.
+        let mut other = ProgramFunction::new();
+        other.add_parameter(f64_1d(2));
+        let stranger = other.add_parameter(f64_1d(2));
+        let Err(err) = function.add_call(callee, &double_signature(2), &[stranger]) else {
+            panic!("an operand from another function is rejected")
+        };
+        assert!(matches!(
+            err,
+            FunctionError::UnknownOperand { operand: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn a_call_operand_may_be_narrower_than_the_parameter_declared_for_it() {
+        // A declared type constrains what may arrive rather than equalling it, so a true size within
+        // a bound is admitted.
+        let bounded = TensorType {
+            dtype: DType::F64,
+            shape: vec![Dim::Bounded { max: 4 }],
+        };
+        let callee = FunctionId::from_index(0);
+        let mut function = ProgramFunction::new();
+        let fixed = function.add_parameter(f64_1d(3));
+        let loose = function.add_parameter(bounded.clone());
+
+        let signature = Signature {
+            inputs: vec![bounded],
+            outputs: vec![],
+        };
+        assert!(function.add_call(callee, &signature, &[fixed]).is_ok());
+
+        // Nothing proves the size of a bounded operand is within a true size.
+        let signature = Signature {
+            inputs: vec![f64_1d(3)],
+            outputs: vec![],
+        };
+        let Err(err) = function.add_call(callee, &signature, &[loose]) else {
+            panic!("a bounded operand cannot fill a parameter of a true size")
+        };
+        assert_eq!(
+            err.to_string(),
+            "operand 0 of the call to @0: expected F64[3], got F64[<=4]"
+        );
+    }
+
+    #[test]
+    fn a_function_holding_a_call_cannot_be_evaluated_on_its_own() {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(1));
+        let called = function
+            .add_call(FunctionId::from_index(0), &double_signature(1), &[x])
+            .unwrap()[0];
+        function.add_result(called).unwrap();
+
+        assert!(!function.has_builtin_eval());
+        let Err(err) = function.eval(&[Tensor::from([1.0_f64])]) else {
+            panic!("resolving a call needs the program holding its callee")
+        };
+        assert_eq!(
+            err.to_string(),
+            "instruction 1 (qiskit.call) has no built-in implementation"
         );
     }
 

--- a/crates/providers/src/program/quantum_program.rs
+++ b/crates/providers/src/program/quantum_program.rs
@@ -10,14 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-//! A callable collection of functions, together with the structures that name what a caller hands
-//! over and what it gets back.
+//! A callable collection of functions.
 
 use std::fmt;
 
 use thiserror::Error;
 
-use super::program_function::{FunctionEvalError, ProgramFunction};
+use super::program_function::{
+    FunctionEvalError, InstructionId, InstructionRef, InstructionRole, InstructionView,
+    ProgramFunction, Signature,
+};
 use crate::data_tree::DataTree;
 use crate::tensor::{Tensor, TensorType};
 
@@ -65,6 +67,68 @@ pub enum ProgramError {
          result(s)"
     )]
     OutputArity { leaves: usize, results: usize },
+
+    /// A call names the function holding it, or one defined after it.
+    #[error("{function} instruction {instruction} calls {callee}, which is not defined before it")]
+    CallOrder {
+        function: FunctionId,
+        instruction: InstructionId,
+        callee: FunctionId,
+    },
+
+    /// A call supplies a different number of operands than its callee takes parameters.
+    #[error(
+        "{function} instruction {instruction} calls {callee}: it takes {parameters} parameter(s), \
+         the call supplies {operands}"
+    )]
+    CallParameterCount {
+        function: FunctionId,
+        instruction: InstructionId,
+        callee: FunctionId,
+        parameters: usize,
+        operands: usize,
+    },
+
+    /// An operand of a call does not satisfy the corresponding parameter type of its callee.
+    #[error(
+        "{function} instruction {instruction} calls {callee}: its parameter {slot} is {parameter}, \
+         the call supplies {operand}"
+    )]
+    CallParameterType {
+        function: FunctionId,
+        instruction: InstructionId,
+        callee: FunctionId,
+        slot: usize,
+        parameter: TensorType,
+        operand: TensorType,
+    },
+
+    /// A call declares a different number of results than its callee produces.
+    #[error(
+        "{function} instruction {instruction} calls {callee}: it produces {results} result(s), the \
+         call declares {outputs}"
+    )]
+    CallResultCount {
+        function: FunctionId,
+        instruction: InstructionId,
+        callee: FunctionId,
+        results: usize,
+        outputs: usize,
+    },
+
+    /// A result a call declares does not admit the corresponding result type of its callee.
+    #[error(
+        "{function} instruction {instruction} calls {callee}: its result {slot} is {result}, the \
+         call declares {output}"
+    )]
+    CallResultType {
+        function: FunctionId,
+        instruction: InstructionId,
+        callee: FunctionId,
+        slot: usize,
+        result: TensorType,
+        output: TensorType,
+    },
 }
 
 /// Why [`QuantumProgram::eval`] could not produce results.
@@ -77,15 +141,29 @@ pub enum ProgramEvalError {
         actual: Box<DataTree<()>>,
     },
 
+    /// A function contains an instruction Qiskit has no in-process implementation of.
+    #[error("{function} instruction {instruction} ({full_name}) has no built-in implementation")]
+    NoBuiltinEval {
+        function: FunctionId,
+        instruction: InstructionId,
+        full_name: String,
+    },
+
     /// The entry point failed.
     #[error(transparent)]
     Function(#[from] FunctionEvalError),
 }
 
-/// A collection of [`ProgramFunction`]s, the last of them the entry point.
+/// A collection of [`ProgramFunction`]s.
 ///
-/// A caller to `eval` provides a [`DataTree`] of tensor inputs arranged in the format prescribed by
-/// `input_types`, and receives back the resulting tensors as prescribed by `output_types`.
+/// A caller to this program provides a [`DataTree`] of tensor inputs arranged in the format
+/// prescribed by [`input_types`](Self::input_types), and receives back the resulting tensors as
+/// prescribed by [`output_types`](Self::output_types).
+///
+/// A function may call one defined before it but not after it, through
+/// [`ProgramFunction::add_call`]. The last function is the entry point to the program, so
+/// definition order is also an execution order. This type has no builder; [`Self::new`] is its
+/// only constructor.
 ///
 /// # Example
 /// ```rust
@@ -135,6 +213,8 @@ impl QuantumProgram {
     ///
     /// The last of `functions` is the entry point, and the structures describe its slots: a
     /// structure's leaves correspond to them by DFS order.
+    ///
+    /// Function calls are checked for type compatibility.
     pub fn new(
         functions: Vec<ProgramFunction>,
         input_structure: DataTree<()>,
@@ -154,6 +234,8 @@ impl QuantumProgram {
         if leaves != results {
             return Err(ProgramError::OutputArity { leaves, results });
         }
+
+        check_calls(&functions)?;
 
         Ok(Self {
             functions,
@@ -190,17 +272,11 @@ impl QuantumProgram {
     }
 
     /// How the program's outputs are arranged and named.
-    ///
-    /// [`DataTree::dotted_paths`] turns this into an address for each output, in output order. The
-    /// structure is the thing worth keeping: a path addresses one leaf of it, and a set of paths
-    /// cannot reconstruct it, because an empty branch contributes no leaves and so no path.
     pub fn output_structure(&self) -> &DataTree<()> {
         &self.output_structure
     }
 
-    /// The declared type of every input, arranged in the input structure.
-    ///
-    /// Answers what a program consumes without evaluating it.
+    /// The declared type of every input.
     pub fn input_types(&self) -> DataTree<TensorType> {
         arrange(
             &self.input_structure,
@@ -208,10 +284,7 @@ impl QuantumProgram {
         )
     }
 
-    /// The declared type of every output, arranged in the output structure.
-    ///
-    /// Answers what a program produces without evaluating it, which is what lets a caller check that
-    /// a result is the one it wanted before paying for it.
+    /// The declared type of every output.
     pub fn output_types(&self) -> DataTree<TensorType> {
         arrange(
             &self.output_structure,
@@ -219,11 +292,18 @@ impl QuantumProgram {
         )
     }
 
+    /// Whether every instruction in every function has a built-in evaluation.
+    ///
+    /// In other words, whether [`eval`](Self::eval) is expected to work.
+    pub fn has_builtin_eval(&self) -> bool {
+        self.first_without_builtin_eval().is_none()
+    }
+
     /// Evaluate the program on a tree of inputs, returning a tree of outputs.
     ///
-    /// `inputs` must be arranged exactly as [`input_structure`](Self::input_structure) says, which is
-    /// checked before anything is evaluated, and the results come back arranged as
-    /// [`output_structure`](Self::output_structure) says.
+    /// `inputs` must be arranged as [`input_structure`](Self::input_structure) dictates, which is
+    /// checked before anything is evaluated, and the results are formatted according to
+    /// [`output_structure`](Self::output_structure).
     pub fn eval(&self, inputs: DataTree<Tensor>) -> Result<DataTree<Tensor>, ProgramEvalError> {
         let actual = inputs.structure();
         if actual != self.input_structure {
@@ -232,9 +312,36 @@ impl QuantumProgram {
                 actual: Box::new(actual),
             });
         }
+        // Every function is checked before anything runs, so a program that needs a backend
+        // produces no intermediates.
+        if let Some((function, instruction)) = self.first_without_builtin_eval() {
+            return Err(ProgramEvalError::NoBuiltinEval {
+                function,
+                instruction: instruction.id(),
+                full_name: instruction.full_name(),
+            });
+        }
         let arguments: Vec<Tensor> = inputs.into_leaves().collect();
-        let results = self.entry_function().eval(&arguments)?;
+        let results = self.entry_function().eval_in(&arguments, &self.functions)?;
         Ok(arrange(&self.output_structure, results))
+    }
+
+    /// The first instruction of any function that has no built-in evaluation.
+    ///
+    /// A call instruction is skipped; the function it names is checked in its own right.
+    fn first_without_builtin_eval(&self) -> Option<(FunctionId, InstructionRef<'_>)> {
+        self.functions
+            .iter()
+            .enumerate()
+            .find_map(|(index, function)| {
+                function
+                    .iter_instructions()
+                    .find(|instruction| {
+                        instruction.role() != InstructionRole::Call
+                            && !instruction.has_builtin_eval()
+                    })
+                    .map(|instruction| (FunctionId::from_index(index), instruction))
+            })
     }
 }
 
@@ -245,10 +352,107 @@ fn arrange<T>(structure: &DataTree<()>, values: Vec<T>) -> DataTree<T> {
         .expect("a structure describes as many slots as the entry point it was checked against")
 }
 
+/// Verify every call instruction of every function against the function it names.
+///
+/// Functions the entry point cannot reach are checked too, so evaluation can resolve every call
+/// with no error path of its own.
+fn check_calls(functions: &[ProgramFunction]) -> Result<(), ProgramError> {
+    for (index, function) in functions.iter().enumerate() {
+        let caller = FunctionId::from_index(index);
+        for instruction in function.iter_instructions() {
+            let InstructionView::Call(callee) = instruction.view() else {
+                continue;
+            };
+            // A call may only name an earlier function. The call graph is acyclic by construction,
+            // and the callee is in bounds without a separate check.
+            if callee.index() >= index {
+                return Err(ProgramError::CallOrder {
+                    function: caller,
+                    instruction: instruction.id(),
+                    callee,
+                });
+            }
+            check_call(
+                caller,
+                instruction,
+                callee,
+                &functions[callee.index()].signature(),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Verify one call instruction's operand and result types against `signature`, the contract of the
+/// function it names.
+fn check_call(
+    function: FunctionId,
+    instruction: InstructionRef<'_>,
+    callee: FunctionId,
+    signature: &Signature,
+) -> Result<(), ProgramError> {
+    if instruction.operands().len() != signature.inputs.len() {
+        return Err(ProgramError::CallParameterCount {
+            function,
+            instruction: instruction.id(),
+            callee,
+            parameters: signature.inputs.len(),
+            operands: instruction.operands().len(),
+        });
+    }
+    for (slot, (parameter, operand)) in signature
+        .inputs
+        .iter()
+        .zip(instruction.operand_types())
+        .enumerate()
+    {
+        if !parameter.admits(operand) {
+            return Err(ProgramError::CallParameterType {
+                function,
+                instruction: instruction.id(),
+                callee,
+                slot,
+                parameter: parameter.clone(),
+                operand: operand.clone(),
+            });
+        }
+    }
+
+    if instruction.output_types().len() != signature.outputs.len() {
+        return Err(ProgramError::CallResultCount {
+            function,
+            instruction: instruction.id(),
+            callee,
+            results: signature.outputs.len(),
+            outputs: instruction.output_types().len(),
+        });
+    }
+    // The instructions reading a result were type-checked against the type the call declares, so
+    // that type has to admit what the callee produces.
+    for (slot, (result, output)) in signature
+        .outputs
+        .iter()
+        .zip(instruction.output_types())
+        .enumerate()
+    {
+        if !output.admits(result) {
+            return Err(ProgramError::CallResultType {
+                function,
+                instruction: instruction.id(),
+                callee,
+                slot,
+                result: result.clone(),
+                output: output.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ops::Add;
+    use crate::ops::{Add, ProgramOp};
     use crate::program::Signature;
     use crate::tensor::{DType, Dim};
 
@@ -491,6 +695,110 @@ mod test {
     }
 
     // ---------------------------------------------------------------------------
+    // Several functions, one calling another
+    // ---------------------------------------------------------------------------
+
+    /// A function that calls `callee` on its one parameter and returns what comes back, given the
+    /// signature the callee has.
+    fn calling_function(callee: FunctionId, signature: &Signature) -> ProgramFunction {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(signature.inputs[0].clone());
+        let called = function.add_call(callee, signature, &[x]).unwrap()[0];
+        function.add_result(called).unwrap();
+        function
+    }
+
+    #[test]
+    fn a_call_computes_what_the_function_it_names_computes() {
+        // @1 is `f(x) = double(x) + double(x)`, over the one body @0.
+        let callee = double_function();
+        let signature = callee.signature();
+        let mut entry = ProgramFunction::new();
+        let x = entry.add_parameter(f64_1d(1));
+        let doubled = entry
+            .add_call(FunctionId::from_index(0), &signature, &[x])
+            .unwrap()[0];
+        let sum = entry.add_op(Add, &[doubled, doubled]).unwrap()[0];
+        entry.add_result(sum).unwrap();
+
+        let program =
+            QuantumProgram::new(vec![callee, entry], DataTree::Leaf(()), DataTree::Leaf(()))
+                .unwrap();
+        assert!(program.has_builtin_eval());
+
+        // The same computation with the body written out where it is called.
+        let mut inlined = ProgramFunction::new();
+        let x = inlined.add_parameter(f64_1d(1));
+        let doubled = inlined.add_op(Add, &[x, x]).unwrap()[0];
+        let sum = inlined.add_op(Add, &[doubled, doubled]).unwrap()[0];
+        inlined.add_result(sum).unwrap();
+        let inlined =
+            QuantumProgram::new(vec![inlined], DataTree::Leaf(()), DataTree::Leaf(())).unwrap();
+
+        let input = DataTree::Leaf(one_element(3.0));
+        assert_eq!(
+            program.eval(input.clone()).unwrap(),
+            DataTree::Leaf(one_element(12.0))
+        );
+        assert_eq!(
+            program.eval(input.clone()).unwrap(),
+            inlined.eval(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_call_may_be_reached_through_a_chain_of_calls() {
+        // @0 doubles, @1 calls @0, and @2 calls @1, so 1.5 comes back as 3.0.
+        let doubling = double_function();
+        let signature = doubling.signature();
+        let program = QuantumProgram::new(
+            vec![
+                doubling,
+                calling_function(FunctionId::from_index(0), &signature),
+                calling_function(FunctionId::from_index(1), &signature),
+            ],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            program.eval(DataTree::Leaf(one_element(1.5))).unwrap(),
+            DataTree::Leaf(one_element(3.0))
+        );
+    }
+
+    #[test]
+    fn a_function_the_entry_point_cannot_reach_is_accepted() {
+        // @0 is dead code, and fails if it is ever evaluated, so the program evaluating at all is
+        // what shows the entry point @1 never reaches it.
+        let mut unreachable = ProgramFunction::new();
+        let x = unreachable.add_parameter(f64_1d(1));
+        let out = unreachable
+            .add_op(Elsewhere { builtin: true }, &[x])
+            .unwrap()[0];
+        unreachable.add_result(out).unwrap();
+
+        let program = QuantumProgram::new(
+            vec![unreachable, add_function()],
+            named_inputs(),
+            named_output(),
+        )
+        .unwrap();
+
+        assert!(program.has_builtin_eval());
+        let inputs = DataTree::mapping([
+            ("x", DataTree::Leaf(one_element(1.0))),
+            ("y", DataTree::Leaf(one_element(10.0))),
+        ])
+        .unwrap();
+        assert_eq!(
+            program.eval(inputs).unwrap(),
+            DataTree::mapping([("sum", DataTree::Leaf(one_element(11.0)))]).unwrap()
+        );
+    }
+
+    // ---------------------------------------------------------------------------
     // Assembly rejections
     // ---------------------------------------------------------------------------
 
@@ -538,6 +846,145 @@ mod test {
 
         assert_eq!(err, ProgramError::NoFunctions);
         assert_eq!(err.to_string(), "there are no functions to enter at");
+    }
+
+    #[test]
+    fn a_call_naming_itself_or_a_later_function_is_rejected() {
+        let signature = double_function().signature();
+
+        // @0 calls @0. A call may only name an earlier function, so the call graph cannot have a
+        // cycle in it and nothing has to look for one.
+        let Err(err) = QuantumProgram::new(
+            vec![calling_function(FunctionId::from_index(0), &signature)],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("a function cannot call itself")
+        };
+        assert!(matches!(err, ProgramError::CallOrder { .. }));
+        assert_eq!(
+            err.to_string(),
+            "@0 instruction 1 calls @0, which is not defined before it"
+        );
+
+        // @0 calls @1, which is defined after it.
+        let Err(err) = QuantumProgram::new(
+            vec![
+                calling_function(FunctionId::from_index(1), &signature),
+                double_function(),
+            ],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("a call may not name a later function")
+        };
+        assert_eq!(
+            err.to_string(),
+            "@0 instruction 1 calls @1, which is not defined before it"
+        );
+    }
+
+    #[test]
+    fn a_call_whose_operands_disagree_with_its_callee_is_rejected() {
+        // The call is built against a signature describing something other than @0, which takes one
+        // F64[1]. Nothing is checked against @0 until the program is assembled.
+        let two_parameters = Signature {
+            inputs: vec![f64_1d(1), f64_1d(1)],
+            outputs: vec![f64_1d(1)],
+        };
+        let mut entry = ProgramFunction::new();
+        let x = entry.add_parameter(f64_1d(1));
+        let called = entry
+            .add_call(FunctionId::from_index(0), &two_parameters, &[x, x])
+            .unwrap()[0];
+        entry.add_result(called).unwrap();
+
+        let Err(err) = QuantumProgram::new(
+            vec![double_function(), entry],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("@0 takes one parameter, not two")
+        };
+        assert_eq!(
+            err.to_string(),
+            "@1 instruction 1 calls @0: it takes 1 parameter(s), the call supplies 2"
+        );
+
+        // One operand, of a shape @0 does not take.
+        let wider = Signature {
+            inputs: vec![f64_1d(2)],
+            outputs: vec![f64_1d(1)],
+        };
+        let Err(err) = QuantumProgram::new(
+            vec![
+                double_function(),
+                calling_function(FunctionId::from_index(0), &wider),
+            ],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("@0 takes an F64[1], and the call supplies an F64[2]")
+        };
+        assert!(matches!(
+            err,
+            ProgramError::CallParameterType { slot: 0, .. }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "@1 instruction 1 calls @0: its parameter 0 is F64[1], the call supplies F64[2]",
+            "the calling function, the call instruction, the slot, and both types are named"
+        );
+    }
+
+    #[test]
+    fn a_call_whose_results_disagree_with_its_callee_is_rejected() {
+        let no_results = Signature {
+            inputs: vec![f64_1d(1)],
+            outputs: vec![],
+        };
+        let mut entry = ProgramFunction::new();
+        let x = entry.add_parameter(f64_1d(1));
+        assert!(
+            entry
+                .add_call(FunctionId::from_index(0), &no_results, &[x])
+                .unwrap()
+                .is_empty()
+        );
+        entry.add_result(x).unwrap();
+
+        let Err(err) = QuantumProgram::new(
+            vec![double_function(), entry],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("@0 produces a result the call does not declare")
+        };
+        assert_eq!(
+            err.to_string(),
+            "@1 instruction 1 calls @0: it produces 1 result(s), the call declares 0"
+        );
+
+        // One result, of a shape @0 does not produce.
+        let wider = Signature {
+            inputs: vec![f64_1d(1)],
+            outputs: vec![f64_1d(2)],
+        };
+        let Err(err) = QuantumProgram::new(
+            vec![
+                double_function(),
+                calling_function(FunctionId::from_index(0), &wider),
+            ],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        ) else {
+            panic!("@0 produces an F64[1], and the call declares an F64[2]")
+        };
+        assert!(matches!(err, ProgramError::CallResultType { slot: 0, .. }));
+        assert_eq!(
+            err.to_string(),
+            "@1 instruction 1 calls @0: its result 0 is F64[1], the call declares F64[2]"
+        );
     }
 
     // ---------------------------------------------------------------------------
@@ -618,5 +1065,140 @@ mod test {
             })
         ));
         assert_eq!(err.to_string(), "argument 1: expected F64[1], got I64[1]");
+    }
+
+    /// An op defined outside the crate whose `eval` always fails, reporting `builtin` for
+    /// [`ProgramOp::has_builtin_eval`]. A backend contributes work Qiskit cannot perform with
+    /// `builtin` false; with it true, the failure lands in the middle of a walk.
+    #[derive(Clone)]
+    struct Elsewhere {
+        builtin: bool,
+    }
+
+    /// The error [`Elsewhere`] returns when asked to evaluate itself.
+    #[derive(Debug)]
+    struct NoImplementation;
+
+    impl fmt::Display for NoImplementation {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "vendor.elsewhere has no in-process implementation")
+        }
+    }
+
+    impl std::error::Error for NoImplementation {}
+
+    impl ProgramOp for Elsewhere {
+        type Error = NoImplementation;
+
+        fn name(&self) -> &str {
+            "elsewhere"
+        }
+
+        fn namespace(&self) -> &str {
+            "vendor"
+        }
+
+        fn arity(&self) -> usize {
+            1
+        }
+
+        fn has_builtin_eval(&self) -> bool {
+            self.builtin
+        }
+
+        fn infer_output_types(
+            &self,
+            inputs: &[TensorType],
+        ) -> Result<Vec<TensorType>, Self::Error> {
+            Ok(vec![inputs[0].clone()])
+        }
+
+        fn eval(&self, _args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
+            Err(NoImplementation)
+        }
+    }
+
+    /// A one-parameter, one-result function holding a single [`Elsewhere`].
+    fn vendor_function(builtin: bool) -> ProgramFunction {
+        let mut function = ProgramFunction::new();
+        let x = function.add_parameter(f64_1d(1));
+        let out = function.add_op(Elsewhere { builtin }, &[x]).unwrap()[0];
+        function.add_result(out).unwrap();
+        function
+    }
+
+    /// A program whose entry point @1 calls @0, which holds a single [`Elsewhere`].
+    fn calls_a_vendor_function(builtin: bool) -> QuantumProgram {
+        let callee = vendor_function(builtin);
+        let signature = callee.signature();
+        QuantumProgram::new(
+            vec![
+                callee,
+                calling_function(FunctionId::from_index(0), &signature),
+            ],
+            DataTree::Leaf(()),
+            DataTree::Leaf(()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_program_whose_call_reaches_an_instruction_needing_a_backend_names_that_instruction() {
+        let program = calls_a_vendor_function(false);
+        assert!(
+            !program.has_builtin_eval(),
+            "the entry point reaches @0, which needs a backend"
+        );
+
+        let Err(err) = program.eval(DataTree::Leaf(one_element(1.0))) else {
+            panic!("a program that needs a backend cannot be evaluated in process")
+        };
+        assert!(matches!(err, ProgramEvalError::NoBuiltinEval { .. }));
+        assert_eq!(
+            err.to_string(),
+            "@0 instruction 1 (vendor.elsewhere) has no built-in implementation",
+            "the function as well as the instruction is named"
+        );
+    }
+
+    #[test]
+    fn a_function_needing_a_backend_counts_even_where_nothing_calls_it() {
+        // The question is asked of every function a program holds, rather than only of those the
+        // entry point reaches.
+        let program = QuantumProgram::new(
+            vec![vendor_function(false), add_function()],
+            named_inputs(),
+            named_output(),
+        )
+        .unwrap();
+
+        assert!(!program.has_builtin_eval());
+    }
+
+    #[test]
+    fn a_call_that_fails_names_the_function_it_reached() {
+        let Err(err) = calls_a_vendor_function(true).eval(DataTree::Leaf(one_element(1.0))) else {
+            panic!("@0 fails as it runs")
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "evaluating the call at instruction 1 to @0"
+        );
+        let mut source = std::error::Error::source(&err);
+        let messages: Vec<String> = std::iter::from_fn(|| {
+            let error = source?;
+            source = error.source();
+            Some(error.to_string())
+        })
+        .collect();
+        assert_eq!(
+            messages,
+            [
+                "evaluating instruction 1 (vendor.elsewhere)".to_string(),
+                "vendor.elsewhere has no in-process implementation".to_string(),
+            ],
+            "the chain leads from the call to the instruction that failed"
+        );
     }
 }

--- a/crates/providers/src/tensor/tensor_type.rs
+++ b/crates/providers/src/tensor/tensor_type.rs
@@ -29,6 +29,21 @@ pub enum Dim {
     Bounded { max: usize },
 }
 
+impl Dim {
+    /// Whether every size `offered` allows is a size this dimension allows.
+    ///
+    /// A fixed dimension allows only its own size. Broadcasting, where a size of `1` stands for any
+    /// size, is [`rules::broadcast_dims`].
+    pub fn admits(self, offered: Dim) -> bool {
+        match (self, offered) {
+            (Dim::Fixed(n), Dim::Fixed(m)) => n == m,
+            (Dim::Fixed(_), Dim::Bounded { .. }) => false,
+            (Dim::Bounded { max }, Dim::Fixed(m)) => m <= max,
+            (Dim::Bounded { max }, Dim::Bounded { max: bound }) => bound <= max,
+        }
+    }
+}
+
 impl fmt::Display for Dim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -57,6 +72,20 @@ impl TensorType {
     /// Return the dimension of every axis, or `None` if any is only bounded above.
     pub fn concrete_shape(&self) -> Option<Vec<usize>> {
         rules::require_static(&self.shape).ok()
+    }
+
+    /// Whether every tensor satisfying `other` also satisfies this type.
+    ///
+    /// A value of type `other` already fits this one, rather than fitting after broadcasting. It is
+    /// [`Tensor::matches`](super::Tensor::matches) with a type in place of the tensor.
+    pub fn admits(&self, other: &TensorType) -> bool {
+        self.dtype == other.dtype
+            && self.shape.len() == other.shape.len()
+            && self
+                .shape
+                .iter()
+                .zip(&other.shape)
+                .all(|(&dim, &offered)| dim.admits(offered))
     }
 }
 
@@ -92,6 +121,51 @@ mod test {
             bit_type(vec![Dim::Fixed(3), Dim::Bounded { max: 8 }]).concrete_shape(),
             None
         );
+    }
+
+    #[test]
+    fn test_dim_admits() {
+        let bounded = Dim::Bounded { max: 4 };
+
+        assert!(Dim::Fixed(3).admits(Dim::Fixed(3)));
+        assert!(bounded.admits(bounded));
+
+        // A bound admits a true size within it, up to and including the bound itself.
+        assert!(bounded.admits(Dim::Fixed(3)));
+        assert!(bounded.admits(Dim::Fixed(4)));
+        assert!(!bounded.admits(Dim::Fixed(5)));
+
+        // A tighter bound is admitted by a looser one, and not the other way round.
+        assert!(bounded.admits(Dim::Bounded { max: 2 }));
+        assert!(!Dim::Bounded { max: 2 }.admits(bounded));
+
+        // A true size is required where a true size is declared.
+        assert!(!Dim::Fixed(3).admits(bounded));
+
+        // A size of 1 stands for any size when broadcasting, which this is not.
+        assert!(!Dim::Fixed(3).admits(Dim::Fixed(1)));
+        assert!(!Dim::Fixed(1).admits(Dim::Fixed(3)));
+    }
+
+    #[test]
+    fn test_tensor_type_admits() {
+        let fixed = bit_type(vec![Dim::Fixed(3)]);
+
+        assert!(fixed.admits(&fixed));
+        assert!(
+            bit_type(vec![Dim::Bounded { max: 4 }]).admits(&fixed),
+            "per axis"
+        );
+
+        // The dtype and the number of axes must agree.
+        assert!(
+            !TensorType {
+                dtype: DType::F64,
+                shape: vec![Dim::Fixed(3)],
+            }
+            .admits(&fixed)
+        );
+        assert!(!fixed.admits(&bit_type(vec![Dim::Fixed(1), Dim::Fixed(3)])));
     }
 
     #[test]

--- a/crates/providers/src/tensor/value.rs
+++ b/crates/providers/src/tensor/value.rs
@@ -147,10 +147,7 @@ impl Tensor {
                 .shape()
                 .iter()
                 .zip(&ty.shape)
-                .all(|(&size, dim)| match *dim {
-                    Dim::Fixed(n) => size == n,
-                    Dim::Bounded { max } => size <= max,
-                })
+                .all(|(&size, &dim)| dim.admits(Dim::Fixed(size)))
     }
 
     /// Element-wise power with NumPy-style broadcasting.


### PR DESCRIPTION
This PR adds the ability for a function to call another function by function ID.
See also #16922 and #16924.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: claude opus 5

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>