### PR TITLE
Add `ParameterExpression.structurally_equal` via `SymbolExpr::eq_exact`

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -1224,8 +1224,10 @@ impl PyParameterExpression {
     /// Are these two expressions exactly structurally equal?
     ///
     /// This is a faster and stricter form of the standard ``==`` relationship, but does not take
-    /// simplifications into account.  All expressions that are :meth:`structurally_equal` are all
-    /// ``==`` to each other, but the reverse is not true.
+    /// simplifications into account.  Almost all expressions that are :meth:`structurally_equal`
+    /// are all ``==`` to each other, but the reverse is not true.  (In the presence of ``nan``
+    /// values, :meth:`structurally_equal` can sometimes return ``True`` when ``==`` compares
+    /// ``False``.)
     ///
     /// This function is most useful in internal tests of the :class:`ParameterExpression` logic.
     ///

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -138,6 +138,13 @@ impl fmt::Display for ParameterExpression {
 }
 
 impl ParameterExpression {
+    /// Exact structural equality of two expressions.
+    ///
+    /// See [`SymbolExpr::eq_exact`] for more detail.
+    pub fn eq_exact(&self, other: &Self) -> bool {
+        (self.name_map == other.name_map) && self.expr.eq_exact(&other.expr)
+    }
+
     pub fn qpy_replay(&self) -> Vec<OPReplay> {
         let mut replay = Vec::new();
         let mut unused: IndexSet<_> = self.name_map.values().cloned().collect();
@@ -1212,6 +1219,46 @@ impl PyParameterExpression {
         } else {
             Ok(false)
         }
+    }
+
+    /// Are these two expressions exactly structurally equal?
+    ///
+    /// This is a faster and stricter form of the standard ``==`` relationship, but does not take
+    /// simplifications into account.  All expressions that are :meth:`structurally_equal` are all
+    /// ``==`` to each other, but the reverse is not true.
+    ///
+    /// This function is most useful in internal tests of the :class:`ParameterExpression` logic.
+    ///
+    /// .. note::
+    ///
+    ///     Many operations on :class:`ParameterExpression` do on-the-fly simplification as they are
+    ///     constructed, so two expressions that appear to have been constructed in different orders
+    ///     can still be internally structurally equal.
+    ///
+    /// Args:
+    ///     rhs: the other object to compare.
+    ///
+    /// Returns:
+    ///     Whether the two objects are structurally equal expressions.
+    ///
+    /// Examples:
+    ///
+    ///     Two expressions can simplify to each other when checking for equality, but not use the
+    ///     same internal structure::
+    ///
+    ///         from qiskit.circuit import Parameter
+    ///
+    ///         x, y = Parameter("x"), Parameter("y")
+    ///         left = x + y + 1
+    ///         right = 1 + y + x
+    ///         assert left == right
+    ///         assert not left.structurally_equal(right)
+    pub fn structurally_equal(&self, rhs: &Bound<PyAny>) -> bool {
+        let Ok(rhs) = rhs.cast::<Self>() else {
+            return false;
+        };
+        let rhs = rhs.borrow();
+        self.inner.eq_exact(&rhs.inner)
     }
 
     #[inline]

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -529,6 +529,78 @@ impl SymbolExpr {
         }
     }
 
+    /// Are these two expressions precisely equal in structure?
+    ///
+    /// This is stricter but faster form of the [`PartialEq`] implementation that does not consider
+    /// symbolic equality via simplification, but instead requires that the exact structures are
+    /// constructed in the same manner.
+    pub fn eq_exact(&self, other: &Self) -> bool {
+        // Helper so `rustfmt` doesn't turn `if (a != b) { return false; }` into 3 lines.
+        macro_rules! return_if_unequal {
+            ($a:expr, $b:expr) => {
+                if $a != $b {
+                    return false;
+                }
+            };
+        }
+        // `backtrack` stores the right-hand sides of `Binary`s, so we can walk back up to them.
+        // `cur` is a minor optimisation to avoid allocations in the case of long chains of `Unary`,
+        // and when walking down the left-hand edges of `Binary`s; instead of pushing into the heap
+        // and immediately popping it back again, we just stay purely in stack space.
+        let mut backtrack = Vec::new();
+        let mut cur = Some((self, other));
+        while let Some((a, b)) = cur.take().or_else(|| backtrack.pop()) {
+            // Short-circuit this entire tree branch if `a` and `b` point to the same object.
+            if std::ptr::eq(a, b) {
+                continue;
+            }
+            match (a, b) {
+                (Self::Symbol(a_sym), Self::Symbol(b_sym)) => return_if_unequal!(a_sym, b_sym),
+                (Self::Value(a_val), Self::Value(b_val)) => return_if_unequal!(a_val, b_val),
+                (
+                    Self::Unary {
+                        op: a_op,
+                        expr: a_expr,
+                    },
+                    Self::Unary {
+                        op: b_op,
+                        expr: b_expr,
+                    },
+                ) => {
+                    return_if_unequal!(a_op, b_op);
+                    cur = Some((a_expr, b_expr));
+                }
+                (
+                    Self::Binary {
+                        op: a_op,
+                        lhs: a_lhs,
+                        rhs: a_rhs,
+                    },
+                    Self::Binary {
+                        op: b_op,
+                        lhs: b_lhs,
+                        rhs: b_rhs,
+                    },
+                ) => {
+                    return_if_unequal!(a_op, b_op);
+                    // This is the same `:std::ptr::eq` trick from the top of the loop, but we
+                    // repeat it here to avoid allocations if possible.
+                    if !Arc::ptr_eq(a_rhs, b_rhs) {
+                        backtrack.push((a_rhs, b_rhs));
+                    }
+                    cur = Some((a_lhs, b_lhs));
+                }
+                // The `SymbolExpr` variants don't match. This doesn't use a full `_` so we still
+                // get compiler protection against expansion of the enum.
+                (Self::Symbol(_), _)
+                | (Self::Value(_), _)
+                | (Self::Unary { .. }, _)
+                | (Self::Binary { .. }, _) => return false,
+            }
+        }
+        true
+    }
+
     /// evaluate the equation
     /// if recursive is false, only this node will be evaluated
     pub fn eval(&self, recurse: bool) -> Option<Value> {
@@ -4266,5 +4338,158 @@ mod test {
         mem::drop(expr);
         assert_eq!(Arc::strong_count(&base), 1);
         assert_eq!(weaks[0].strong_count(), 0);
+    }
+
+    #[test]
+    fn test_eq_exact_unary_non_simplification() {
+        let unary_negate = |expr| SymbolExpr::Unary {
+            op: UnaryOp::Neg,
+            expr: Arc::new(expr),
+        };
+        let val = Value::Int(1);
+        let direct = SymbolExpr::Value(-val);
+        let indirect = unary_negate(SymbolExpr::Value(val));
+        assert_eq!(direct, indirect);
+        assert!(!direct.eq_exact(&indirect));
+
+        let two_extra_negations = unary_negate(unary_negate(indirect.clone()));
+        assert_eq!(indirect, two_extra_negations);
+        assert!(!direct.eq_exact(&indirect));
+    }
+
+    #[test]
+    fn test_eq_exact_unary_deep() {
+        let make_big = |mut expr| {
+            for _ in 0..BIG_CALL_STACK {
+                expr = SymbolExpr::Unary {
+                    op: UnaryOp::Neg,
+                    expr: Arc::new(expr),
+                };
+            }
+            expr
+        };
+
+        let one = Value::Int(1);
+        let two = Value::Int(2);
+        let base = make_big(SymbolExpr::Value(one));
+        assert!(base.eq_exact(&make_big(SymbolExpr::Value(one))));
+        assert!(!base.eq_exact(&make_big(SymbolExpr::Value(two))));
+    }
+
+    #[test]
+    fn test_eq_exact_binary_deep() {
+        let make_big_lhs = |mut expr| {
+            for _ in 0..BIG_CALL_STACK {
+                expr = SymbolExpr::Binary {
+                    op: BinaryOp::Pow,
+                    lhs: Arc::new(expr),
+                    rhs: Arc::new(SymbolExpr::Value(Value::Int(2))),
+                }
+            }
+            expr
+        };
+        let make_big_rhs = |mut expr| {
+            for _ in 0..BIG_CALL_STACK {
+                expr = SymbolExpr::Binary {
+                    op: BinaryOp::Pow,
+                    lhs: Arc::new(SymbolExpr::Value(Value::Int(2))),
+                    rhs: Arc::new(expr),
+                }
+            }
+            expr
+        };
+        let one = Value::Int(1);
+        let two = Value::Int(2);
+        let base = make_big_lhs(SymbolExpr::Value(one));
+        assert!(base.eq_exact(&make_big_lhs(SymbolExpr::Value(one))));
+        assert!(!base.eq_exact(&make_big_lhs(SymbolExpr::Value(two))));
+
+        let base = make_big_rhs(SymbolExpr::Value(one));
+        assert!(base.eq_exact(&make_big_rhs(SymbolExpr::Value(one))));
+        assert!(!base.eq_exact(&make_big_rhs(SymbolExpr::Value(two))));
+    }
+
+    #[test]
+    fn test_eq_exact_binary_backtracks() {
+        let extend_lhs = |mut expr, size: usize| {
+            for _ in 0..size {
+                expr = SymbolExpr::Binary {
+                    op: BinaryOp::Pow,
+                    lhs: Arc::new(expr),
+                    rhs: Arc::new(SymbolExpr::Value(Value::Int(2))),
+                }
+            }
+            expr
+        };
+        let extend_rhs = |mut expr, size: usize| {
+            for _ in 0..size {
+                expr = SymbolExpr::Binary {
+                    op: BinaryOp::Pow,
+                    lhs: Arc::new(SymbolExpr::Value(Value::Int(2))),
+                    rhs: Arc::new(expr),
+                }
+            }
+            expr
+        };
+
+        let one = Value::Int(1);
+        let two = Value::Int(2);
+
+        let left = SymbolExpr::Binary {
+            op: BinaryOp::Pow,
+            lhs: Arc::new(SymbolExpr::Value(one)),
+            rhs: Arc::new(SymbolExpr::Value(one)),
+        };
+        let right = SymbolExpr::Binary {
+            op: BinaryOp::Pow,
+            lhs: Arc::new(SymbolExpr::Value(one)),
+            rhs: Arc::new(SymbolExpr::Value(two)),
+        };
+
+        // Failure deep on the lhs.
+        assert!(!extend_lhs(left.clone(), 5).eq_exact(&extend_lhs(right.clone(), 5)));
+        // Failure deep on the rhs.
+        assert!(!extend_rhs(left.clone(), 5).eq_exact(&extend_rhs(right.clone(), 5)));
+
+        // Failure in a middle right edge of a deep left tree.
+        let shared_base = extend_lhs(left.clone(), 5);
+        let left_mid = extend_lhs(
+            SymbolExpr::Binary {
+                op: BinaryOp::Pow,
+                lhs: Arc::new(shared_base.clone()),
+                rhs: Arc::new(SymbolExpr::Value(one)),
+            },
+            5,
+        );
+        let right_mid = extend_lhs(
+            SymbolExpr::Binary {
+                op: BinaryOp::Pow,
+                lhs: Arc::new(shared_base.clone()),
+                rhs: Arc::new(SymbolExpr::Value(two)),
+            },
+            5,
+        );
+        assert!(!extend_lhs(left_mid, 5).eq_exact(&extend_lhs(right_mid, 5)));
+
+        // Failure on a left edge of a deep right tree.
+        // Failure in a middle right edge of a deep left tree.
+        let shared_base = extend_rhs(right.clone(), 5);
+        let left_mid = extend_rhs(
+            SymbolExpr::Binary {
+                op: BinaryOp::Pow,
+                lhs: Arc::new(SymbolExpr::Value(one)),
+                rhs: Arc::new(shared_base.clone()),
+            },
+            5,
+        );
+        let right_mid = extend_rhs(
+            SymbolExpr::Binary {
+                op: BinaryOp::Pow,
+                lhs: Arc::new(SymbolExpr::Value(two)),
+                rhs: Arc::new(shared_base.clone()),
+            },
+            5,
+        );
+        assert!(!extend_rhs(left_mid, 5).eq_exact(&extend_rhs(right_mid, 5)));
     }
 }

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -4471,8 +4471,7 @@ mod test {
         );
         assert!(!extend_lhs(left_mid, 5).eq_exact(&extend_lhs(right_mid, 5)));
 
-        // Failure on a left edge of a deep right tree.
-        // Failure in a middle right edge of a deep left tree.
+        // Failure on a middle left edge of a deep right tree.
         let shared_base = extend_rhs(right.clone(), 5);
         let left_mid = extend_rhs(
             SymbolExpr::Binary {

--- a/releasenotes/notes/parameter-expression-structurally_equal-f0eaf7b64da911aa.yaml
+++ b/releasenotes/notes/parameter-expression-structurally_equal-f0eaf7b64da911aa.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    Added :meth:`.ParameterExpression.structurally_equal`, which can be used to compare whether two
+    expressions have equal internal structures.  This is mostly useful for testing Qiskit itself.

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -31,6 +31,7 @@ from qiskit.utils.optionals import HAS_SYMPY
 
 param_x = Parameter("x")
 param_y = Parameter("y")
+param_z = Parameter("z")
 nested_expr = param_x + param_y - param_x
 nested_expr = nested_expr.subs({param_y: param_x})
 
@@ -74,6 +75,23 @@ real_values = [0.41, 0.9, -0.83, math.pi, -math.pi / 124, -42.42]
 @ddt.ddt
 class TestParameterExpression(QiskitTestCase):
     """Test parameter expression."""
+
+    def assertStructurallyEqualResult(
+        self, left: ParameterExpression, right: ParameterExpression, result: bool
+    ):
+        """Assert that ``left.structurally_equal(right) == result`` with a better error message."""
+        self.assertIsInstance(left, ParameterExpression)
+        self.assertIsInstance(right, ParameterExpression)
+        if left.structurally_equal(right) != result:
+            op = "not ==" if result else "=="
+            msg = f"Assertion failure: '{left}' should {op} '{right}'."
+            raise self.failureException(msg)
+
+    def assertStructurallyEqual(self, left, right):
+        self.assertStructurallyEqualResult(left, right, True)
+
+    def assertNotStructurallyEqual(self, left, right):
+        self.assertStructurallyEqualResult(left, right, False)
 
     @ddt.data(param_x, param_x + param_y, (param_x + 1.0).bind({param_x: 1.0}))
     def test_num_parameters(self, expr):
@@ -1052,3 +1070,36 @@ class TestParameterExpression(QiskitTestCase):
 
         expected = x + y - 3.0
         self.assertEqual(expected, sub2)
+
+    def test_structurally_equal_simplification(self):
+        x = Parameter("x")
+        y = Parameter("y")
+
+        # These two expressions do not canonicalise to each other, as of the introduction of the
+        # test (2026-09-07), so they should not appear structurally equal.  If canonicalisation is
+        # introduced, the test case should be changed (after we've checked that `structurally_equal`
+        # is actually correct).
+        left = x + y + 1
+        right = 1 + y + x
+        self.assertEqual(left, right)
+        self.assertNotStructurallyEqual(left, right)
+
+    @ddt.unpack
+    @ddt.data(
+        (param_x, param_x, True),
+        (param_x, param_y, False),
+        (param_x + 1, param_x + 1, True),
+        (param_x + 1, param_x + 2, False),
+        (param_x + 1, param_y + 1, False),
+        (-param_x, -param_x, True),
+        (-param_x, -param_y, False),
+        (param_x + (2 * param_y), param_x + (2 * param_y), True),
+        (param_x + (2 * param_y), param_x + (2 * param_z), False),
+        ((-param_x) ** param_y, (-param_x) ** param_y, True),
+        ((-param_x) ** param_y, (-param_y) ** (param_x), False),
+        (param_x**-param_y, param_x**-param_y, True),
+        (param_x + param_y, param_x - param_y, False),
+        (-param_x, param_x.sin(), False),
+    )
+    def test_structurally_equal(self, left, right, expected):
+        self.assertStructurallyEqualResult(left, right, expected)


### PR DESCRIPTION
This is primarily intended to be used for testing; there are several places where we wanted to test that the structure of a `ParameterExpression` was precisely equal to something, but use of the simplifying `==` implementation was masking trouble.

This PR alone is not entirely sufficient from Python space; we may also want to add some sort of temporary suppression of the on-the-fly simplification operations, so it's easier to build exact test cases (and there are cases where this might be faster, too), but that's a separate work item.

The naming discrepancy between Python and Rust is because:

1. We have precedent in Python with `DAGCircuit.structurally_equal`
2. In Rust, I wanted to keep discoverability by tab-completion on `eq`.

---

This is after feature freeze, but is primarily intended only for testing.  I don't mind if we choose to delay it til 2.7.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
