### PR TITLE
Fix Litinski transformation on PPR with 32+ qubits

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1786,7 +1786,7 @@ impl PauliProductRotation {
             .zip(self.x.iter())
             .filter(|(z, x)| **z || **x)
             .count();
-        let dim = 2u32.pow(num_qubits as u32);
+        let dim = (num_qubits as f64).exp2();
         let tr_over_dim = if num_qubits == 0 {
             // This is an identity Pauli rotation.
             (Complex64::new(0.0, -angle / 2.)).exp()
@@ -1794,7 +1794,7 @@ impl PauliProductRotation {
             Complex64::new((angle / 2.).cos(), 0.)
         };
 
-        Some((tr_over_dim, dim as f64))
+        Some((tr_over_dim, dim))
     }
 
     /// Return a dense matrix representation of the matrix.

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -545,7 +545,7 @@ fn is_ppr_angle_close_to_multiple_of_pi2(
 
     // direct calculation of dim and tr_over_dim
     let num_qubits = z.iter().zip(x.iter()).filter(|(z, x)| **z || **x).count();
-    let dim = 2u32.pow(num_qubits as u32);
+    let dim = (num_qubits as f64).exp2();
     let tr_over_dim = if num_qubits == 0 {
         // This is an identity Pauli rotation.
         (Complex64::new(0.0, -theta / 2.)).exp()
@@ -553,7 +553,7 @@ fn is_ppr_angle_close_to_multiple_of_pi2(
         Complex64::new((theta / 2.).cos(), 0.)
     };
 
-    if average_gate_fidelity_below_tol(tr_over_dim, dim.into(), tol).is_some() {
+    if average_gate_fidelity_below_tol(tr_over_dim, dim, tol).is_some() {
         Some((closest_integer as i64).rem_euclid(4) as usize)
     } else {
         None

--- a/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
+++ b/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
@@ -5,4 +5,5 @@ fixes:
     dimension used in the Clifford-proximity check overflowed on 32+ qubits,
     causing non-Clifford rotations to be incorrectly classified as Clifford-close.
 
-    See `#16869 <https://github.com/Qiskit/qiskit/issues/16869>`__.
+    Fixed `#16869 <https://github.com/Qiskit/qiskit/issues/16869>`__.
+    

--- a/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
+++ b/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.LitinskiTransformation` where the Hilbert-space
+    dimension used in the Clifford-proximity check overflowed on 32+ qubits,
+    causing non-Clifford rotations to be incorrectly classified as Clifford-close.
+
+    See `#16869 <https://github.com/Qiskit/qiskit/issues/16869>`__.

--- a/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
+++ b/releasenotes/notes/fix-litinski-overflow-624d005e18d2763e.yaml
@@ -4,6 +4,7 @@ fixes:
     Fixed a bug in :class:`.LitinskiTransformation` where the Hilbert-space
     dimension used in the Clifford-proximity check overflowed on 32+ qubits,
     causing non-Clifford rotations to be incorrectly classified as Clifford-close.
+    The same overflow was also fixed in :class:`.PauliProductRotationGate` when
+    computing its trace and dimension.
 
     Fixed `#16869 <https://github.com/Qiskit/qiskit/issues/16869>`__.
-    

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -641,9 +641,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.append(PauliProductRotationGate(Pauli(pauli_str), angle=0.1), range(num_qubits))
         qc.measure(range(num_qubits), range(num_qubits))
         qct = LitinskiTransformation(use_ppr=True)(qc)
-        op_names = [inst.operation.name for inst in qct.data]
-        self.assertEqual(op_names.count("pauli_product_rotation"), 1)
-        self.assertEqual(op_names.count("pauli_product_measurement"), num_qubits)
+        op_counts = qct.count_ops()
+        self.assertEqual(op_counts.get("pauli_product_rotation", 0), 1)
+        self.assertEqual(op_counts.get("pauli_product_measurement", 0), num_qubits)        
 
     def test_on_circuits_with_ppr_ppm(self):
         """Test the Litinski transformation pass on a more complex with Clifford gates,

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -643,7 +643,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qct = LitinskiTransformation(use_ppr=True)(qc)
         op_counts = qct.count_ops()
         self.assertEqual(op_counts.get("pauli_product_rotation", 0), 1)
-        self.assertEqual(op_counts.get("pauli_product_measurement", 0), num_qubits)        
+        self.assertEqual(op_counts.get("pauli_product_measurement", 0), num_qubits)
 
     def test_on_circuits_with_ppr_ppm(self):
         """Test the Litinski transformation pass on a more complex with Clifford gates,

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -631,6 +631,20 @@ class TestLitinskiTransformation(QiskitTestCase):
         qct = LitinskiTransformation(use_ppr=True)(qc)
         self.assertEqual(qc, qct)
 
+    def test_ppr_with_32_qubits(self):
+        """Test the Litinski transformation pass on a non-Clifford PPR with 32+ qubits,
+        which is the threshold at which the Hilbert-space dimension overflows u32.
+        """
+        num_qubits = 32
+        pauli_str = "X" * num_qubits
+        qc = QuantumCircuit(num_qubits, num_qubits)
+        qc.append(PauliProductRotationGate(Pauli(pauli_str), angle=0.1), range(num_qubits))
+        qc.measure(range(num_qubits), range(num_qubits))
+        qct = LitinskiTransformation(use_ppr=True)(qc)
+        op_names = [inst.operation.name for inst in qct.data]
+        self.assertEqual(op_names.count("pauli_product_rotation"), 1)
+        self.assertEqual(op_names.count("pauli_product_measurement"), num_qubits)
+
     def test_on_circuits_with_ppr_ppm(self):
         """Test the Litinski transformation pass on a more complex with Clifford gates,
         T gates and Z-measures.


### PR DESCRIPTION
### Summary
Fixes #16869 second issue: applying `LitinskiTransformation` to a circuit containing a non-Clifford PPR with 32+ qubits. 
The Hilbert-space dimension (2^num_qubits) was previously computed as a u32, which overflows at num_qubits = 32 (wrapping to 0 in release mode and panicking in debug mode). With dim=0, the fidelity formula always returns 1.0, causing every rotation to be incorrectly classified as Clifford-close and silently absorbed into the Clifford frame instead of being preserved.
Fixed the same overflow in PauliProductRotation::rotation_trace_and_dim in crates/circuit/src/operations.rs.

Thanks to @windoctober for finding the bug.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: IBM Bob 2.0.3; I reviewed and checked the tool's suggestions. 
- [ ] Some submitted code was generated by: