### PR TITLE
Enforce consistent module-manifest style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ comparison-chain = "allow"
 # vast majority of these are debug statements that we forget about.
 print_stdout = "deny"
 print_stderr = "deny"
+# Require `<module>/mod.rs` naming instead of `<module>.rs`.  This is purely for consistent style.
+self_named_module_files = "deny"
 
 [workspace.lints.rust]
 # In Rust 2021, the bodies of `unsafe fn` may use `unsafe` functions themselves without marking

--- a/crates/transpiler/src/lib.rs
+++ b/crates/transpiler/src/lib.rs
@@ -10,6 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#![allow(
+    clippy::self_named_module_files,
+    // See https://github.com/rust-lang/rust-clippy/issues/11916
+    reason = "false positive in clippy for Rust <= 1.91",
+)]
+
 pub mod angle_bound_registry;
 pub mod commutation_checker;
 pub mod equivalence;

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -10,6 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+#![allow(
+    clippy::self_named_module_files,
+    // See https://github.com/rust-lang/rust-clippy/issues/11916
+    reason = "false positive in clippy for Rust <= 1.91",
+)]
+
 use anyhow::Result;
 
 use crate::commutation_checker::CommutationChecker;

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -10,12 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-#![allow(
-    clippy::self_named_module_files,
-    // See https://github.com/rust-lang/rust-clippy/issues/11916
-    reason = "false positive in clippy for Rust <= 1.91",
-)]
-
 use anyhow::Result;
 
 use crate::commutation_checker::CommutationChecker;


### PR DESCRIPTION
There's two ways to specify modules in Rust: `<module>/mod.rs` and `<module>.rs` with a separate `<module>` directory.  Qiskit exclusively uses the `<module>/mod.rs` form, so this enables the Clippy style lint that makes sure we don't get inconsistent with ourselves.

Note the Rust reference (somewhat controversially[^1]) says "prefer the `<module>.rs` form", but a) consistency with our already-chosen style is more important, b) the given reason ("avoid multiple `mod.rs` files"??) is kind of nonsense - any competent editor has a fuzzy finder, c) having a file and a directory makes the top-level module noisier.

[^1]: https://github.com/rust-lang/reference/pull/1703

---

I had a stylistic comment on #16696 about this, and I dislike making stylistic comments that should just be format/lint rules.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
