### PR TITLE
Fix an edge case in `SymbolExpr::sub_opt`

### DIFF
--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -1948,8 +1948,8 @@ impl SymbolExpr {
                                 // case: l_lhs - (lv + rv)
                                 (_, SymbolExpr::Value(lv)) => {
                                     return Some(_sub(
-                                        SymbolExpr::Value(rv + lv),
                                         l_lhs.as_ref().clone(),
+                                        SymbolExpr::Value(rv + lv),
                                     ));
                                 }
                                 (_, _) => (),

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -1042,3 +1042,13 @@ class TestParameterExpression(QiskitTestCase):
                     expression = getattr(lhs, method)(rhs)
 
                     self.assertEqual(reference, expression.bind({x: value}))
+
+    def test_sub_sub(self):
+        """Regression test for two nested subtractions with numeric values."""
+        x, y = Parameter("x"), Parameter("y")
+        expr1 = x + y
+        sub1 = expr1 - 1.0
+        sub2 = sub1 - 2.0
+
+        expected = x + y - 3.0
+        self.assertEqual(expected, sub2)


### PR DESCRIPTION
#16753 introduced a bug where nested sub-binary expression with numeric values as RHS values could lead to a -1 multiplier. E.g. ((x+y) - 1) - 2) would become 3 - (x+y) instead of (x+y) - 3.

This has no release note since the bug is not yet released. This needs to go into 2.6 to fix the already merged PR.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
