### PR TITLE
Configure `cibuildwheel` maximum Python version

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -71,10 +71,30 @@ on:
 
 
 jobs:
+  config_pre:
+    name: "Configure"
+    uses: ./.github/workflows/config.yml
+
+  config:
+    # We set the Python versions to build and test using our configured values in GitHub Actions,
+    # rather than duplicating them into `pyproject.toml`.  Setting `CIBW_PROJECT_REQUIRES_PYTHON`
+    # doesn't affect the metadata of the wheel, it just overrides `cibuildwheel`'s detection of
+    # which versions of Python are supported.  We use that rather than `CIBW_BUILD` because it's
+    # easier to use that as a coarse-grained platform/ABI selector.
+    outputs:
+      requires-python: ${{ steps.output.outputs.requires-python }}
+    needs: [config_pre]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set requires-python
+        id: output
+        run: echo 'requires-python=>=${{ needs.config_pre.outputs.python-old }},<=${{ needs.config_pre.outputs.python-new }}' >> $GITHUB_OUTPUT
+
   wheels-tier-1:
     name: "Wheels / Tier 1"
     if: (inputs.wheels-tier-1 == 'default' && inputs.default-action || inputs.wheels-tier-1) == 'build'
     runs-on: ${{ matrix.os }}
+    needs: [config]
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +144,8 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ needs.config.outputs.requires-python }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -133,6 +155,7 @@ jobs:
     name: "Wheels / macOS x86_64"
     if: (inputs.wheels-macos-intel == 'default' && inputs.default-action || inputs.wheels-macos-intel) == 'build'
     runs-on: macos-15-intel
+    needs: [config]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -146,6 +169,8 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ needs.config.outputs.requires-python }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -157,6 +182,7 @@ jobs:
     name: "Wheels / Linux s390x"
     if: (inputs.wheels-linux-s390x == 'default' && inputs.default-action || inputs.wheels-linux-s390x) == 'build'
     runs-on: ubuntu-24.04-s390x
+    needs: [config]
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
@@ -166,6 +192,8 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ needs.config.outputs.requires-python }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -176,6 +204,7 @@ jobs:
     name: "Wheels / Linux ppc64le"
     if: (inputs.wheels-linux-ppc64le == 'default' && inputs.default-action || inputs.wheels-linux-ppc64le) == 'build'
     runs-on: ubuntu-24.04-ppc64le
+    needs: [config]
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust
@@ -185,6 +214,8 @@ jobs:
         run: python3 -m pip install --user -r ./.github/workflows/wheels/requirements.txt
       - name: Run cibuildwheel
         run: python3 -m cibuildwheel
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ needs.config.outputs.requires-python }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -195,6 +226,7 @@ jobs:
     name: "sdist"
     if: (inputs.sdist == 'default' && inputs.default-action || inputs.sdist) == 'build'
     runs-on: ubuntu-latest
+    needs: [config]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7


### PR DESCRIPTION
If we keep `cibuildwheel` completely up-to-date, it will attempt to build _and test_ wheels up to the maximum current Python, including if it is in pre-release.  We don't want our wheel-build jobs to fail if our dependencies aren't ready for the prerelease (as happened with `dill` during the Python 3.15 release-candidate period), so we want to skip the tests for them entirely.  Our wheels are still compatible because we build for `abi3`.

I used `CIBW_PROJECT_REQUIRES_PYTHON` instead of messing with `CIBW_BUILD` or `CIBW_TEST_SKIP` because it's nicer to express the ABI intent with static globs on `CIBW_BUILD` (i.e. we build `cp3??-*` but not `cp3??t-*` as yet), and `CIBW_TEST_SKIP` is awkward because we'd have to calculate which versions of Python _not_ to build; there's no "test-only" or the like.

Motivated by #16901

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
