### PR TITLE
Preserve classical dependencies in LookaheadSwap

### DIFF
--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -289,22 +289,27 @@ def _map_free_gates(state, gates):
             remaining_gates (list): gates that cannot be executed on the layout.
     """
     blocked_qubits = set()
+    blocked_clbits = set()
 
     mapped_gates = []
     remaining_gates = []
     layout_map = state.layout._v2p
 
     for gate in gates:
+        op_node = _first_op_node(gate["graph"])
+        clbits = op_node.cargs
+
         # Gates without a partition (barrier, snapshot, save, load, noise) may
         # still have associated qubits. Look for them in the qargs.
         if not gate["partition"]:
-            qubits = _first_op_node(gate["graph"]).qargs
+            qubits = op_node.qargs
 
             if not qubits:
                 continue
 
-            if blocked_qubits.intersection(qubits):
+            if blocked_qubits.intersection(qubits) or blocked_clbits.intersection(clbits):
                 blocked_qubits.update(qubits)
+                blocked_clbits.update(clbits)
                 remaining_gates.append(gate)
             else:
                 mapped_gate = _transform_gate_for_system(gate, state)
@@ -313,8 +318,9 @@ def _map_free_gates(state, gates):
 
         qubits = gate["partition"][0]
 
-        if blocked_qubits.intersection(qubits):
+        if blocked_qubits.intersection(qubits) or blocked_clbits.intersection(clbits):
             blocked_qubits.update(qubits)
+            blocked_clbits.update(clbits)
             remaining_gates.append(gate)
         elif len(qubits) == 1:
             mapped_gate = _transform_gate_for_system(gate, state)
@@ -324,6 +330,7 @@ def _map_free_gates(state, gates):
             mapped_gates.append(mapped_gate)
         else:
             blocked_qubits.update(qubits)
+            blocked_clbits.update(clbits)
             remaining_gates.append(gate)
 
     return mapped_gates, remaining_gates

--- a/releasenotes/notes/fix-lookahead-swap-clbit-order-9a1c2b3d4e5f6a7b.yaml
+++ b/releasenotes/notes/fix-lookahead-swap-clbit-order-9a1c2b3d4e5f6a7b.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed :class:`.LookaheadSwap` reversing the order of two operations that
+    write to the same classical bit. When an earlier two-qubit operation was
+    temporarily blocked because its qubits were not adjacent, a later operation
+    on independent qubits writing to the same clbit could be mapped ahead of it,
+    reordering the write-after-write dependency on the classical wire. The pass
+    now tracks classical-bit dependencies alongside qubit dependencies.
+    Fixed `#16870 <https://github.com/Qiskit/qiskit/issues/16870>`__.

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -19,8 +19,9 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.transpiler import CouplingMap, Target
 from qiskit.converters import circuit_to_dag
-from qiskit.circuit.library import CXGate
+from qiskit.circuit.library import CXGate, PauliProductMeasurement
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
+from qiskit.quantum_info import Pauli
 from test import QiskitTestCase
 
 from ..legacy_cmaps import MELBOURNE_CMAP
@@ -314,6 +315,23 @@ class TestLookaheadSwap(QiskitTestCase):
         self.assertEqual(
             mapped_dag.count_ops().get("swap", 0), dag_circuit.count_ops().get("swap", 0) + 1
         )
+
+    def test_preserves_classical_write_after_write_order(self):
+        """Two operations writing the same clbit must keep their relative order.
+
+        A two-qubit operation on non-adjacent qubits is initially blocked, but a later
+        operation on an independent qubit writing to the same clbit must not be mapped
+        ahead of it, as that reverses the write-after-write order on the classical bit.
+        """
+        circuit = QuantumCircuit(3, 1)
+        circuit.append(PauliProductMeasurement(Pauli("ZZ")), [0, 2], [0])
+        circuit.measure(1, 0)
+        dag_circuit = circuit_to_dag(circuit)
+
+        mapped_dag = LookaheadSwap(CouplingMap.from_line(3)).run(dag_circuit)
+
+        writers = [node.op.name for node in mapped_dag.topological_op_nodes() if node.cargs]
+        self.assertEqual(writers, ["pauli_product_measurement", "measure"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

`LookaheadSwap` could reverse the order of two operations that write to the same classical bit. When an earlier two-qubit operation is temporarily blocked because its qubits are not adjacent on the coupling map, `_map_free_gates` would still map a later operation on independent qubits — even when both operations write the same `Clbit` — reordering the write-after-write dependency on the classical wire. `_map_free_gates` only tracked `blocked_qubits`, ignoring classical dependencies.

Fix #16870

### Fix

`_map_free_gates` now tracks `blocked_clbits` alongside `blocked_qubits`: a gate whose clbits intersect the blocked set is deferred to `remaining_gates` and its clbits are added to the blocked set, mirroring the existing qubit logic. Register-condition clbits are included, since `serial_layers()` exposes them via the op node's `cargs`.

This is the analogue for `LookaheadSwap` of the classical-dependency fix made for `SabreSwap` in #7952.

### Tests

Added `test_preserves_classical_write_after_write_order` using the reporter's reproducer (a `PauliProductMeasurement` on non-adjacent qubits `[0, 2]` followed by `measure(1, 0)` on a line coupling map), asserting the two clbit writers keep their original order.

### Validation

Ran against a clean checkout with the prebuilt `qiskit` wheel:

```
$ python -m pytest test/python/transpiler/test_lookahead_swap.py -q
...........
11 passed in 1.53s
```

RED→GREEN, verified genuine:
- With the fix reverted (pristine `lookahead_swap.py`), the new test fails:
  `['measure', 'pauli_product_measurement'] != ['pauli_product_measurement', 'measure']`.
- With the fix applied it passes, and all 11 tests in the file pass.
- `black --check` on both changed files: unchanged.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: an LLM assistant (this PR description and code comments), reviewed by me.
- [x] Some submitted code was generated by: an LLM assistant, reviewed and verified by me (RED→GREEN + full existing suite).

Happy to adjust the approach or test if you'd prefer a different form.
