### PR TITLE
Fix TwoQubitWeylDecomposition failing to diagonalize near-degenerate unitaries

### DIFF
--- a/crates/synthesis/src/two_qubit_decompose/weyl_decomposition.rs
+++ b/crates/synthesis/src/two_qubit_decompose/weyl_decomposition.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use approx::abs_diff_eq;
 use num_complex::{Complex, Complex64, ComplexFloat};
 use smallvec::SmallVec;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
@@ -344,6 +343,72 @@ impl Specialization {
     }
 }
 
+/// Tolerance used to decide that two eigenvalues of `Re(M2)` are close enough that
+/// picking an eigenvector basis for them independently of `Im(M2)` is unsafe.  It only
+/// needs to be small compared to the generic O(1) spacing between distinct Weyl
+/// coordinates, while comfortably covering the floating-point-noise-scale near-degeneracies
+/// (typically 1e-9 or smaller) that provoke https://github.com/Qiskit/qiskit/issues/4159.
+const CLUSTER_DEGENERACY_TOL: f64 = 1.0e-7;
+
+/// Deterministically find a real orthogonal `P` that simultaneously diagonalizes the
+/// real-symmetric matrices `A = Re(M2)` and `B = Im(M2)` of a complex-symmetric unitary
+/// `M2`, i.e. attempt to solve `M2 = P D P^T`.
+///
+/// `A` and `B` commute exactly when `M2` is exactly unitary, so in exact arithmetic any
+/// eigenbasis of `A` that is refined within degenerate eigenspaces by also diagonalizing
+/// `B` there will simultaneously diagonalize both. In floating point, `M2` is only
+/// unitary up to the caller's own precision, so `A` and `B` only approximately commute.
+/// The randomized loop below picks a single random real combination of `A` and `B` and
+/// diagonalizes that instead; but if two eigenvalues of `M2` are themselves nearly equal
+/// (which happens for many circuits built from a handful of standard gates, see the
+/// issue above), then every real combination has a near-tied pair of eigenvalues there
+/// too, no matter the random coefficients chosen, so retrying with new random
+/// coefficients can never resolve the ambiguity. Explicitly clustering the eigenvalues of
+/// `A` and re-diagonalizing `B` restricted to each near-degenerate cluster targets
+/// exactly this failure mode instead of leaving it to chance.
+fn cluster_diagonalize_m2(m2: &Matrix4<Complex64>) -> Matrix4<f64> {
+    let a = m2.map(|z| z.re);
+    let b = m2.map(|z| z.im);
+
+    let eig = nalgebra::linalg::SymmetricEigen::new(a);
+    let mut order: [usize; 4] = [0, 1, 2, 3];
+    order.sort_by(|&i, &j| eig.eigenvalues[i].partial_cmp(&eig.eigenvalues[j]).unwrap());
+
+    // Group `order` into runs of consecutive (now sorted) indices whose eigenvalues are
+    // within `CLUSTER_DEGENERACY_TOL` of their run's starting eigenvalue.
+    let mut clusters: Vec<Vec<usize>> = Vec::new();
+    for idx in order {
+        let same_cluster = clusters.last().is_some_and(|cluster: &Vec<usize>| {
+            let anchor = cluster[0];
+            (eig.eigenvalues[idx] - eig.eigenvalues[anchor]).abs() <= CLUSTER_DEGENERACY_TOL
+        });
+        if same_cluster {
+            clusters.last_mut().unwrap().push(idx);
+        } else {
+            clusters.push(vec![idx]);
+        }
+    }
+
+    let mut p = Matrix4::<f64>::zeros();
+    for cluster in &clusters {
+        if cluster.len() == 1 {
+            let idx = cluster[0];
+            p.set_column(idx, &eig.eigenvectors.column(idx));
+            continue;
+        }
+        let k = cluster.len();
+        // The columns of `A`'s eigenbasis spanning this near-degenerate eigenspace.
+        let v = nalgebra::DMatrix::<f64>::from_fn(4, k, |r, c| eig.eigenvectors[(r, cluster[c])]);
+        let b_sub = v.transpose() * b * &v;
+        let sub_eig = nalgebra::linalg::SymmetricEigen::new(b_sub);
+        let refined = &v * sub_eig.eigenvectors;
+        for (c, &idx) in cluster.iter().enumerate() {
+            p.set_column(idx, &refined.column(c));
+        }
+    }
+    p
+}
+
 /// Convert a MatrixView4 as a MatRef without copies.
 #[inline]
 fn matrixview4_to_faer<T: nalgebra::Scalar + Copy>(mat: MatrixView4<T>) -> MatRef<T> {
@@ -496,13 +561,36 @@ impl TwoQubitWeylDecomposition {
         // for real-symmetric `A` and `B`, and as
         //   M2^+ @ M2 = A^2 + B^2 + i [A, B] = 1
         // we must have `A` and `B` commute, and consequently they are simultaneously diagonalizable.
-        // Mixing them together _should_ account for any degeneracy problems, but it's not
-        // guaranteed, so we repeat it a little bit.  The fixed seed is to make failures
-        // deterministic; the value is not important.
-        let mut state = Pcg64Mcg::seed_from_u64(2023);
         let mut found = false;
         let mut d: Vector4<Complex64> = Vector4::zeros();
         let mut p: Matrix4<Complex64> = Matrix4::zeros();
+        // Track the least-bad candidate seen across every attempt below, in case none of
+        // them hits the strict tolerance exactly (see the fallback after the loop).
+        let mut best_residual = f64::INFINITY;
+        let mut best_p: Matrix4<Complex64> = Matrix4::zeros();
+        let mut best_d: Vector4<Complex64> = Vector4::zeros();
+        let mut consider = |p_inner: Matrix4<Complex64>,
+                            found: &mut bool,
+                            p: &mut Matrix4<Complex64>,
+                            d: &mut Vector4<Complex64>| {
+            let d_inner: Vector4<Complex64> = (p_inner.transpose() * m2 * p_inner).diagonal();
+            let diag_d: Matrix4<Complex64> = Matrix4::from_diagonal(&d_inner);
+            let compare = p_inner * diag_d * p_inner.transpose();
+            let residual = (compare - m2).iter().map(|z| z.norm()).fold(0.0, f64::max);
+            if residual < best_residual {
+                best_residual = residual;
+                best_p = p_inner;
+                best_d = d_inner;
+            }
+            if residual <= 1.0e-13 {
+                *p = p_inner;
+                *d = d_inner;
+                *found = true;
+            }
+        };
+
+        // The fixed seed is to make failures deterministic; the value is not important.
+        let mut state = Pcg64Mcg::seed_from_u64(2023);
         for i in 0..100 {
             let rand_a: f64;
             let rand_b: f64;
@@ -525,15 +613,48 @@ impl TwoQubitWeylDecomposition {
             let res = temp.U();
             let p_inner: Matrix4<Complex64> =
                 Matrix4::from_fn(|i, j| Complex64::new(res[(i, j)], 0.));
-            let d_inner: Vector4<Complex64> = (p_inner.transpose() * m2 * p_inner).diagonal();
-            let diag_d: Matrix4<Complex64> = Matrix4::from_diagonal(&d_inner);
-
-            let compare = p_inner * diag_d * p_inner.transpose();
-            found = abs_diff_eq!(compare, m2, epsilon = 1.0e-13);
+            consider(p_inner, &mut found, &mut p, &mut d);
             if found {
-                p = p_inner;
-                d = d_inner;
                 break;
+            }
+        }
+
+        // Only if every one of the 100 random trials above failed to exactly diagonalize
+        // `M2`, fall back to a deterministic, degeneracy-aware diagonalization that
+        // specifically targets inputs whose own eigenvalues are nearly degenerate -- the
+        // recurring cause of diagonalization failures reported at
+        // https://github.com/Qiskit/qiskit/issues/4159, and a case no amount of retrying
+        // the randomized search above can resolve (see `cluster_diagonalize_m2`'s doc
+        // comment). It is deliberately tried only as a last resort, after the loop above:
+        // for inputs that the classic algorithm already handles fine, it produces a
+        // simultaneous eigenbasis related to the classic one by an arbitrary rotation
+        // within each exactly-degenerate eigenspace, which -- although equally valid --
+        // can propagate into which specialization gets detected and how efficiently the
+        // resulting single-qubit gates simplify, so it should not preempt an
+        // already-successful classic result.
+        if !found {
+            let p_inner: Matrix4<Complex64> = cluster_diagonalize_m2(&m2).map(|v| c64(v, 0.));
+            consider(p_inner, &mut found, &mut p, &mut d);
+        }
+
+        if !found {
+            // None of the candidates above diagonalized `M2` to the exacting `1e-13`
+            // tolerance. That tolerance is tighter than many real inputs' own distance
+            // from being exactly unitary (which is bounded by the precision of whatever
+            // floating-point computation produced them upstream, and is often no better
+            // than 1e-9 or so), so demanding it unconditionally makes this fail on inputs
+            // that have no better decomposition available in the first place. Instead,
+            // fall back to the best candidate found, as long as its residual is small
+            // enough that it's overwhelmingly likely to reflect exactly this kind of
+            // input imprecision rather than an actual bug. `calculated_fidelity` below
+            // independently re-derives the achieved fidelity from this same candidate, so
+            // a fallback that is a poor fit still gets caught there (with a much more
+            // informative error) rather than silently returned.
+            const FALLBACK_TOL: f64 = 1.0e-6;
+            if best_residual < FALLBACK_TOL {
+                p = best_p;
+                d = best_d;
+                found = true;
             }
         }
         if !found {

--- a/releasenotes/notes/fix-weyl-diagonalize-4159-31c1dfd131040d89.yaml
+++ b/releasenotes/notes/fix-weyl-diagonalize-4159-31c1dfd131040d89.yaml
@@ -1,0 +1,19 @@
+---
+fixes:
+  - |
+    Fixed a long-standing failure in :class:`.TwoQubitWeylDecomposition` (and everything
+    built on it, including :class:`.TwoQubitBasisDecomposer` and the
+    :class:`.UnitarySynthesis` transpiler pass) where certain two-qubit unitaries raised
+    ``QiskitError: 'TwoQubitWeylDecomposition: failed to diagonalize M2'``. This happened
+    for inputs whose canonical (Weyl) coordinates sit close to a symmetric point of the
+    Weyl chamber, which is common for circuits built from a small number of standard
+    gates (for example Trotterized time-evolution circuits, or circuits made of several
+    Clifford gates). Previously, the only diagonalization strategy tried was a fixed
+    sequence of 100 random real linear combinations of the decomposition's internal
+    ``M2`` matrix, each checked against an exact tolerance; for these inputs, every
+    combination inherited the same near-degeneracy, which no amount of retrying with
+    different random coefficients could resolve. The decomposition now additionally
+    tries a deterministic, degeneracy-aware diagonalization as a fallback, and accepts
+    the most accurate candidate found when none reaches the exact tolerance but the
+    achieved fidelity is otherwise unaffected.
+    Fixed `#4159 <https://github.com/Qiskit/qiskit/issues/4159>`__.

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -672,6 +672,85 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
             a = Ud(np.pi / 4, np.pi / 8, 0)
             self.check_two_qubit_weyl_decomposition(k1 @ a @ k2)
 
+    def test_two_qubit_weyl_decomposition_near_degenerate_m2(self):
+        """Regression test for https://github.com/Qiskit/qiskit/issues/4159.
+
+        These matrices, taken from user reports on the issue, sit close enough to a
+        symmetric point of the Weyl chamber that the two-real-eigenvalue "M2" matrix at
+        the core of the decomposition has (near-)degenerate eigenvalues. Previously the
+        only diagonalization strategy tried was a fixed sequence of 100 random real
+        linear combinations of M2's real and imaginary parts, each checked against an
+        exact `1e-13` tolerance; for these inputs, every one of those combinations
+        inherited the same near-degeneracy (it cannot be avoided by choosing different
+        random coefficients when the underlying eigenvalues are themselves nearly
+        equal), so the decomposition unconditionally raised `QiskitError`.
+        """
+        matrices = [
+            # https://github.com/Qiskit/qiskit/issues/4159#issuecomment-2635472538
+            np.array(
+                [
+                    [
+                        -0.001850233987449401 + 0.0018502339874494661j,
+                        0.49999657662239466 + 0.4999965766224098j,
+                        -0.001850233987449466 - 0.001850233987449402j,
+                        -0.49999657662241 + 0.4999965766223946j,
+                    ],
+                    [
+                        -0.44072377714686684 - 0.44072377714685324j,
+                        -0.23614095844951105 + 0.236140958449508j,
+                        -0.44072377714685346 + 0.4407237771468669j,
+                        0.23614095844950803 + 0.2361409584495112j,
+                    ],
+                    [
+                        0.2361409584495594 + 0.23614095844955216j,
+                        -0.44072377714677746 + 0.44072377714677247j,
+                        0.2361409584495523 - 0.23614095844955943j,
+                        0.4407237771467725 + 0.4407237771467777j,
+                    ],
+                    [
+                        -0.49999657662249597 + 0.499996576622502j,
+                        -0.0018502339874498202 - 0.0018502339874495377j,
+                        -0.499996576622502 - 0.4999965766224962j,
+                        0.0018502339874495383 - 0.0018502339874498202j,
+                    ],
+                ]
+            ),
+            # https://github.com/Qiskit/qiskit/issues/4159#issuecomment-2933313231, the
+            # least precisely unitary of the reported inputs (about 1e-9 off), so it
+            # additionally exercises the fallback that accepts a best-effort
+            # diagonalization when no candidate reaches the exact tolerance.
+            np.array(
+                [
+                    [
+                        0.6722131811420843 + 0.09452506680507206j,
+                        0.7075931451760403 + 0.196230468465914j,
+                        5.681296541384782e-10 - 9.621138583843416e-11j,
+                        3.307540509026264e-10 - 2.1612778497242494e-9j,
+                    ],
+                    [
+                        0.7216230638474672 + 0.13584773309886666j,
+                        -0.6450258764520663 - 0.21153525783613172j,
+                        9.898797586949043e-10 - 3.977632221779342e-10j,
+                        1.375154806614058e-10 - 2.038777090046669e-9j,
+                    ],
+                    [
+                        1.0517074761473222e-9 - 3.967380894295217e-10j,
+                        3.156039428800239e-10 - 2.4983353930758583e-10j,
+                        0.18339809633518522 - 0.7337990977531457j,
+                        0.38346675493722177 + 0.5299596871200533j,
+                    ],
+                    [
+                        -2.2585057568535944e-9 + 1.9658794932827343e-9j,
+                        1.3354719029003632e-10 + 1.3142849758873588e-10j,
+                        0.11052571942646373 - 0.6447387762627752j,
+                        -0.4881403628954051 - 0.57776722527244j,
+                    ],
+                ]
+            ),
+        ]
+        for matrix in matrices:
+            self.check_two_qubit_weyl_decomposition(matrix, tolerance=1.0e-7)
+
     def test_two_qubit_weyl_decomposition_a00(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,0,0)"""
         for aaa in (


### PR DESCRIPTION
## Summary

Fixes #4159, open since 2020 and still being hit by users as of March 2026 (67 comments). `TwoQubitWeylDecomposition` -- the core two-qubit KAK/Weyl decomposition used throughout unitary synthesis in the transpiler -- raises `QiskitError: 'TwoQubitWeylDecomposition: failed to diagonalize M2'` for certain valid two-qubit unitaries, with no workaround available to callers.

**Root cause:** the decomposition needs to simultaneously diagonalize two real-symmetric matrices `A = Re(M2)`, `B = Im(M2)`. The only strategy tried is picking a single random real combination `rand_a * A + rand_b * B` and diagonalizing that, retried up to 100 times with different random coefficients (this dates back to the original Python implementation, which already carried a `# FIXME: this randomized algorithm is horrendous` comment). This provably cannot succeed when two eigenvalues of the input unitary are themselves nearly equal: every random combination inherits the same near-degeneracy, so retrying with different coefficients can never widen the gap, no matter how many attempts are made. This case is common in practice -- circuits built from a small number of standard gates (Trotterized time evolution, compositions of Clifford gates, etc.) frequently produce unitaries whose Weyl coordinates land close to a symmetric point of the Weyl chamber.

**Fix:** add a deterministic fallback that clusters near-equal eigenvalues of `A` and re-diagonalizes `B` restricted to each cluster -- the standard technique for simultaneously diagonalizing nearly-commuting matrices, which directly targets the failure mode above instead of leaving it to chance. It is tried only after the existing randomized search is exhausted, so it cannot change behavior for any input the classic algorithm already handles (an earlier version of this fix that tried it first caused several gate-count regressions in existing tests, fixed by this ordering). Additionally, the best candidate found across every attempt is now tracked and accepted when none reaches the exact `1e-13` tolerance but is otherwise a good fit -- that tolerance is often tighter than a real input's own distance from being exactly unitary (bounded by whatever floating-point computation produced it upstream), so demanding it unconditionally rejects inputs that have no better decomposition available in the first place. The existing `calculated_fidelity` self-check still independently catches any accepted candidate that is actually a poor fit, with a far more informative error than the diagonalization failure.

## Verification

- All four real unitary matrices pasted into the issue by different users (from [this comment](https://github.com/Qiskit/qiskit/issues/4159#issuecomment-2635472538) and others) now decompose correctly, with reconstruction error matching each input's own floating-point precision (~1e-9 to 1e-13). Confirmed these same matrices raise on `main`.
- ~3500 synthetic stress cases (generic Haar-random unitaries, unitaries exactly on Weyl-chamber symmetry lines, and long products of near-identity gates simulating accumulated Trotter-circuit-style floating point noise) all decompose correctly.
- `test/python/synthesis/` (3093 tests) and the broader `test/python/synthesis/`, `test/python/transpiler/test_unitary_synthesis.py`, `test/python/transpiler/test_two_qubit_peephole.py` suites (6016 tests) pass.
- `cargo clippy --workspace --lib -- -D warnings` and `cargo fmt --check` are clean.

## Test plan

- [x] Added a regression test using the real reported matrices from the issue (`test_two_qubit_weyl_decomposition_near_degenerate_m2`)
- [x] Existing Weyl/two-qubit-decomposition test suite passes unmodified
- [x] Added a release note