### PR TITLE
Fix LightCone sparse observable ordering

### DIFF
--- a/qiskit/transpiler/passes/optimization/light_cone.py
+++ b/qiskit/transpiler/passes/optimization/light_cone.py
@@ -83,7 +83,10 @@ class LightCone(TransformationPass):
                 )
             lightcone_qubits = [dag.qubits[i] for i in self.indices]
             # `lightcone_operations` is a list of tuples, each containing (operation, list_of_qubits)
-            lightcone_operations = [(PauliGate(self.bit_terms), lightcone_qubits)]
+            # `bit_terms` uses sparse positional ordering (`bit_terms[i]` acts on
+            # `indices[i]`), while `PauliGate` uses dense ordering where the
+            # rightmost character acts on local qubit 0, so reverse the label.
+            lightcone_operations = [(PauliGate(self.bit_terms[::-1]), lightcone_qubits)]
 
         return set(lightcone_qubits), lightcone_operations
 

--- a/releasenotes/notes/fix-light-cone-sparse-order-7f3a9c1e2b4d5f60.yaml
+++ b/releasenotes/notes/fix-light-cone-sparse-order-7f3a9c1e2b4d5f60.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.LightCone` where the positional association between
+    multi-qubit sparse ``bit_terms`` and ``indices`` was reversed when
+    constructing the initial observable. Asymmetric observables could therefore
+    cause incorrect gate removal and change expectation values. The
+    ``bit_terms[i]`` to ``indices[i]`` association is now preserved correctly.
+    Fixed `#16866 <https://github.com/Qiskit/qiskit/issues/16866>`__.

--- a/test/python/transpiler/test_light_cone.py
+++ b/test/python/transpiler/test_light_cone.py
@@ -155,9 +155,27 @@ class TestLightConePass(QiskitTestCase):
         expected.cx(2, 3)
         expected.ry(theta[8], 0)
         expected.ry(theta[10], 2)
-        expected.rz(theta[14], 2)
+        # "IZIX" is X(q0) Z(q2): RZ on q0 anticommutes (kept) while RZ on
+        # q2 commutes (dropped). Pre-gh-16866 reversal kept rz(theta[14], 2).
+        expected.rz(theta[12], 0)
 
         self.assertEqual(expected, new_circuit)
+
+    def test_asymmetric_xz_preserves_bit_term_order(self):
+        """Regression test for gh-16866: `bit_terms[i]` must act on `indices[i]`."""
+        # Sparse "XZ" on [0, 1] means X(q0) Z(q1), so Z(q0) does not
+        # commute with the observable and must be retained. Reversing the
+        # association would wrongly interpret it as Z(q0) X(q1) and drop Z(q0).
+        light_cone = LightCone(bit_terms="XZ", indices=[0, 1])
+        pm = PassManager([light_cone])
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.z(0)
+
+        new_circuit = pm.run(qc)
+
+        self.assertEqual(qc, new_circuit)
 
     def test_all_commuting(self):
         """Test for a circuit that fully commutes with an observable."""
@@ -312,7 +330,14 @@ class TestLightConePass(QiskitTestCase):
 
         new_circuit = pm.run(qc)
 
-        expected = QuantumCircuit(15)
+        if pauli_string == "YYYYYZXYYYYYYYY":
+            # Correct sparse association gives Y(q5) Y(q6), which does not
+            # commute with CX(5, 6), so it must be retained. The pre-gh-16866
+            # reversal mirrored the observable to Z(q5) X(q6), which commutes
+            # and wrongly expected an empty circuit.
+            expected = qc
+        else:
+            expected = QuantumCircuit(15)
 
         self.assertEqual(expected, new_circuit)
 


### PR DESCRIPTION
### Summary

Fixes #16866.

`LightCone` reverses the positional association between sparse observable `bit_terms` and `indices`.

Sparse observable terms associate positionally as `bit_terms[i] -> indices[i]`, while `PauliGate` uses Qiskit's dense Pauli ordering, where the rightmost character acts on local qubit 0. Passing `bit_terms` directly to `PauliGate` therefore reverses asymmetric multi-qubit observables.

This can cause `LightCone` to perform commutation checks against the wrong observable and incorrectly remove gates, changing expectation values.

### Details

- Reverse `bit_terms` when constructing the initial `PauliGate`, preserving the positional association with `indices`.
- Add a regression test for an asymmetric `"XZ"` observable on qubits `[0, 1]`.
- Update two existing test expectations that depended on the reversed ordering.
- Add a release note for the bug fix.

### Testing

- `python -m pytest test/python/transpiler/test_light_cone.py -v` — 22 passed.
- `ruff check qiskit/transpiler/passes/optimization/light_cone.py test/python/transpiler/test_light_cone.py` — passed.
- `black --check qiskit/transpiler/passes/optimization/light_cone.py test/python/transpiler/test_light_cone.py` — passed.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: ChatGPT (OpenAI), Claude (Anthropic)
- [x] Some submitted code was generated by: AI coding agents using OpenAI and Anthropic models

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->