### PR TITLE
Avoid hard allocation abort from QPY provided sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "crossterm",
  "foldhash 0.2.0",
  "hashbrown 0.15.5",
+ "indexmap",
  "itertools 0.15.0",
  "lexical-core",
  "lexical-write-float",

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -36,6 +36,7 @@ ahash = "0.8.12"
 unicode-segmentation = "1.13"
 lexical-core = "1.0.6"
 lexical-write-float = "1.0.6"
+indexmap.workspace = true
 
 [dependencies.pyo3]
 workspace = true

--- a/crates/circuit/src/bit_locator.rs
+++ b/crates/circuit/src/bit_locator.rs
@@ -13,6 +13,7 @@
 use std::{fmt::Debug, hash::Hash, sync::OnceLock};
 
 use crate::bit::{BitLocations, Register};
+use crate::error::TryReserveError;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict};
 use qiskit_util::IndexMap;
@@ -65,6 +66,17 @@ where
             bit_locations: IndexMap::with_capacity_and_hasher(capacity, Default::default()),
             cached: OnceLock::new(),
         }
+    }
+
+    /// Create an empty bit locator with a pre-allocated capacity to contain a given number. This
+    /// will return an error if the specified capacity can't be allocated.
+    pub fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+        let mut bit_locations = IndexMap::with_hasher(Default::default());
+        bit_locations.try_reserve(capacity)?;
+        Ok(Self {
+            bit_locations,
+            cached: OnceLock::new(),
+        })
     }
 
     /// Track a bit at the given locations.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -60,6 +60,8 @@ use qiskit_util::IndexMap;
 use smallvec::SmallVec;
 use thiserror::Error;
 
+use crate::error::TryReserveError;
+
 import_exception!(qiskit.circuit.exceptions, CircuitError);
 
 /// This struct models the error conditions that can be raised from the
@@ -102,6 +104,8 @@ pub enum CircuitDataError {
     InvalidParameter,
     #[error("bad type after binding for gate '{0}': '{1}'")]
     StandardGateParameterIsComplex(String, String),
+    #[error(transparent)]
+    TryReserveError(TryReserveError),
 }
 impl<T: Debug> From<object_registry::AbsentObject<T>> for CircuitDataError {
     fn from(val: object_registry::AbsentObject<T>) -> Self {
@@ -111,6 +115,12 @@ impl<T: Debug> From<object_registry::AbsentObject<T>> for CircuitDataError {
 impl<T: Debug, B: Debug> From<object_registry::AddError<T, B>> for CircuitDataError {
     fn from(val: object_registry::AddError<T, B>) -> Self {
         Self::AddObjectRegistry(val.erase_type())
+    }
+}
+
+impl From<TryReserveError> for CircuitDataError {
+    fn from(val: TryReserveError) -> Self {
+        Self::TryReserveError(val)
     }
 }
 
@@ -142,6 +152,7 @@ impl From<CircuitDataError> for PyErr {
                     "bad type after binding for gate '{gate_name}': '{expr}'"
                 ))
             }
+            CircuitDataError::TryReserveError(error) => error.into(),
         }
     }
 }
@@ -765,6 +776,43 @@ impl CircuitData {
             cregs: RegisterData::new(),
             qubit_indices: BitLocator::with_capacity(num_qubits as usize),
             clbit_indices: BitLocator::with_capacity(num_clbits as usize),
+            vars_stretches: VarStretchContainer::new(),
+        };
+
+        // use the global phase setter to ensure parameters are registered
+        // in the parameter table
+        res.set_global_phase_param(global_phase)?;
+        res.add_anonymous_qubits(num_qubits)
+            .expect("cannot represent a too-large count");
+        res.add_anonymous_clbits(num_clbits)
+            .expect("cannot represent a too-large count");
+        Ok(res)
+    }
+
+    /// Build an empty CircuitData object with an initially allocated instruction capacity.
+    /// This will error if the specified capacity can not be allocated.
+    pub fn try_with_capacity(
+        num_qubits: u32,
+        num_clbits: u32,
+        instruction_capacity: usize,
+        global_phase: Param,
+    ) -> Result<Self, CircuitDataError> {
+        let mut data = Vec::new();
+        data.try_reserve(instruction_capacity)
+            .map_err(TryReserveError::VecTryReserve)?;
+        let mut res = CircuitData {
+            data,
+            qargs_interner: Interner::new(),
+            cargs_interner: Interner::new(),
+            qubits: ObjectRegistry::try_with_capacity(num_qubits as usize)?,
+            clbits: ObjectRegistry::try_with_capacity(num_clbits as usize)?,
+            blocks: ControlFlowBlocks::new(),
+            param_table: ParameterTable::new(),
+            global_phase: Param::Float(0.0),
+            qregs: RegisterData::new(),
+            cregs: RegisterData::new(),
+            qubit_indices: BitLocator::try_with_capacity(num_qubits as usize)?,
+            clbit_indices: BitLocator::try_with_capacity(num_clbits as usize)?,
             vars_stretches: VarStretchContainer::new(),
         };
 

--- a/crates/circuit/src/error.rs
+++ b/crates/circuit/src/error.rs
@@ -10,7 +10,48 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::PyErr;
+use pyo3::exceptions::PyMemoryError;
 use pyo3::import_exception;
+
+use hashbrown::TryReserveError as HashTryReserveError;
+use indexmap::TryReserveError as IndexTryReserveError;
+use std::collections::TryReserveError as VecTryReserveError;
+use thiserror::Error;
 
 import_exception!(qiskit.dagcircuit.exceptions, DAGCircuitError);
 import_exception!(qiskit.dagcircuit.exceptions, DAGDependencyError);
+
+#[derive(Debug, Error)]
+pub enum TryReserveError {
+    #[error(transparent)]
+    VecTryReserve(VecTryReserveError),
+    #[error("{0:?}")]
+    HashTryReserve(HashTryReserveError),
+    #[error(transparent)]
+    IndexTryReserve(IndexTryReserveError),
+}
+
+impl From<VecTryReserveError> for TryReserveError {
+    fn from(val: VecTryReserveError) -> Self {
+        Self::VecTryReserve(val)
+    }
+}
+
+impl From<HashTryReserveError> for TryReserveError {
+    fn from(val: HashTryReserveError) -> Self {
+        Self::HashTryReserve(val)
+    }
+}
+
+impl From<IndexTryReserveError> for TryReserveError {
+    fn from(val: IndexTryReserveError) -> Self {
+        Self::IndexTryReserve(val)
+    }
+}
+
+impl From<TryReserveError> for PyErr {
+    fn from(val: TryReserveError) -> Self {
+        PyMemoryError::new_err(val.to_string())
+    }
+}

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use crate::CapacityError;
+use crate::error::TryReserveError;
 use hashbrown::HashMap;
 use hashbrown::hash_map::OccupiedError;
 use pyo3::exceptions::{PyKeyError, PyValueError};
@@ -210,6 +211,20 @@ where
             indices: HashMap::with_capacity(capacity),
             cached: OnceLock::new(),
         }
+    }
+
+    /// Create a new ObjectRegistry with an initial capacity pre-allocated. This
+    /// will return an error if the specified capacity can not be allocated.
+    pub fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+        let mut objects = Vec::new();
+        objects.try_reserve(capacity)?;
+        let mut indices = HashMap::new();
+        indices.try_reserve(capacity)?;
+        Ok(ObjectRegistry {
+            objects,
+            indices,
+            cached: OnceLock::new(),
+        })
     }
 
     /// Gets the number of registered objects.

--- a/crates/qpy/src/bytes.rs
+++ b/crates/qpy/src/bytes.rs
@@ -311,9 +311,21 @@ impl BinRead for Bytes {
         _endian: Endian,
         args: Self::Args<'_>,
     ) -> BinResult<Self> {
-        let mut buf = vec![0u8; args.count];
-        reader.read_exact(&mut buf)?;
-        Ok(Bytes(buf))
+        let mut list: Vec<u8> = Vec::new();
+        list.try_reserve_exact(args.count).map_err(|e| {
+            binrw::Error::Io(binrw::io::Error::new(
+                binrw::io::ErrorKind::OutOfMemory,
+                e.to_string(),
+            ))
+        })?;
+        if reader.take(args.count as u64).read_to_end(&mut list)? == args.count {
+            Ok(Bytes(list))
+        } else {
+            Err(binrw::Error::Io(binrw::io::Error::new(
+                binrw::io::ErrorKind::UnexpectedEof,
+                "Insufficient bytes in QPY for specified size",
+            )))
+        }
     }
 }
 

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -484,7 +484,7 @@ fn unpack_pauli_product_measurement(
         ));
     }
     let z_values = unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?;
-    let z: Vec<bool> = z_values.to_boolean_vec().ok_or_else(|| {
+    let z: Vec<bool> = z_values.to_boolean_vec()?.ok_or_else(|| {
         QpyError::InvalidParameter(format!(
             "Pauli product measurement z parameter should be a boolean or integer vector, but got {:?}",
             z_values
@@ -492,7 +492,7 @@ fn unpack_pauli_product_measurement(
     })?;
 
     let x_values = unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?;
-    let x: Vec<bool> = x_values.to_boolean_vec().ok_or_else(|| {
+    let x: Vec<bool> = x_values.to_boolean_vec()?.ok_or_else(|| {
         QpyError::InvalidParameter(format!(
             "Pauli product measurement x parameter should be a boolean or integer vector, but got {:?}",
             x_values
@@ -511,7 +511,7 @@ fn unpack_pauli_product_measurement(
             })?;
             value != 0
         }
-        _ => neg_value.as_typed::<bool>().ok_or_else(|| {
+        _ => neg_value.as_typed::<bool>()?.ok_or_else(|| {
                 QpyError::InvalidParameter(format!(
                     "Pauli product measurement neg parameter should be a boolean or integer, but got {:?}",
                     neg_value
@@ -535,13 +535,13 @@ fn unpack_pauli_product_rotation(
         ));
     }
     let z_values = unpack_generic_value(&instruction.params[0], qpy_data, ValueEndian::Big)?;
-    let z = z_values.to_boolean_vec().ok_or_else(|| {
+    let z = z_values.to_boolean_vec()?.ok_or_else(|| {
         QpyError::InvalidParameter(
             "Pauli product rotation z parameter should be a boolean vector".to_string(),
         )
     })?;
     let x_values = unpack_generic_value(&instruction.params[1], qpy_data, ValueEndian::Big)?;
-    let x = x_values.to_boolean_vec().ok_or_else(|| {
+    let x = x_values.to_boolean_vec()?.ok_or_else(|| {
         QpyError::InvalidParameter(
             "Pauli product rotation x parameter should be a boolean vector".to_string(),
         )
@@ -1067,8 +1067,16 @@ fn add_registers_and_bits(
 ) -> Result<(), QpyError> {
     let num_qubits = packed_circuit.header.num_qubits as usize;
     let num_clbits = packed_circuit.header.num_clbits as usize;
-    let mut qubits: Vec<Option<ShareableQubit>> = vec![None; num_qubits];
-    let mut clbits: Vec<Option<ShareableClbit>> = vec![None; num_clbits];
+    let mut qubits: Vec<Option<ShareableQubit>> = Vec::new();
+    qubits
+        .try_reserve_exact(num_qubits)
+        .map_err(QpyError::AllocationError)?;
+    qubits.extend((0..num_qubits).map(|_| None));
+    let mut clbits: Vec<Option<ShareableClbit>> = Vec::new();
+    clbits
+        .try_reserve_exact(num_clbits)
+        .map_err(QpyError::AllocationError)?;
+    clbits.extend((0..num_clbits).map(|_| None));
     let mut qregs = Vec::new();
     let mut cregs = Vec::new();
 
@@ -1310,7 +1318,12 @@ pub(crate) fn unpack_circuit(
     // create an empty circuit; we'll fill data as we go along
     let mut qpy_data = QPYReadData {
         caller,
-        circuit_data: CircuitData::with_capacity(0, 0, instruction_capacity, Param::Float(0.0))?,
+        circuit_data: CircuitData::try_with_capacity(
+            0,
+            0,
+            instruction_capacity,
+            Param::Float(0.0),
+        )?,
         version,
         use_symengine,
         standalone_vars: HashMap::new(),

--- a/crates/qpy/src/error.rs
+++ b/crates/qpy/src/error.rs
@@ -145,6 +145,9 @@ pub enum QpyError {
     /// A QPY feature that requires the Python runtime was used from a native caller.
     #[error("QPY feature '{0}' is only available when QPY is invoked from Python")]
     PythonOnly(&'static str),
+
+    #[error(transparent)]
+    AllocationError(std::collections::TryReserveError),
 }
 
 impl From<QpyError> for PyErr {

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -412,8 +412,20 @@ impl ConditionPack {
         let condition_type = ConditionType::try_from(key).map_err(|e| to_binrw_error(reader, e))?;
         let data = match condition_type {
             ConditionType::TwoTuple => {
-                let mut buf = vec![0u8; register_size as usize];
-                reader.read_exact(&mut buf)?;
+                let mut buf = Vec::new();
+                buf.try_reserve_exact(register_size as usize).map_err(|e| {
+                    binrw::Error::Io(binrw::io::Error::new(
+                        binrw::io::ErrorKind::OutOfMemory,
+                        e.to_string(),
+                    ))
+                })?;
+                reader.take(register_size as u64).read_to_end(&mut buf)?;
+                if buf.len() != register_size as usize {
+                    return Err(binrw::Error::Io(binrw::io::Error::new(
+                        binrw::io::ErrorKind::UnexpectedEof,
+                        "Insufficient bytes in QPY for specified size",
+                    )));
+                }
                 ConditionData::Register(buf.into())
             }
             ConditionType::Expression => {
@@ -477,16 +489,24 @@ impl BinRead for VirtualQBitPack {
         } else {
             // InRegister: first value is the index; name_length is always i32
             let name_length = i32::read_options(reader, endian, ())? as usize;
-            let mut buf = vec![0u8; name_length];
-            reader.read_exact(&mut buf)?;
-            let register_name = String::from_utf8(buf).map_err(|e| binrw::Error::Custom {
-                pos: reader.stream_position().unwrap_or(0),
-                err: Box::new(e),
+            let mut buf = String::new();
+            buf.try_reserve_exact(name_length).map_err(|e| {
+                binrw::Error::Io(binrw::io::Error::new(
+                    binrw::io::ErrorKind::OutOfMemory,
+                    e.to_string(),
+                ))
             })?;
-            Ok(VirtualQBitPack::InRegister {
-                index: first as u32,
-                register_name,
-            })
+            if reader.take(name_length as u64).read_to_string(&mut buf)? == name_length {
+                Ok(VirtualQBitPack::InRegister {
+                    index: first as u32,
+                    register_name: buf,
+                })
+            } else {
+                Err(binrw::Error::Io(binrw::io::Error::new(
+                    binrw::io::ErrorKind::UnexpectedEof,
+                    "Insufficient bytes in QPY for specified size",
+                )))
+            }
         }
     }
 }

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -246,7 +246,10 @@ pub fn read_raw_circuits(
     )?;
 
     // Read circuits using offset differences to determine sizes
-    let mut circuits = Vec::with_capacity(num_programs);
+    let mut circuits = Vec::new();
+    circuits
+        .try_reserve_exact(num_programs)
+        .map_err(QpyError::AllocationError)?;
 
     for i in 0..num_programs {
         let size = if i + 1 < circuit_table.len() {
@@ -318,7 +321,10 @@ pub fn load_qpy(
         qpy_file_header.symbolic_encoding,
         SymbolicEncoding::Symengine
     );
-    let mut circuits = Vec::with_capacity(num_programs);
+    let mut circuits = Vec::new();
+    circuits
+        .try_reserve_exact(num_programs)
+        .map_err(QpyError::AllocationError)?;
     let mut cursor = Cursor::new(data as &[u8]);
     cursor.seek(std::io::SeekFrom::Start(header_size as u64))?;
     if qpy_file_header.qpy_version >= 16 {

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -500,11 +500,11 @@ pub enum GenericValue {
 // we want to be able to extract the value relatively painlessly;
 // e.g. let my_bool = value.as_typed::<bool>().unwrap()
 pub trait FromGenericValue: Sized {
-    fn from_generic(value: &GenericValue) -> Option<Self>;
+    fn from_generic(value: &GenericValue) -> Result<Option<Self>, QpyError>;
 }
 
 impl GenericValue {
-    pub(crate) fn as_typed<T: FromGenericValue>(&self) -> Option<T> {
+    pub(crate) fn as_typed<T: FromGenericValue>(&self) -> Result<Option<T>, QpyError> {
         T::from_generic(self)
     }
     // reintreprets int64 and float64 as if they were given in little endian, since this is needed when encoding instruction parameters
@@ -553,20 +553,22 @@ impl GenericValue {
         }
     }
     // boolean vectors are tricky since there are several ways to encode them
-    pub(crate) fn to_boolean_vec(&self) -> Option<Vec<bool>> {
+    pub(crate) fn to_boolean_vec(&self) -> Result<Option<Vec<bool>>, QpyError> {
         match self {
             GenericValue::Tuple(elements) => elements
                 .iter()
                 .map(|val| val.as_typed::<bool>())
-                .collect::<Option<Vec<bool>>>(),
+                .collect::<Result<Option<Vec<bool>>, _>>(),
             GenericValue::NumpyObject(bytes) => {
-                let npy = NpyFile::new(Cursor::new(&bytes.0)).ok()?;
+                let Some(npy) = NpyFile::new(Cursor::new(&bytes.0)).ok() else {
+                    return Ok(None);
+                };
                 if npy.shape().len() != 1 {
-                    return None;
+                    return Ok(None);
                 }
-                npy.into_vec().ok()
+                Ok(npy.into_vec().ok())
             }
-            _ => None,
+            _ => Ok(None),
         }
     }
     pub(crate) fn numpy_array_from_boolean_vec(values: &[bool]) -> Result<Self, QpyError> {
@@ -604,11 +606,11 @@ impl GenericValue {
 macro_rules! impl_from_generic {
     ($t:ty, $variant:ident) => {
         impl FromGenericValue for $t {
-            fn from_generic(value: &GenericValue) -> Option<Self> {
-                match value {
+            fn from_generic(value: &GenericValue) -> Result<Option<Self>, QpyError> {
+                Ok(match value {
                     GenericValue::$variant(v) => Some(v.clone()),
                     _ => None,
-                }
+                })
             }
         }
     };
@@ -623,27 +625,32 @@ impl_from_generic!(Complex64, Complex64);
 
 // booleans are stored as i64 in current QPY, we should be able to convert from them
 impl FromGenericValue for bool {
-    fn from_generic(value: &GenericValue) -> Option<Self> {
-        match value {
+    fn from_generic(value: &GenericValue) -> Result<Option<Self>, QpyError> {
+        Ok(match value {
             GenericValue::Bool(val) => Some(*val),
             GenericValue::Int64(val) => Some(*val != 0),
             _ => None,
-        }
+        })
     }
 }
 
 // Extracting tuples is a little more trick; we'll use macro for the easy case of Vec<T> for a specific T
 impl<T: FromGenericValue> FromGenericValue for Vec<T> {
-    fn from_generic(value: &GenericValue) -> Option<Self> {
+    fn from_generic(value: &GenericValue) -> Result<Option<Self>, QpyError> {
         match value {
             GenericValue::Tuple(vec) => {
-                let mut out = Vec::with_capacity(vec.len());
+                let mut out = Vec::new();
+                out.try_reserve_exact(vec.len())
+                    .map_err(QpyError::AllocationError)?;
                 for item in vec {
-                    out.push(T::from_generic(item)?);
+                    let Some(val) = T::from_generic(item)? else {
+                        return Ok(None);
+                    };
+                    out.push(val);
                 }
-                Some(out)
+                Ok(Some(out))
             }
-            _ => None,
+            _ => Ok(None),
         }
     }
 }
@@ -1257,7 +1264,7 @@ mod qpy_value_tests {
         for values in [vec![], vec![false], vec![true, false, true]] {
             let value =
                 GenericValue::numpy_array_from_boolean_vec(&values).unwrap_or(GenericValue::Null);
-            assert_eq!(value.to_boolean_vec(), Some(values));
+            assert_eq!(value.to_boolean_vec().unwrap(), Some(values));
         }
     }
 

--- a/releasenotes/notes/fix-oom-abort-qpy-f3e70857d39435a1.yaml
+++ b/releasenotes/notes/fix-oom-abort-qpy-f3e70857d39435a1.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`.qpy.dump` function where in several cases it
+    would previously crash the process if the payload specified it needed more
+    memory than was available. For several of the cases fixed it will now raise
+    a :class:`.QpyError` which can be caught and handled. However, in general
+    QPY deserialization is not safe against resource exhaustion and running it
+    may still cause an OOM failure that result in a hard process crash either
+    from the operating system or the allocator.
+    Fixes `#16898 <https://github.com/Qiskit/qiskit/issues/16898>`__.


### PR DESCRIPTION
This commit fixes several cases of potential out of memory aborts caused by the rust allocator when loading QPY payloads. In several locations in the QPY deserialization we were directly reserving capacity unconditionally based on the size specified in the payload. This would potentially result in the Rust allocator allocator aborts the process in a hard error if there was insufficient memory available to allocate the specified size. As QPY payloads are often transferred between systems with varying memory capacity we can never guarantee that a qpy payload will be able to fit in memory on the deserializing system. But to improve the experience of QPY deserializing payloads on systems with limited memory capacity this replaces all those cases that could result in a hard abort with fallible memory reservations. This will then result in a QPYError being raised to the user if sufficient memory can not be allocated. This can then be handled by the user however is appropriate instead of a hard crash of the process.

As a side effect I expect this might actually improve the performance of the QPY deserialization slightly as it no longer needs to zero the elements in the Vecs used for the raw bytes buffer used during deserialization of certain fields in the QPY payload.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
