### PR TITLE
[WIP] Generalize add/sub simplification for binary+-binary expressions with a shared term

### DIFF
--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -1488,31 +1488,24 @@ impl SymbolExpr {
                                 if l_rhs.expand().string_id() == r_rhs.expand().string_id() {
                                     let t = SymbolExpr::Value(lv + rv);
                                     match (op, rop) {
-                                        (BinaryOp::Add, BinaryOp::Add) => {
-                                            // (lv + X) + (rv + X)  ->  (lv+rv) + 2*X = t + 2*X
-                                            let doubled = _mul(
-                                                SymbolExpr::Value(Value::Int(2)),
+                                        // (lv + X) + (rv + X)  ->  t + 2*X
+                                        // (lv - X) + (rv - X)  ->  t - 2*X
+                                        (BinaryOp::Add, BinaryOp::Add)
+                                        | (BinaryOp::Sub, BinaryOp::Sub) => {
+                                            let two_signed =
+                                                if matches!(op, BinaryOp::Add) { 2 } else { -2 };
+                                            let doubled_signed = _mul(
+                                                SymbolExpr::Value(Value::Int(two_signed)),
                                                 l_rhs.as_ref().clone(),
                                             );
                                             return Some(if t.is_zero() {
-                                                doubled
+                                                doubled_signed
                                             } else {
-                                                _add(t, doubled)
+                                                _add(t, doubled_signed)
                                             });
                                         }
-                                        (BinaryOp::Sub, BinaryOp::Sub) => {
-                                            // (lv - X) + (rv - X)  ->  (lv+rv) - 2*X = t - 2*X
-                                            let mdoubled: SymbolExpr = _mul(
-                                                SymbolExpr::Value(Value::Int(-2)),
-                                                l_rhs.as_ref().clone(),
-                                            );
-                                            return Some(if t.is_zero() {
-                                                mdoubled
-                                            } else {
-                                                _add(t, mdoubled)
-                                            });
-                                        }
-                                        // (lv +- X) + (rv -+ X)  ->  the X terms cancel: (lv+rv) = t
+                                        // (lv + X) + (rv - X)  ->  X canceled -> (lv+rv) = t
+                                        // (lv - X) + (rv + X)  ->  X canceled -> (lv+rv) = t
                                         (BinaryOp::Sub, BinaryOp::Add)
                                         | (BinaryOp::Add, BinaryOp::Sub) => {
                                             return Some(t);
@@ -1541,8 +1534,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
-                            // (X / lv) + (Y / rv) where X == +-Y
-                            //   ->  (rv*X + lv*Y) / (lv*rv)
+                            // (X / lv) + (Y / rv) ->  (rv*X + lv*Y) / (lv*rv)
+                            // only when X == +-Y, so add_opt collapses (rv*X + lv*Y) into a single term
                             (_, SymbolExpr::Value(lv), _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Div, BinaryOp::Div) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1558,8 +1551,8 @@ impl SymbolExpr {
                                     };
                                 }
                             }
-                            // (lv * X) + (Y / rv) where X == +-Y: rewrite the Div as a Mul
-                            //   ->  (lv * X) + ((1/rv) * Y), then retry
+                            // (lv * X) + (Y / rv) ->  (lv * X) + ((1/rv) * Y)
+                            // rewrite Div as Mul when X == +-Y so add_opt collapses them into a single term
                             (SymbolExpr::Value(_), _, _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Mul, BinaryOp::Div) = (op, rop)
                                     && (l_rhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1575,8 +1568,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
-                            // (X / lv) + (rv * Y) where X == +-Y: rewrite the Div as a Mul
-                            //   ->  ((1/lv) * X) + (rv * Y), then retry
+                            // (X / lv) + (rv * Y) -> ((1/lv) * X) + (rv * Y)
+                            // rewrite Div as Mul when X == +-Y so add_opt collapses them into a single term
                             (_, SymbolExpr::Value(lv), SymbolExpr::Value(_), _) => {
                                 if let (BinaryOp::Div, BinaryOp::Mul) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_rhs.expand().string_id()
@@ -1908,33 +1901,26 @@ impl SymbolExpr {
                                 if l_rhs.expand().string_id() == r_rhs.expand().string_id() {
                                     let t = SymbolExpr::Value(lv - rv);
                                     match (op, rop) {
-                                        // (lv +- X) - (rv +- X)  ->  the X terms cancel: (lv-rv) = t
+                                        // (lv + X) - (rv + X)  ->  X canceled -> (lv-rv) = t
+                                        // (lv - X) - (rv - X)  ->  X canceled -> (lv-rv) = t
                                         (BinaryOp::Add, BinaryOp::Add)
                                         | (BinaryOp::Sub, BinaryOp::Sub) => {
                                             return Some(t);
                                         }
                                         // (lv - X) - (rv + X)  ->  (lv-rv) - 2*X = t - 2*X
-                                        (BinaryOp::Sub, BinaryOp::Add) => {
-                                            let mdoubled = _mul(
-                                                SymbolExpr::Value(Value::Int(-2)),
-                                                l_rhs.as_ref().clone(),
-                                            );
-                                            return Some(if t.is_zero() {
-                                                mdoubled
-                                            } else {
-                                                _add(t, mdoubled)
-                                            });
-                                        }
                                         // (lv + X) - (rv - X)  ->  (lv-rv) + 2*X = t + 2*X
-                                        (BinaryOp::Add, BinaryOp::Sub) => {
-                                            let doubled = _mul(
-                                                SymbolExpr::Value(Value::Int(2)),
+                                        (BinaryOp::Sub, BinaryOp::Add)
+                                        | (BinaryOp::Add, BinaryOp::Sub) => {
+                                            let two_signed =
+                                                if matches!(op, BinaryOp::Sub) { -2 } else { 2 };
+                                            let doubled_signed = _mul(
+                                                SymbolExpr::Value(Value::Int(two_signed)),
                                                 l_rhs.as_ref().clone(),
                                             );
                                             return Some(if t.is_zero() {
-                                                doubled
+                                                doubled_signed
                                             } else {
-                                                _add(t, doubled)
+                                                _add(t, doubled_signed)
                                             });
                                         }
                                         // (lv * X) - (rv * X)  ->  (lv-rv) * X = t * X
@@ -1961,8 +1947,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
-                            // (X / lv) - (Y / rv) where X == +-Y
-                            //   ->  (rv*X - lv*Y) / (lv*rv)
+                            // (X / lv) - (Y / rv) -> (rv*X - lv*Y) / (lv*rv)
+                            // only when X == +-Y, so sub_opt collapses rv*X - lv*Y into a single term
                             (_, SymbolExpr::Value(lv), _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Div, BinaryOp::Div) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1978,8 +1964,8 @@ impl SymbolExpr {
                                     };
                                 }
                             }
-                            // (lv * X) - (Y / rv) where X == +-Y: rewrite the Div as a Mul
-                            //   ->  (lv * X) - ((1/rv) * Y), then retry
+                            // (lv * X) - (Y / rv) ->  (lv * X) - ((1/rv) * Y)
+                            // rewrite the Div as a Mul only when X == +-Y so sub_opt collapses them
                             (SymbolExpr::Value(_), _, _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Mul, BinaryOp::Div) = (op, rop)
                                     && (l_rhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1995,8 +1981,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
-                            // (X / lv) - (rv * Y) where X == +-Y: rewrite the Div as a Mul
-                            //   ->  ((1/lv) * X) - (rv * Y), then retry
+                            // (X / lv) - (rv * Y) -> ((1/lv) * X) - (rv * Y)
+                            // rewrite the Div as a Mul only when X == +-Y so sub_opt collapses them
                             (_, SymbolExpr::Value(lv), SymbolExpr::Value(_), _) => {
                                 if let (BinaryOp::Div, BinaryOp::Mul) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_rhs.expand().string_id()

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -1470,6 +1470,7 @@ impl SymbolExpr {
                     lhs: l_lhs,
                     rhs: l_rhs,
                 } => {
+                    // Binary + Binary
                     if let SymbolExpr::Binary {
                         op: rop,
                         lhs: r_lhs,
@@ -1482,28 +1483,41 @@ impl SymbolExpr {
                             r_lhs.as_ref(),
                             r_rhs.as_ref(),
                         ) {
+                            // shared terms (lv op X) + (rv op X)
                             (SymbolExpr::Value(lv), _, SymbolExpr::Value(rv), _) => {
                                 if l_rhs.expand().string_id() == r_rhs.expand().string_id() {
                                     let t = SymbolExpr::Value(lv + rv);
                                     match (op, rop) {
-                                        (BinaryOp::Add, BinaryOp::Add) if t.is_zero() => {
-                                            return Some(_mul(
+                                        (BinaryOp::Add, BinaryOp::Add) => {
+                                            // (lv + X) + (rv + X)  ->  (lv+rv) + 2*X = t + 2*X
+                                            let doubled = _mul(
                                                 SymbolExpr::Value(Value::Int(2)),
                                                 l_rhs.as_ref().clone(),
-                                            ));
+                                            );
+                                            return Some(if t.is_zero() {
+                                                doubled
+                                            } else {
+                                                _add(t, doubled)
+                                            });
                                         }
-                                        (BinaryOp::Sub, BinaryOp::Sub) if t.is_zero() => {
-                                            return Some(_mul(
+                                        (BinaryOp::Sub, BinaryOp::Sub) => {
+                                            // (lv - X) + (rv - X)  ->  (lv+rv) - 2*X = t - 2*X
+                                            let mdoubled: SymbolExpr = _mul(
                                                 SymbolExpr::Value(Value::Int(-2)),
                                                 l_rhs.as_ref().clone(),
-                                            ));
+                                            );
+                                            return Some(if t.is_zero() {
+                                                mdoubled
+                                            } else {
+                                                _add(t, mdoubled)
+                                            });
                                         }
+                                        // (lv +- X) + (rv -+ X)  ->  the X terms cancel: (lv+rv) = t
                                         (BinaryOp::Sub, BinaryOp::Add)
-                                        | (BinaryOp::Add, BinaryOp::Sub)
-                                            if t.is_zero() =>
-                                        {
-                                            return Some(SymbolExpr::Value(Value::Int(0)));
+                                        | (BinaryOp::Add, BinaryOp::Sub) => {
+                                            return Some(t);
                                         }
+                                        // (lv * X) + (rv * X)  ->  (lv+rv) * X = t * X
                                         (BinaryOp::Mul, BinaryOp::Mul) => {
                                             if t.is_zero() {
                                                 return Some(SymbolExpr::Value(Value::Int(0)));
@@ -1513,6 +1527,7 @@ impl SymbolExpr {
                                                 None => Some(_mul(t, l_rhs.as_ref().clone())),
                                             };
                                         }
+                                        // (lv / X) + (rv / X)  ->  (lv+rv) / X = t / X
                                         (BinaryOp::Div, BinaryOp::Div) => {
                                             if t.is_zero() {
                                                 return Some(SymbolExpr::Value(Value::Int(0)));
@@ -1526,6 +1541,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
+                            // (X / lv) + (Y / rv) where X == +-Y
+                            //   ->  (rv*X + lv*Y) / (lv*rv)
                             (_, SymbolExpr::Value(lv), _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Div, BinaryOp::Div) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1541,6 +1558,8 @@ impl SymbolExpr {
                                     };
                                 }
                             }
+                            // (lv * X) + (Y / rv) where X == +-Y: rewrite the Div as a Mul
+                            //   ->  (lv * X) + ((1/rv) * Y), then retry
                             (SymbolExpr::Value(_), _, _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Mul, BinaryOp::Div) = (op, rop)
                                     && (l_rhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1556,6 +1575,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
+                            // (X / lv) + (rv * Y) where X == +-Y: rewrite the Div as a Mul
+                            //   ->  ((1/lv) * X) + (rv * Y), then retry
                             (_, SymbolExpr::Value(lv), SymbolExpr::Value(_), _) => {
                                 if let (BinaryOp::Div, BinaryOp::Mul) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_rhs.expand().string_id()
@@ -1864,6 +1885,7 @@ impl SymbolExpr {
                         }
                     }
                 }
+                // Binary - Binary
                 SymbolExpr::Binary {
                     op,
                     lhs: l_lhs,
@@ -1881,28 +1903,41 @@ impl SymbolExpr {
                             r_lhs.as_ref(),
                             r_rhs.as_ref(),
                         ) {
+                            // shared terms: (lv op X) - (rv op X)
                             (SymbolExpr::Value(lv), _, SymbolExpr::Value(rv), _) => {
                                 if l_rhs.expand().string_id() == r_rhs.expand().string_id() {
                                     let t = SymbolExpr::Value(lv - rv);
                                     match (op, rop) {
+                                        // (lv +- X) - (rv +- X)  ->  the X terms cancel: (lv-rv) = t
                                         (BinaryOp::Add, BinaryOp::Add)
-                                        | (BinaryOp::Sub, BinaryOp::Sub)
-                                            if t.is_zero() =>
-                                        {
-                                            return Some(SymbolExpr::Value(Value::Int(0)));
+                                        | (BinaryOp::Sub, BinaryOp::Sub) => {
+                                            return Some(t);
                                         }
-                                        (BinaryOp::Sub, BinaryOp::Add) if t.is_zero() => {
-                                            return Some(_mul(
+                                        // (lv - X) - (rv + X)  ->  (lv-rv) - 2*X = t - 2*X
+                                        (BinaryOp::Sub, BinaryOp::Add) => {
+                                            let doubled_minus = _mul(
                                                 SymbolExpr::Value(Value::Int(-2)),
                                                 l_rhs.as_ref().clone(),
-                                            ));
+                                            );
+                                            return Some(if t.is_zero() {
+                                                doubled_minus
+                                            } else {
+                                                _add(t, doubled_minus)
+                                            });
                                         }
-                                        (BinaryOp::Add, BinaryOp::Sub) if t.is_zero() => {
-                                            return Some(_mul(
+                                        // (lv + X) - (rv - X)  ->  (lv-rv) + 2*X = t + 2*X
+                                        (BinaryOp::Add, BinaryOp::Sub) => {
+                                            let doubled = _mul(
                                                 SymbolExpr::Value(Value::Int(2)),
                                                 l_rhs.as_ref().clone(),
-                                            ));
+                                            );
+                                            return Some(if t.is_zero() {
+                                                doubled
+                                            } else {
+                                                _add(t, doubled)
+                                            });
                                         }
+                                        // (lv * X) - (rv * X)  ->  (lv-rv) * X = t * X
                                         (BinaryOp::Mul, BinaryOp::Mul) => {
                                             if t.is_zero() {
                                                 return Some(SymbolExpr::Value(Value::Int(0)));
@@ -1912,6 +1947,7 @@ impl SymbolExpr {
                                                 None => Some(_mul(t, l_rhs.as_ref().clone())),
                                             };
                                         }
+                                        // (lv / X) - (rv / X)  ->  (lv-rv) / X = t / X
                                         (BinaryOp::Div, BinaryOp::Div) => {
                                             if t.is_zero() {
                                                 return Some(SymbolExpr::Value(Value::Int(0)));
@@ -1925,6 +1961,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
+                            // (X / lv) - (Y / rv) where X == +-Y
+                            //   ->  (rv*X - lv*Y) / (lv*rv)
                             (_, SymbolExpr::Value(lv), _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Div, BinaryOp::Div) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1940,6 +1978,8 @@ impl SymbolExpr {
                                     };
                                 }
                             }
+                            // (lv * X) - (Y / rv) where X == +-Y: rewrite the Div as a Mul
+                            //   ->  (lv * X) - ((1/rv) * Y), then retry
                             (SymbolExpr::Value(_), _, _, SymbolExpr::Value(rv)) => {
                                 if let (BinaryOp::Mul, BinaryOp::Div) = (op, rop)
                                     && (l_rhs.expand().string_id() == r_lhs.expand().string_id()
@@ -1955,6 +1995,8 @@ impl SymbolExpr {
                                     }
                                 }
                             }
+                            // (X / lv) - (rv * Y) where X == +-Y: rewrite the Div as a Mul
+                            //   ->  ((1/lv) * X) - (rv * Y), then retry
                             (_, SymbolExpr::Value(lv), SymbolExpr::Value(_), _) => {
                                 if let (BinaryOp::Div, BinaryOp::Mul) = (op, rop)
                                     && (l_lhs.expand().string_id() == r_rhs.expand().string_id()

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -1915,14 +1915,14 @@ impl SymbolExpr {
                                         }
                                         // (lv - X) - (rv + X)  ->  (lv-rv) - 2*X = t - 2*X
                                         (BinaryOp::Sub, BinaryOp::Add) => {
-                                            let doubled_minus = _mul(
+                                            let mdoubled = _mul(
                                                 SymbolExpr::Value(Value::Int(-2)),
                                                 l_rhs.as_ref().clone(),
                                             );
                                             return Some(if t.is_zero() {
-                                                doubled_minus
+                                                mdoubled
                                             } else {
-                                                _add(t, doubled_minus)
+                                                _add(t, mdoubled)
                                             });
                                         }
                                         // (lv + X) - (rv - X)  ->  (lv-rv) + 2*X = t + 2*X

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -19,7 +19,6 @@ import pickle
 import copy
 import functools
 import itertools
-import operator
 
 from test import combine
 from test import QiskitTestCase
@@ -1121,74 +1120,37 @@ class TestParameterExpression(QiskitTestCase):
     def test_structurally_equal(self, left, right, expected):
         self.assertStructurallyEqualResult(left, right, expected)
 
-    def test_add_optimization_with_shared_terms(self):
-        """Add of expressions with shared terms and opposite sign should cancel."""
+    @ddt.data("__add__", "__sub__")
+    def test_optimization_with_shared_terms(self, method):
+        """Adding or subtracting two expressions with a shared term should fold the constants and
+        either double or cancel the shared term.
 
-        x = Parameter("x")
-
-        # (label, lhs, rhs, expected_repr)
-        cases = [
-            # plain symbol cancellation
-            ("(x) + (-x)", x, -x, "0"),
-            ("(-x) + (x)", -x, x, "0"),
-            # shared symbol cancels when sign is opposite
-            ("(x+1) + (x+2)", x + 1, x + 2, "3 + 2*x"),
-            ("(x+1) + (x-1)", x + 1, x - 1, "2*x"),
-            ("(-x+1) + (-x+2)", -x + 1, -x + 2, "3 - 2*x"),
-            ("(-x+1) + (-x-1)", -x + 1, -x - 1, "(-2)*x"),
-            ("(-x+1) + (x+2)", -x + 1, x + 2, "3"),
-            ("(-x+1) + (x-1)", -x + 1, x - 1, "0"),
-            ("(x+1) + (-x+1)", x + 1, -x + 1, "2"),
-            ("(x+1) + (-x-1)", x + 1, -x - 1, "0"),
-        ]
-
-        self._assert_simplifies(cases, operator.add)
-
-    def test_sub_optimization_with_shared_terms(self):
-        """Sub of expressions with shared terms and same sign should cancel."""
-
-        x = Parameter("x")
-
-        # (label, lhs, rhs, expected_repr)
-        cases = [
-            # plain symbol cancellation
-            ("(x) - (x)", x, x, "0"),
-            # shared symbol cancels when sign is equal
-            ("(x+1) - (x-1)", x + 1, x - 1, "2"),
-            ("(x+1) - (x+1)", x + 1, x + 1, "0"),
-            ("(-x+1) - (-x-1)", -x + 1, -x - 1, "2"),
-            ("(-x+1) - (-x+1)", -x + 1, -x + 1, "0"),
-            ("(x+1) - (-x+3)", x + 1, -x + 3, "-2 + 2*x"),
-            ("(x+1) - (-x+1)", x + 1, -x + 1, "2*x"),
-            ("(-x+1) - (x+2)", -x + 1, x + 2, "-1 - 2*x"),
-            ("(-x+1) - (x+1)", -x + 1, x + 1, "(-2)*x"),
-        ]
-
-        self._assert_simplifies(cases, operator.sub)
-
-    def _assert_simplifies(self, cases, op):
-        """Check that each ``op(lhs, rhs)`` simplifies as expected, and that
-        the results is arithmetically correct.
-
-        ``cases`` is a list of ``(label, lhs, rhs, expected)`` tuples.
+        Tests all combinations of ``x+1, x-1, -x+1, -x-1`` with add/sub, comparing against the
+        expected simplified expression.
         """
+        # (expression, sign of x, constant); the sign and constant are used to compute the
+        # expected expression.
+        terms = [
+            (param_x + 1, 1, 1),
+            (param_x - 1, 1, -1),
+            (-param_x + 1, -1, 1),
+            (-param_x - 1, -1, -1),
+        ]
+        # all ordered pairs, including an expression paired with itself
+        for (lhs, left_sign, left_const), (rhs, right_sign, right_const) in itertools.product(
+            terms, repeat=2
+        ):
+            with self.subTest(lhs=str(lhs), method=method, rhs=str(rhs)):
 
-        params = sorted(
-            {q for _, lhs, rhs, _ in cases for q in lhs.parameters | rhs.parameters},
-            key=lambda q: q.name,
-        )
-        bind = {p: float(i) for i, p in enumerate(params, start=1)}
+                expression = getattr(lhs, method)(rhs)
 
-        for name, lhs, rhs, expected in cases:
-            with self.subTest(name):
-                expr = op(lhs, rhs)
+                # compute expected simplified experession directly
+                sign = getattr(left_sign, method)(right_sign)
+                const = getattr(left_const, method)(right_const)
+                expected = sign * param_x + const
 
-                # simplified as expected
-                self.assertEqual(str(expr), expected)
-
-                # simplified expression is arithmetically correct
-                lhs_bind = {p: v for p, v in bind.items() if p in lhs.parameters}
-                rhs_bind = {p: v for p, v in bind.items() if p in rhs.parameters}
-                reference = op(lhs.bind(lhs_bind), rhs.bind(rhs_bind))
-                expr_bind = {p: v for p, v in bind.items() if p in expr.parameters}
-                self.assertAlmostEqual(float(expr.bind(expr_bind).numeric()), float(reference))
+                # `assertStructurallyEqual` would be the better assertion here, but it
+                # doesn't handle simplification yet -- a cancelled symbol stays listed in
+                # `name_map`, so the expected expression won't match.  Comparing the rendered
+                # form in the meantime.
+                self.assertEqual(str(expression), str(expected))

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -19,6 +19,7 @@ import pickle
 import copy
 import functools
 import itertools
+import operator
 
 from test import combine
 from test import QiskitTestCase
@@ -1054,7 +1055,7 @@ class TestParameterExpression(QiskitTestCase):
         value = 1.234
 
         for terms in [add_sub_terms, pow_terms, rpow_terms, mul_terms, rdiv_terms, div_terms]:
-            for lhs, rhs in itertools.combinations(terms, 2):
+            for lhs, rhs in itertools.permutations(terms, 2):
                 with self.subTest(lhs=lhs, rhs=rhs):
                     reference = getattr(lhs.bind({x: value}), method)(rhs.bind({x: value}))
                     expression = getattr(lhs, method)(rhs)
@@ -1119,3 +1120,74 @@ class TestParameterExpression(QiskitTestCase):
     )
     def test_structurally_equal(self, left, right, expected):
         self.assertStructurallyEqualResult(left, right, expected)
+    def test_add_with_shared_terms(self):
+        """Add of expressions with shared terms and opposite sign should cancel."""
+
+        x = Parameter("x")
+
+        # (label, lhs, rhs, expected_repr)
+        cases = [
+            # plain symbol cancellation
+            ("(x) + (-x)", x, -x, "0"),
+            ("(-x) + (x)", -x, x, "0"),
+            # shared symbol cancels when sign is opposite
+            ("(x+1) + (x+2)", x + 1, x + 2, "3 + 2*x"),
+            ("(x+1) + (x-1)", x + 1, x - 1, "2*x"),
+            ("(-x+1) + (-x+2)", -x + 1, -x + 2, "3 - 2*x"),
+            ("(-x+1) + (-x-1)", -x + 1, -x - 1, "(-2)*x"),
+            ("(-x+1) + (x+2)", -x + 1, x + 2, "3"),
+            ("(-x+1) + (x-1)", -x + 1, x - 1, "0"),
+            ("(x+1) + (-x+1)", x + 1, -x + 1, "2"),
+            ("(x+1) + (-x-1)", x + 1, -x - 1, "0"),
+        ]
+
+        self._assert_simplifies(cases, operator.add)
+
+    def test_sub_with_shared_terms(self):
+        """Sub of expressions with shared terms and same sign should cancel."""
+
+        x = Parameter("x")
+
+        # (label, lhs, rhs, expected_repr)
+        cases = [
+            # plain symbol cancellation
+            ("(x) - (x)", x, x, "0"),
+            # shared symbol cancels when sign is equal
+            ("(x+1) - (x-1)", x + 1, x - 1, "2"),
+            ("(x+1) - (x+1)", x + 1, x + 1, "0"),
+            ("(-x+1) - (-x-1)", -x + 1, -x - 1, "2"),
+            ("(-x+1) - (-x+1)", -x + 1, -x + 1, "0"),
+            ("(x+1) - (-x+3)", x + 1, -x + 3, "-2 + 2*x"),
+            ("(x+1) - (-x+1)", x + 1, -x + 1, "2*x"),
+            ("(-x+1) - (x+2)", -x + 1, x + 2, "-1 - 2*x"),
+            ("(-x+1) - (x+1)", -x + 1, x + 1, "(-2)*x"),
+        ]
+
+        self._assert_simplifies(cases, operator.sub)
+
+    def _assert_simplifies(self, cases, op):
+        """Check that each ``op(lhs, rhs)`` simplifies as expected, and that
+        the results is arithmetically correct.
+
+        ``cases`` is a list of ``(label, lhs, rhs, expected)`` tuples.
+        """
+
+        params = sorted(
+            {q for _, lhs, rhs, _ in cases for q in lhs.parameters | rhs.parameters},
+            key=lambda q: q.name,
+        )
+        bind = {p: float(i) for i, p in enumerate(params, start=1)}
+
+        for name, lhs, rhs, expected in cases:
+            with self.subTest(name):
+                expr = op(lhs, rhs)
+
+                # simplified as expected
+                self.assertEqual(str(expr), expected)
+
+                # simplified expression is arithmetically correct
+                lhs_bind = {p: v for p, v in bind.items() if p in lhs.parameters}
+                rhs_bind = {p: v for p, v in bind.items() if p in rhs.parameters}
+                reference = op(lhs.bind(lhs_bind), rhs.bind(rhs_bind))
+                expr_bind = {p: v for p, v in bind.items() if p in expr.parameters}
+                self.assertAlmostEqual(float(expr.bind(expr_bind).numeric()), float(reference))

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -1120,7 +1120,8 @@ class TestParameterExpression(QiskitTestCase):
     )
     def test_structurally_equal(self, left, right, expected):
         self.assertStructurallyEqualResult(left, right, expected)
-    def test_add_with_shared_terms(self):
+
+    def test_add_optimization_with_shared_terms(self):
         """Add of expressions with shared terms and opposite sign should cancel."""
 
         x = Parameter("x")
@@ -1143,7 +1144,7 @@ class TestParameterExpression(QiskitTestCase):
 
         self._assert_simplifies(cases, operator.add)
 
-    def test_sub_with_shared_terms(self):
+    def test_sub_optimization_with_shared_terms(self):
         """Sub of expressions with shared terms and same sign should cancel."""
 
         x = Parameter("x")


### PR DESCRIPTION
Partially solves #16786 , Follow-up to the review comment on #16752.

`SymbolExpr` simplifies several simple cases but misses other obvious ones.
Specifically it doesn't simplify the general form of add/sub of two binary expressions with shared symbols terms.
This PR expands it to such cases:
```
(x+1) + (-x+2)  ==>  3
(x+1) + (x+2)   ==>  3 + 2*x
```

Currently, the binary-binary has an arm for `(lv op X) ± (rv rop X)` pattern,  but simplification is gated on the constants summing to zero.
```
add_opt, t = lv+rv 
------------------
(lv + X) + (rv + X) ==>  if t == 0 then  2X, otherwise no simplification 
(lv + X) + (rv - X) ==>  if t == 0 then  0, otherwise no simplification 
```

Dropping the gate and keeping `t` generalizes the simplification, while existing results are unchanged.
```
add_opt, t = lv+rv 
------------------
(lv + X) + (rv + X) ==> t + 2X
(lv + X) + (rv - X) ==> t
```


### What changed:
- `crates/circuit/src/parameter/symbol_expr.rs` — `add_opt` and `sub_opt`, the
  `(SymbolExpr::Value(lv), _, SymbolExpr::Value(rv), _)` match arm simplification expanded. Also added documentation of patterns handled in each of the Binary-Binary code blocks.
- `test/python/circuit/test_parameter_expression.py` — `test_add_optimization_with_shared_terms`
  and `test_sub_optimization_with_shared_terms`, covering all four operator pairings each with and without a zero constant sum.
- `test_optimization_same_symbol` (added in #16752) changed terms pairing to 
  `itertools.permutations` instead of `combinations` to make it test also the reversed op pair in each case.
  
### Not covered in this PR:
- Bare symbol + Binary: `x + (-x+1), (x+1) - x` — it's not in the binary×binary block.
- Shared non-constant term: `(x+y) + (x-y)`, `(x*z+y) + (x*z-y)` — fall through to the catch-all `(_, _, _, _)` arm of the binary-binary.


### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: Claude Opus 5
- [x] Some submitted code was generated by: Claude Opus 5
