### PR TITLE
Add nodes to cast a dtype and broadcast a shape

### DIFF
--- a/crates/providers/src/ops/broadcast_to.rs
+++ b/crates/providers/src/ops/broadcast_to.rs
@@ -1,0 +1,252 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! The op that broadcasts an operand to a chosen shape.
+
+use super::error::MathOpError;
+use super::inference::broadcast_to;
+use super::{ProgramOp, QISKIT};
+use crate::tensor::{Dim, Tensor, TensorError, TensorType};
+
+/// Broadcast a tensor to a target shape, right-aligning the two.
+///
+/// Arithmetic ops broadcast their own operands, so this op is for a shape arithmetic does not
+/// reach. An axis of size one grows to any size and leading axes may be added. An axis cannot be
+/// dropped, since the result shape is the target.
+///
+/// A [`Dim::Bounded`] target axis is copied from the operand, and matches only an identical operand
+/// axis. Evaluation uses the operand's own size for it.
+#[derive(Clone)]
+pub struct BroadcastTo {
+    target: Vec<Dim>,
+}
+
+impl BroadcastTo {
+    /// Construct a `BroadcastTo` op producing `target`.
+    pub fn new(target: Vec<Dim>) -> Self {
+        Self { target }
+    }
+
+    /// The shape an operand of shape `shape` is broadcast to.
+    ///
+    /// A fixed target axis gives its own size. A bounded one takes the operand's size along the axis
+    /// it aligns with.
+    fn concrete_target(&self, shape: &[usize]) -> Result<Vec<usize>, MathOpError> {
+        let Some(offset) = self.target.len().checked_sub(shape.len()) else {
+            return Err(TensorError::DimShapeMismatch {
+                lhs: shape.iter().copied().map(Dim::Fixed).collect(),
+                rhs: self.target.clone(),
+            }
+            .into());
+        };
+        self.target
+            .iter()
+            .enumerate()
+            .map(|(axis, dim)| match *dim {
+                Dim::Fixed(size) => Ok(size),
+                Dim::Bounded { .. } if axis >= offset => Ok(shape[axis - offset]),
+                // A leading axis the operand does not have, so it has no size to copy.
+                Dim::Bounded { .. } => Err(TensorError::DynamicDim {
+                    shape: self.target.clone(),
+                }
+                .into()),
+            })
+            .collect()
+    }
+}
+
+impl ProgramOp for BroadcastTo {
+    type Error = MathOpError;
+
+    fn name(&self) -> &str {
+        "broadcast_to"
+    }
+    fn namespace(&self) -> &str {
+        QISKIT
+    }
+    fn arity(&self) -> usize {
+        1
+    }
+    fn has_builtin_eval(&self) -> bool {
+        true
+    }
+    fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
+        crate::unpack_operands!(self, inputs, [x]);
+        Ok(vec![broadcast_to(x, &self.target)?])
+    }
+    fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
+        crate::unpack_operands!(self, args, [x]);
+        Ok(vec![x.broadcast_to(&self.concrete_target(x.shape())?)?])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tensor::DType;
+    use ndarray::arr2;
+
+    /// A `TensorType` over `shape`; every test here is about the shape alone.
+    fn ty(shape: Vec<Dim>) -> TensorType {
+        TensorType {
+            dtype: DType::F64,
+            shape,
+        }
+    }
+
+    /// A shape of fixed axes.
+    fn fixed(sizes: &[usize]) -> Vec<Dim> {
+        sizes.iter().copied().map(Dim::Fixed).collect()
+    }
+
+    #[test]
+    fn test_broadcast_to_full_name_and_arity() {
+        let op = BroadcastTo::new(fixed(&[3]));
+        assert_eq!(op.full_name(), "qiskit.broadcast_to");
+        assert_eq!(op.arity(), 1);
+        assert!(op.has_builtin_eval());
+    }
+
+    #[test]
+    fn test_infer_output_types_is_the_target_and_keeps_the_dtype() {
+        // An axis of size one reaches the target's size, and a missing leading axis is added.
+        for shape in [fixed(&[1, 5]), fixed(&[5]), fixed(&[3, 5])] {
+            assert_eq!(
+                BroadcastTo::new(fixed(&[3, 5]))
+                    .infer_output_types(&[ty(shape.clone())])
+                    .unwrap(),
+                vec![ty(fixed(&[3, 5]))],
+                "for operand shape {shape:?}"
+            );
+        }
+        let bit = TensorType {
+            dtype: DType::Bit,
+            shape: fixed(&[1]),
+        };
+        assert_eq!(
+            BroadcastTo::new(fixed(&[4]))
+                .infer_output_types(&[bit])
+                .unwrap()[0]
+                .dtype,
+            DType::Bit
+        );
+    }
+
+    #[test]
+    fn test_infer_output_types_copies_a_bounded_axis_from_the_operand() {
+        let shots = Dim::Bounded { max: 4000 };
+        assert_eq!(
+            BroadcastTo::new(vec![shots, Dim::Fixed(5)])
+                .infer_output_types(&[ty(vec![shots, Dim::Fixed(1)])])
+                .unwrap(),
+            vec![ty(vec![shots, Dim::Fixed(5)])]
+        );
+    }
+
+    #[test]
+    fn test_infer_output_types_rejects_a_target_it_cannot_reach() {
+        // `rules::broadcast_dims_to` holds the table of what is admitted; these are its refusals
+        // arriving through the op.
+        let shots = Dim::Bounded { max: 4000 };
+        assert_eq!(
+            BroadcastTo::new(fixed(&[4]))
+                .infer_output_types(&[ty(fixed(&[3]))])
+                .unwrap_err(),
+            MathOpError::Tensor(TensorError::DimShapeMismatch {
+                lhs: fixed(&[3]),
+                rhs: fixed(&[4]),
+            })
+        );
+        assert_eq!(
+            BroadcastTo::new(fixed(&[5]))
+                .infer_output_types(&[ty(vec![shots])])
+                .unwrap_err(),
+            MathOpError::Tensor(TensorError::DynamicDim { shape: vec![shots] })
+        );
+        let err = BroadcastTo::new(vec![shots])
+            .infer_output_types(&[ty(fixed(&[1]))])
+            .unwrap_err();
+        assert_eq!(
+            err,
+            MathOpError::Tensor(TensorError::DynamicDim { shape: vec![shots] })
+        );
+        assert_eq!(
+            err.to_string(),
+            "shape [<=4000] has an axis whose size is only bounded above, \
+             where a true size is required"
+        );
+    }
+
+    #[test]
+    fn test_eval_duplicates_the_operand() {
+        let x = Tensor::from([1.0_f64, 2.0, 3.0]);
+        assert_eq!(
+            BroadcastTo::new(fixed(&[2, 3])).eval(&[x]).unwrap(),
+            vec![Tensor::F64(
+                arr2(&[[1.0_f64, 2.0, 3.0], [1.0, 2.0, 3.0]])
+                    .into_dyn()
+                    .into_shared()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_eval_takes_a_bounded_axis_size_from_the_operand() {
+        // The bound is 4000 but the tensor has three rows, so the result has three. A bounded axis
+        // takes its size from the operand.
+        let x = Tensor::F64(arr2(&[[1.0_f64], [2.0], [3.0]]).into_dyn().into_shared());
+        let op = BroadcastTo::new(vec![Dim::Bounded { max: 4000 }, Dim::Fixed(2)]);
+        assert_eq!(
+            op.eval(&[x]).unwrap(),
+            vec![Tensor::F64(
+                arr2(&[[1.0_f64, 1.0], [2.0, 2.0], [3.0, 3.0]])
+                    .into_dyn()
+                    .into_shared()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_eval_rejects_an_operand_that_does_not_fit_the_target() {
+        // Inference rejects both of these, so a type-checked op cannot reach them. Evaluation
+        // returns an error rather than panicking.
+        assert_eq!(
+            BroadcastTo::new(fixed(&[4]))
+                .eval(&[Tensor::from([1.0_f64, 2.0, 3.0])])
+                .unwrap_err(),
+            MathOpError::Tensor(TensorError::ShapeMismatch {
+                lhs: vec![3],
+                rhs: vec![4],
+            })
+        );
+        assert_eq!(
+            BroadcastTo::new(fixed(&[3]))
+                .eval(&[Tensor::F64(
+                    arr2(&[[1.0_f64], [2.0]]).into_dyn().into_shared()
+                )])
+                .unwrap_err(),
+            MathOpError::Tensor(TensorError::DimShapeMismatch {
+                lhs: fixed(&[2, 1]),
+                rhs: fixed(&[3]),
+            })
+        );
+        let shots = Dim::Bounded { max: 4000 };
+        assert_eq!(
+            BroadcastTo::new(vec![shots, Dim::Fixed(3)])
+                .eval(&[Tensor::from([1.0_f64, 2.0, 3.0])])
+                .unwrap_err(),
+            MathOpError::Tensor(TensorError::DynamicDim {
+                shape: vec![shots, Dim::Fixed(3)],
+            })
+        );
+    }
+}

--- a/crates/providers/src/ops/cast.rs
+++ b/crates/providers/src/ops/cast.rs
@@ -1,0 +1,180 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! An op to cast an operand's dtype.
+
+use super::error::MathOpError;
+use super::inference::{cast, cast_dtype};
+use super::{ProgramOp, QISKIT};
+use crate::tensor::{DType, Tensor, TensorType};
+
+/// Cast a tensor to a target dtype, keeping its shape.
+#[derive(Clone)]
+pub struct Cast {
+    target: DType,
+}
+
+impl Cast {
+    /// Construct a `Cast` op producing `target`.
+    pub fn new(target: DType) -> Self {
+        Self { target }
+    }
+}
+
+impl ProgramOp for Cast {
+    type Error = MathOpError;
+
+    fn name(&self) -> &str {
+        "cast"
+    }
+    fn namespace(&self) -> &str {
+        QISKIT
+    }
+    fn arity(&self) -> usize {
+        1
+    }
+    fn has_builtin_eval(&self) -> bool {
+        true
+    }
+    fn infer_output_types(&self, inputs: &[TensorType]) -> Result<Vec<TensorType>, Self::Error> {
+        crate::unpack_operands!(self, inputs, [x]);
+        Ok(vec![cast(x, self.target)?])
+    }
+    fn eval(&self, args: &[Tensor]) -> Result<Vec<Tensor>, Self::Error> {
+        crate::unpack_operands!(self, args, [x]);
+        let target = cast_dtype(x.dtype(), self.target)?;
+        Ok(vec![x.clone().cast(target)])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tensor::Dim;
+    use num_complex::Complex64;
+
+    /// The type of a 1-D tensor of `len` elements.
+    fn ty_1d(dtype: DType, len: usize) -> TensorType {
+        TensorType {
+            dtype,
+            shape: vec![Dim::Fixed(len)],
+        }
+    }
+
+    #[test]
+    fn test_cast_full_name_and_arity() {
+        let op = Cast::new(DType::F64);
+        assert_eq!(op.full_name(), "qiskit.cast");
+        assert_eq!(op.arity(), 1);
+        assert!(op.has_builtin_eval());
+    }
+
+    #[test]
+    fn test_infer_output_types_replaces_the_dtype_and_keeps_the_shape() {
+        assert_eq!(
+            Cast::new(DType::I32)
+                .infer_output_types(&[ty_1d(DType::F64, 3)])
+                .unwrap(),
+            vec![ty_1d(DType::I32, 3)]
+        );
+        let bounded = |dtype| TensorType {
+            dtype,
+            shape: vec![Dim::Bounded { max: 4000 }, Dim::Fixed(2)],
+        };
+        assert_eq!(
+            Cast::new(DType::F64)
+                .infer_output_types(&[bounded(DType::Bit)])
+                .unwrap(),
+            vec![bounded(DType::F64)]
+        );
+    }
+
+    #[test]
+    fn test_cast_to_the_dtype_an_operand_already_has_is_admitted() {
+        assert_eq!(
+            Cast::new(DType::F64)
+                .infer_output_types(&[ty_1d(DType::F64, 2)])
+                .unwrap(),
+            vec![ty_1d(DType::F64, 2)]
+        );
+        assert_eq!(
+            Cast::new(DType::C64)
+                .infer_output_types(&[ty_1d(DType::C64, 2)])
+                .unwrap(),
+            vec![ty_1d(DType::C64, 2)]
+        );
+    }
+
+    #[test]
+    fn test_eval_casts_its_operand() {
+        assert_eq!(
+            Cast::new(DType::I32)
+                .eval(&[Tensor::from([1.7_f64, -2.2, 3.0])])
+                .unwrap(),
+            vec![Tensor::from([1_i32, -2, 3])]
+        );
+        assert_eq!(
+            Cast::new(DType::F64)
+                .eval(&[Tensor::from([1_i8, 2])])
+                .unwrap(),
+            vec![Tensor::from([1.0_f64, 2.0])]
+        );
+    }
+
+    #[test]
+    fn test_eval_casts_to_bit_by_testing_against_zero() {
+        // Any non-zero value becomes 1, so the bitwise ops can read the result.
+        assert_eq!(
+            Cast::new(DType::Bit)
+                .eval(&[Tensor::from([0.0_f64, 2.5, -1.0])])
+                .unwrap(),
+            vec![Tensor::Bit(
+                ndarray::arr1(&[0u8, 1, 1]).into_dyn().into_shared()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_a_complex_operand_cannot_be_cast_to_a_real_dtype() {
+        // Rejected when the op is added, so a function cannot type-check and then fail while
+        // running.
+        let op = Cast::new(DType::F64);
+        let err = op.infer_output_types(&[ty_1d(DType::C128, 2)]).unwrap_err();
+        assert_eq!(
+            err,
+            MathOpError::UnsupportedCast {
+                from: DType::C128,
+                to: DType::F64,
+            }
+        );
+        assert_eq!(err.to_string(), "cannot cast C128 to F64");
+        assert_eq!(
+            op.eval(&[Tensor::from([Complex64::new(1.0, 2.0)])])
+                .unwrap_err(),
+            err
+        );
+
+        // A complex target is fine, in either direction between the two widths.
+        assert_eq!(
+            Cast::new(DType::C64)
+                .infer_output_types(&[ty_1d(DType::C128, 2)])
+                .unwrap(),
+            vec![ty_1d(DType::C64, 2)]
+        );
+        assert_eq!(
+            Cast::new(DType::C128)
+                .infer_output_types(&[ty_1d(DType::F32, 2)])
+                .unwrap(),
+            vec![ty_1d(DType::C128, 2)]
+        );
+    }
+}

--- a/crates/providers/src/ops/error.rs
+++ b/crates/providers/src/ops/error.rs
@@ -10,13 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-//! What the arithmetic, bitwise and reduction ops reject.
+//! Errors raised by ops.
 
 use crate::tensor::{DType, Dim, TensorError};
 use thiserror::Error;
 
-/// Errors returned by the arithmetic, bitwise and reduction [`ProgramOp`](super::ProgramOp)
-/// implementations.
+/// Errors returned by the [`ProgramOp`](super::ProgramOp) implementations Qiskit defines.
 ///
 /// Operands are positional, so an offending one is named by index. The op itself is named by
 /// whatever wraps the error: a [`ProgramFunction`](crate::ProgramFunction) attaches its type name.
@@ -33,16 +32,15 @@ pub enum MathOpError {
     #[error("operand {operand}: dtype {dtype} is not supported")]
     UnsupportedDType { operand: usize, dtype: DType },
     /// Two operands promote to a dtype this op does not compute.
-    ///
-    /// An elementwise operation works in the promoted dtype, so that is what has to be admitted.
-    /// Both operand dtypes are named, because neither is at fault on its own: `add` takes a `Bit`
-    /// operand happily alongside an `F64` one, and refuses only two of them together.
     #[error("operands of dtype {lhs} and {rhs} promote to {dtype}, which is not supported")]
     UnsupportedPromotion {
         lhs: DType,
         rhs: DType,
         dtype: DType,
     },
+    /// Complex dtypes cannot be cast to real dtypes.
+    #[error("cannot cast {from} to {to}")]
+    UnsupportedCast { from: DType, to: DType },
     /// A tensor operation failed (dtype or shape mismatch).
     #[error(transparent)]
     Tensor(#[from] TensorError),
@@ -75,12 +73,7 @@ pub(super) fn check_axis(axis: usize, ndim: usize) -> Result<(), MathOpError> {
     Ok(())
 }
 
-/// Remove `axis` from a shape, bounds-checked against its rank.
-///
-/// A reduction divides by the reduced axis's size, but only at run time, which is when that size is
-/// known, and the axis is gone from the result type either way. Surviving axes are copied out
-/// untouched. So a [`Dim::Bounded`] axis passes straight through whether or not it is the one being
-/// folded.
+/// Remove `axis` from a shape.
 pub(super) fn reduced_shape(axis: usize, shape: &[Dim]) -> Result<Vec<Dim>, MathOpError> {
     check_axis(axis, shape.len())?;
     let mut shape = shape.to_vec();

--- a/crates/providers/src/ops/inference.rs
+++ b/crates/providers/src/ops/inference.rs
@@ -10,21 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-//! How operand types become result types, written once per family of op.
-//!
-//! An op names one of these rather than spelling out its own inference, contributing only the
-//! dtypes it accepts and, where a family allows it, how its result dtype follows from its
-//! operand's. The number of distinct rules in the catalogue is therefore the number of functions
-//! here, which is what keeps two ops in the same family from drifting apart.
-//!
-//! The rules coerce: an elementwise operation promotes its operand dtypes and broadcasts their
-//! shapes rather than demanding that a caller insert conversions. Nothing is lost by that, because
-//! an op records both its operand types and its result types, so the explicit form remains
-//! reconstructible from a built program.
+//! Various rules for output tensor type inference.
 
 use super::error::MathOpError;
-use crate::tensor::rules::{broadcast_dims, promotion};
-use crate::tensor::{DType, TensorType};
+use crate::tensor::rules::{broadcast_dims, broadcast_dims_to, promotion};
+use crate::tensor::{DType, Dim, TensorType};
 
 /// Which dtypes an op admits.
 ///
@@ -40,12 +30,12 @@ pub(super) fn any(_dtype: DType) -> bool {
     true
 }
 
-/// Type an elementwise operation over two operands: dtypes promote, shapes broadcast.
+/// Infer the result type of an elementwise operation over two operands.
 ///
-/// The accepted set is checked against the *promoted* dtype rather than each operand's, because that
-/// is the dtype the operation will actually compute in. So `add` admits a `Bit` operand alongside an
-/// `F64` one, which promote to `F64`, while refusing two `Bit` operands, which do not promote to
-/// anything it implements.
+/// The operand dtypes promote and the shapes broadcast. `accepts` is checked against the promoted
+/// dtype rather than against each operand, because the promoted dtype is the one the operation
+/// computes in. So `add` accepts a `Bit` operand alongside an `F64` one, which promote to `F64`, and
+/// rejects two `Bit` operands.
 pub(super) fn elementwise_binary(
     x: &TensorType,
     y: &TensorType,
@@ -65,10 +55,9 @@ pub(super) fn elementwise_binary(
     })
 }
 
-/// Type an elementwise operation over one operand: dtype and shape forwarded untouched.
+/// Infer the result type of an elementwise operation over one operand.
 ///
-/// Being elementwise and unary, this needs no size for any axis, so a bounded one passes straight
-/// through.
+/// The dtype and shape are unchanged.
 pub(super) fn elementwise_unary(
     x: &TensorType,
     accepts: Accepts,
@@ -77,10 +66,10 @@ pub(super) fn elementwise_unary(
     Ok(x.clone())
 }
 
-/// Type a reduction along `axis`, which the result does not have.
+/// Infer the result type of a reduction along `axis`.
 ///
-/// The result dtype is the family's own function of the operand's, not a promotion: averaging a bit
-/// tensor yields a float, which no promotion rule could express.
+/// The result does not have `axis`. Its dtype is `result_dtype` of the operand's dtype; the mean of a
+/// bit tensor is a float, for instance.
 pub(super) fn reduce(
     x: &TensorType,
     axis: usize,
@@ -94,6 +83,22 @@ pub(super) fn reduce(
     })
 }
 
+/// Return the tensor type of a dtype cast to `target`.
+pub(super) fn cast(x: &TensorType, target: DType) -> Result<TensorType, MathOpError> {
+    Ok(TensorType {
+        dtype: cast_dtype(x.dtype, target)?,
+        shape: x.shape.clone(),
+    })
+}
+
+/// Return the tensor type of a broadcast to `target`.
+pub(super) fn broadcast_to(x: &TensorType, target: &[Dim]) -> Result<TensorType, MathOpError> {
+    Ok(TensorType {
+        dtype: x.dtype,
+        shape: broadcast_dims_to(&x.shape, target)?,
+    })
+}
+
 /// Validate that a single operand's dtype is admitted.
 fn check_accepts(dtype: DType, accepts: Accepts) -> Result<(), MathOpError> {
     if !accepts(dtype) {
@@ -102,11 +107,23 @@ fn check_accepts(dtype: DType, accepts: Accepts) -> Result<(), MathOpError> {
     Ok(())
 }
 
-/// The dtype an elementwise binary operation will compute in, for an evaluation that has tensors in
-/// hand rather than types.
+/// The dtype a cast from `from` to `to` produces.
 ///
-/// Evaluation coerces its operands to this before computing, which is what makes the tensors agree
-/// with the types inference promised.
+/// This is the evaluation-time counterpart of [`cast`], which works from types. Every cast is
+/// supported except from a complex dtype to a real one.
+pub(super) fn cast_dtype(from: DType, to: DType) -> Result<DType, MathOpError> {
+    let complex = |dtype| matches!(dtype, DType::C64 | DType::C128);
+    if complex(from) && !complex(to) {
+        return Err(MathOpError::UnsupportedCast { from, to });
+    }
+    Ok(to)
+}
+
+/// The dtype an elementwise binary operation computes in.
+///
+/// This is the evaluation-time counterpart of [`elementwise_binary`], which works from types.
+/// Evaluation casts both operands to this dtype first, so the result matches the type that was
+/// inferred.
 pub(super) fn promoted_dtype(x: DType, y: DType, accepts: Accepts) -> Result<DType, MathOpError> {
     let dtype = promotion(x, y);
     if !accepts(dtype) {
@@ -255,6 +272,73 @@ mod test {
                 dtype: DType::Bit,
             },
             "a promotion the op does not admit is refused at evaluation time too"
+        );
+    }
+
+    #[test]
+    fn test_cast_replaces_the_dtype_and_keeps_the_shape() {
+        let shape = vec![Dim::Bounded { max: 10 }, Dim::Fixed(2)];
+        assert_eq!(
+            cast(
+                &TensorType {
+                    dtype: DType::Bit,
+                    shape: shape.clone(),
+                },
+                DType::C128
+            )
+            .unwrap(),
+            TensorType {
+                dtype: DType::C128,
+                shape,
+            }
+        );
+    }
+
+    #[test]
+    fn test_cast_refuses_a_complex_operand_and_a_real_target() {
+        let err = cast(&ty(DType::C64, &[2]), DType::F64).unwrap_err();
+        assert_eq!(
+            err,
+            MathOpError::UnsupportedCast {
+                from: DType::C64,
+                to: DType::F64,
+            }
+        );
+        assert_eq!(err.to_string(), "cannot cast C64 to F64");
+        assert_eq!(
+            cast(&ty(DType::C64, &[2]), DType::C128).unwrap(),
+            ty(DType::C128, &[2]),
+            "a complex target is admitted in either width"
+        );
+    }
+
+    #[test]
+    fn test_cast_dtype_is_the_dtype_cast_infers() {
+        assert_eq!(cast_dtype(DType::Bit, DType::C128).unwrap(), DType::C128);
+        assert_eq!(
+            cast_dtype(DType::C128, DType::I8).unwrap_err(),
+            MathOpError::UnsupportedCast {
+                from: DType::C128,
+                to: DType::I8,
+            },
+            "a cast the op does not admit is refused at evaluation time too"
+        );
+    }
+
+    #[test]
+    fn test_broadcast_to_makes_the_target_the_result_shape() {
+        let target = [Dim::Fixed(4), Dim::Fixed(2), Dim::Fixed(3)];
+        assert_eq!(
+            broadcast_to(&ty(DType::F32, &[1, 3]), &target).unwrap(),
+            ty(DType::F32, &[4, 2, 3]),
+            "the dtype is unchanged and the shape is the target"
+        );
+        assert_eq!(
+            broadcast_to(&ty(DType::F32, &[2]), &target).unwrap_err(),
+            MathOpError::Tensor(TensorError::DimShapeMismatch {
+                lhs: vec![Dim::Fixed(2)],
+                rhs: target.to_vec(),
+            })
         );
     }
 }

--- a/crates/providers/src/ops/mod.rs
+++ b/crates/providers/src/ops/mod.rs
@@ -19,6 +19,8 @@
 
 mod binary;
 mod bitwise;
+mod broadcast_to;
+mod cast;
 mod constant;
 mod error;
 mod inference;
@@ -28,6 +30,8 @@ mod shot_loop;
 
 pub use binary::{Add, Divide, Multiply, Power, Remainder, Subtract};
 pub use bitwise::{BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, Parity};
+pub use broadcast_to::BroadcastTo;
+pub use cast::Cast;
 pub use constant::Constant;
 pub use error::MathOpError;
 pub use program_op::{BoxedOpError, BoxedProgramOp, ErasedProgramOp, ProgramOp, QISKIT};

--- a/crates/providers/src/program/program_function.rs
+++ b/crates/providers/src/program/program_function.rs
@@ -841,8 +841,9 @@ mod test {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
-    use crate::ops::{Add, Constant, Mean};
+    use crate::ops::{Add, BroadcastTo, Cast, Constant, Mean};
     use crate::tensor::{DType, Dim};
+    use ndarray::arr2;
 
     /// The type of a 1-D `F64` tensor of `len` elements.
     fn f64_1d(len: usize) -> TensorType {
@@ -1434,6 +1435,47 @@ mod test {
             panic!("expected one F64 result, got {results:?}")
         };
         assert_eq!(mean.iter().copied().collect::<Vec<f64>>(), vec![0.75]);
+    }
+
+    #[test]
+    fn mean_cast_and_broadcast_combined() {
+        // Smoke test with mean, cast, and broadcast combined.
+        let mut function = ProgramFunction::new();
+        let shots = function.add_parameter(TensorType {
+            dtype: DType::Bit,
+            shape: vec![Dim::Fixed(4), Dim::Fixed(2)],
+        });
+        let mean = function.add_op(Mean::new(0), &[shots]).unwrap()[0];
+        let whole = function.add_op(Cast::new(DType::I64), &[mean]).unwrap()[0];
+        let per_shot = function
+            .add_op(
+                BroadcastTo::new(vec![Dim::Fixed(4), Dim::Fixed(2)]),
+                &[whole],
+            )
+            .unwrap()[0];
+        function.add_result(per_shot).unwrap();
+
+        assert_eq!(
+            function.type_of(per_shot),
+            Some(&TensorType {
+                dtype: DType::I64,
+                shape: vec![Dim::Fixed(4), Dim::Fixed(2)],
+            })
+        );
+
+        // Evaluate
+        let bits = arr2(&[[1_u8, 0], [1, 1], [1, 1], [1, 1]]).into_dyn();
+        let results = function
+            .eval(&[Tensor::from(bits).cast(DType::Bit)])
+            .unwrap();
+        assert_eq!(
+            results,
+            vec![Tensor::I64(
+                arr2(&[[1_i64, 0], [1, 0], [1, 0], [1, 0]])
+                    .into_dyn()
+                    .into_shared()
+            )]
+        );
     }
 
     #[test]

--- a/crates/providers/src/tensor/rules.rs
+++ b/crates/providers/src/tensor/rules.rs
@@ -154,6 +154,30 @@ pub fn broadcast_dims(a: &[Dim], b: &[Dim]) -> Result<Vec<Dim>, TensorError> {
         .collect()
 }
 
+/// Compute the shape `shape` is broadcast to when the target is `target`, right-aligning the two.
+pub fn broadcast_dims_to(shape: &[Dim], target: &[Dim]) -> Result<Vec<Dim>, TensorError> {
+    let mismatch = || TensorError::DimShapeMismatch {
+        lhs: shape.to_vec(),
+        rhs: target.to_vec(),
+    };
+    if shape.len() > target.len() {
+        return Err(mismatch());
+    }
+    align_axes(shape, target, Dim::Fixed(1))
+        .map(|pair| match pair {
+            (from, to) if from == to => Ok(to),
+            (Dim::Fixed(1), to @ Dim::Fixed(_)) => Ok(to),
+            (Dim::Bounded { .. }, _) => Err(TensorError::DynamicDim {
+                shape: shape.to_vec(),
+            }),
+            (_, Dim::Bounded { .. }) => Err(TensorError::DynamicDim {
+                shape: target.to_vec(),
+            }),
+            _ => Err(mismatch()),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -348,6 +372,83 @@ mod test {
         assert_eq!(
             broadcast_dims(&[bounded, Dim::Fixed(3)], &[Dim::Fixed(3)]).unwrap(),
             vec![bounded, Dim::Fixed(3)]
+        );
+    }
+
+    #[test]
+    fn test_broadcast_dims_to_reaches_the_target() {
+        let fixed = |sizes: &[usize]| sizes.iter().copied().map(Dim::Fixed).collect::<Vec<_>>();
+
+        // A size of 1 grows to the target's size, and a size already the target's is unchanged.
+        assert_eq!(
+            broadcast_dims_to(&fixed(&[1, 5]), &fixed(&[3, 5])).unwrap(),
+            fixed(&[3, 5])
+        );
+        // So do the implicit leading axes that pad the shorter shape.
+        assert_eq!(
+            broadcast_dims_to(&fixed(&[5]), &fixed(&[3, 5])).unwrap(),
+            fixed(&[3, 5])
+        );
+        assert_eq!(broadcast_dims_to(&[], &fixed(&[3])).unwrap(), fixed(&[3]));
+        assert_eq!(broadcast_dims_to(&[], &[]).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn test_broadcast_dims_to_copies_a_bounded_axis_from_the_operand() {
+        let bounded = Dim::Bounded { max: 4000 };
+        assert_eq!(
+            broadcast_dims_to(&[bounded, Dim::Fixed(1)], &[bounded, Dim::Fixed(5)]).unwrap(),
+            vec![bounded, Dim::Fixed(5)]
+        );
+    }
+
+    #[test]
+    fn test_broadcast_dims_to_rejects_a_bounded_axis_with_no_known_size() {
+        let bounded = Dim::Bounded { max: 4000 };
+        let other = Dim::Bounded { max: 8 };
+        for (shape, target, at_fault) in [
+            // A bounded operand axis has no size to compare against a fixed target.
+            (vec![bounded], vec![Dim::Fixed(5)], vec![bounded]),
+            // Growing into a bounded axis would need a number of copies that is unknown.
+            (vec![Dim::Fixed(1)], vec![bounded], vec![bounded]),
+            (vec![Dim::Fixed(5)], vec![bounded], vec![bounded]),
+            (vec![], vec![bounded], vec![bounded]),
+            // Two different bounds need not be equal sizes.
+            (vec![other], vec![bounded], vec![other]),
+        ] {
+            assert_eq!(
+                broadcast_dims_to(&shape, &target).unwrap_err(),
+                TensorError::DynamicDim {
+                    shape: at_fault.clone()
+                },
+                "for {shape:?} broadcast to {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_broadcast_dims_to_rejects_a_target_it_cannot_reach() {
+        // A size other than 1 cannot grow, and an axis cannot be dropped.
+        for (shape, target) in [
+            (vec![Dim::Fixed(3)], vec![Dim::Fixed(4)]),
+            (vec![Dim::Fixed(5)], vec![Dim::Fixed(1)]),
+            (vec![Dim::Fixed(1), Dim::Fixed(3)], vec![Dim::Fixed(3)]),
+        ] {
+            let err = broadcast_dims_to(&shape, &target).unwrap_err();
+            assert_eq!(
+                err,
+                TensorError::DimShapeMismatch {
+                    lhs: shape.clone(),
+                    rhs: target.clone(),
+                },
+                "for {shape:?} broadcast to {target:?}"
+            );
+        }
+        assert_eq!(
+            broadcast_dims_to(&[Dim::Fixed(3)], &[Dim::Fixed(4)])
+                .unwrap_err()
+                .to_string(),
+            "shapes [3] and [4] are not broadcast-compatible"
         );
     }
 

--- a/crates/providers/src/tensor/value.rs
+++ b/crates/providers/src/tensor/value.rs
@@ -12,7 +12,7 @@
 
 //! A tensor value: a dense array over one of the supported dtypes.
 
-use ndarray::{ArcArrayD, ArrayD};
+use ndarray::{ArcArrayD, ArrayD, IxDyn};
 use num_complex::{Complex32, Complex64};
 
 use super::broadcast::{broadcast_elementwise, broadcast_shape};
@@ -205,6 +205,43 @@ impl Tensor {
                 rhs: rhs.dtype(),
             }),
         }
+    }
+
+    /// Broadcast this tensor to `shape`.
+    ///
+    /// The shapes are right-aligned, so leading axes may be added and an axis of size `1` grows to
+    /// any size. Returns [`TensorError::ShapeMismatch`] if `shape` cannot be reached that way. This
+    /// is the value-level counterpart of [`broadcast_dims_to`](super::rules::broadcast_dims_to).
+    pub fn broadcast_to(&self, shape: &[usize]) -> Result<Tensor, TensorError> {
+        if self.shape() == shape {
+            return Ok(self.clone());
+        }
+        let ix = IxDyn(shape);
+        macro_rules! broadcast {
+            ($variant:ident, $arr:expr) => {
+                $arr.broadcast(ix)
+                    .map(|view| Tensor::$variant(view.to_owned().into_shared()))
+            };
+        }
+        match self {
+            Tensor::C128(a) => broadcast!(C128, a),
+            Tensor::C64(a) => broadcast!(C64, a),
+            Tensor::F64(a) => broadcast!(F64, a),
+            Tensor::F32(a) => broadcast!(F32, a),
+            Tensor::I64(a) => broadcast!(I64, a),
+            Tensor::I32(a) => broadcast!(I32, a),
+            Tensor::I16(a) => broadcast!(I16, a),
+            Tensor::I8(a) => broadcast!(I8, a),
+            Tensor::U64(a) => broadcast!(U64, a),
+            Tensor::U32(a) => broadcast!(U32, a),
+            Tensor::U16(a) => broadcast!(U16, a),
+            Tensor::U8(a) => broadcast!(U8, a),
+            Tensor::Bit(a) => broadcast!(Bit, a),
+        }
+        .ok_or_else(|| TensorError::ShapeMismatch {
+            lhs: self.shape().to_vec(),
+            rhs: shape.to_vec(),
+        })
     }
 
     /// Cast this tensor to `target`, consuming it. Returns `self` unchanged if already that dtype.
@@ -691,6 +728,57 @@ mod test {
     fn test_cast_complex_to_real_panics() {
         let t = Tensor::from([Complex64::new(1.0, 2.0)]);
         let _ = t.cast(DType::F64);
+    }
+
+    // -----------------------------------------------------------------------
+    // broadcast_to
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_broadcast_to_duplicates_along_the_axes_that_grow() {
+        // [1, 2, 3] to [2, 3] repeats the row; a leading axis may be added.
+        let t = Tensor::from([1.0_f64, 2.0, 3.0]);
+        let Tensor::F64(arr) = t.broadcast_to(&[2, 3]).unwrap() else {
+            panic!("expected F64 tensor")
+        };
+        assert_eq!(arr.shape(), &[2, 3]);
+        assert_eq!(arr.as_slice().unwrap(), &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0]);
+
+        // A single element reaches any shape.
+        let Tensor::Bit(arr) =
+            Tensor::Bit(ndarray::ArrayD::from_elem(IxDyn(&[1]), 1u8).into_shared())
+                .broadcast_to(&[2, 2])
+                .unwrap()
+        else {
+            panic!("expected Bit tensor")
+        };
+        assert_eq!(arr.as_slice().unwrap(), &[1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn test_broadcast_to_its_own_shape_shares_the_buffer() {
+        let t = Tensor::from([1.0_f64, 2.0, 3.0]);
+        let broadcast = t.broadcast_to(&[3]).unwrap();
+        let (Tensor::F64(orig), Tensor::F64(copy)) = (&t, &broadcast) else {
+            panic!("expected F64 tensors")
+        };
+        assert_eq!(orig.as_ptr(), copy.as_ptr());
+    }
+
+    #[test]
+    fn test_broadcast_to_a_shape_it_cannot_reach_reports_both() {
+        let t = Tensor::from([1.0_f64, 2.0, 3.0]);
+        for shape in [vec![4], vec![1], vec![3, 2], vec![]] {
+            let err = t.broadcast_to(&shape).unwrap_err();
+            assert_eq!(
+                err,
+                TensorError::ShapeMismatch {
+                    lhs: vec![3],
+                    rhs: shape.clone(),
+                },
+                "for target {shape:?}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This branch adds some casting and broadcasting nodes, mostly as a test to make sure that
rank polymorphism works in the way I want it to; I don't actually need these nodes any
time soon because the arithmetic and bitwise nodes all broadcast and coerce as needed.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [x] Some submitted code was generated by: claude opus 5

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>