### PR TITLE
Fix UnrollForLoops with break and continue in switch cases

### DIFF
--- a/qiskit/transpiler/passes/utils/unroll_forloops.py
+++ b/qiskit/transpiler/passes/utils/unroll_forloops.py
@@ -12,7 +12,7 @@
 
 """UnrollForLoops transpilation pass"""
 
-from qiskit.circuit import ForLoopOp, ContinueLoopOp, BreakLoopOp, IfElseOp
+from qiskit.circuit import ForLoopOp, ContinueLoopOp, BreakLoopOp, IfElseOp, SwitchCaseOp
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passes.utils import control_flow
 from qiskit.converters import circuit_to_dag
@@ -70,12 +70,13 @@ class UnrollForLoops(TransformationPass):
 
 
 def _body_contains_continue_or_break(circuit):
-    """Checks if a circuit contains ``continue``s or ``break``s. Conditional bodies are inspected."""
+    """Checks if a circuit contains ``continue``s or ``break``s.
+    Conditional bodies and switch statements are inspected recursively."""
     for inst in circuit.data:
         operation = inst.operation
         if isinstance(operation, (ContinueLoopOp, BreakLoopOp)):
             return True
-        if isinstance(operation, IfElseOp):
+        if isinstance(operation, (IfElseOp, SwitchCaseOp)):
             for block in operation.params:
                 if _body_contains_continue_or_break(block):
                     return True

--- a/releasenotes/notes/unroll-forloops-switch-case-32fcea60859b9ad0.yaml
+++ b/releasenotes/notes/unroll-forloops-switch-case-32fcea60859b9ad0.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixed an issue where UnrollForLoops would unroll a loop whose break clause issue
+    is nested inside a SwitchCaseOp. UnrollForLoops now explicity checks for any
+    SwitchCaseOp and inspects it recursively.

--- a/test/python/transpiler/test_unroll_forloops.py
+++ b/test/python/transpiler/test_unroll_forloops.py
@@ -165,6 +165,44 @@ class TestUnrollForLoops(QiskitTestCase):
 
         self.assertEqual(result, qc)
 
+    def test_skip_break_in_switch(self):
+        """Unrolling should not rebind a break nested inside a switch."""
+        qc = QuantumCircuit(1, 1)
+        once = range(1)
+
+        with qc.for_loop(once):
+            with qc.for_loop(once):
+                with qc.switch(qc.clbits[0]) as case:
+                    with case(0):
+                        qc.id(0)
+                        qc.break_loop()
+            qc.x(0)
+
+        passmanager = PassManager()
+        passmanager.append(UnrollForLoops(max_target_depth=1))
+        result = passmanager.run(qc)
+
+        self.assertEqual(result, qc)
+
+    def test_skip_continue_in_switch(self):
+        """Unrolling should not rebind a continue nested inside a switch."""
+        qc = QuantumCircuit(1, 1)
+        once = range(1)
+
+        with qc.for_loop(once):
+            with qc.for_loop(once):
+                with qc.switch(qc.clbits[0]) as case:
+                    with case(0):
+                        qc.id(0)
+                        qc.continue_loop()
+            qc.x(0)
+
+        passmanager = PassManager()
+        passmanager.append(UnrollForLoops(max_target_depth=1))
+        result = passmanager.run(qc)
+
+        self.assertEqual(result, qc)
+
     def test_max_target_depth(self):
         """Unrolling should not be done when results over `max_target_depth`"""
 


### PR DESCRIPTION
Fixes #16863

I have made `UnrollForLoops` explicitly check for a `SwitchCaseOp` and then perform the same behaviour as it currently does for `IfElseOp`.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [X] Some submitted code was generated by: OpenAI
