### PR TITLE
Handle potential overflows in arithmetic during QPY load

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -170,9 +170,9 @@ pub fn unpack_condition(
 fn recognize_instruction_type(
     instruction: &formats::CircuitInstructionV2Pack,
     custom_instructions: &HashMap<String, CustomCircuitInstructionData>,
-) -> InstructionType {
+) -> Result<InstructionType, QpyError> {
     let name = instruction.gate_class_name.as_str();
-    if name == PAULI_PRODUCT_MEASUREMENT_GATE_CLASS_NAME {
+    Ok(if name == PAULI_PRODUCT_MEASUREMENT_GATE_CLASS_NAME {
         InstructionType::PauliProductMeasurement
     } else if name == PAULI_PRODUCT_ROTATION_GATE_CLASS_NAME {
         InstructionType::PauliProductRotation
@@ -203,8 +203,17 @@ fn recognize_instruction_type(
     } else {
         // This can either be a standard gate, or something Pythonic.
         // For standard gate, we need both the gate class name to be standard, and the controls should be standard as well
-        let has_nonstandard_control = instruction.num_ctrl_qubits > 0
-            && (instruction.ctrl_state != (1 << instruction.num_ctrl_qubits) - 1);
+        let has_nonstandard_control = if instruction.num_ctrl_qubits > 0 {
+            if instruction.num_ctrl_qubits >= 32 {
+                return Err(QpyError::InvalidInstruction(format!(
+                    "Instruction has {} but at most 31 are supported",
+                    instruction.num_ctrl_qubits
+                )));
+            }
+            instruction.ctrl_state != (1 << instruction.num_ctrl_qubits) - 1
+        } else {
+            false
+        };
         let standard_gate_name =
             standard_gate_from_gate_class_name(instruction.gate_class_name.as_str()).is_some();
         if !has_nonstandard_control && standard_gate_name {
@@ -213,7 +222,7 @@ fn recognize_instruction_type(
             // it is either a python gate, a python instruction or a python operation; all treated in the same manner
             InstructionType::Python
         }
-    }
+    })
 }
 
 type InstructionBits = (Interned<[Qubit]>, Interned<[Clbit]>);
@@ -357,7 +366,7 @@ pub fn unpack_instruction(
     qpy_data: &mut QPYReadData,
 ) -> Result<PackedInstruction, QpyError> {
     let label = (!instruction.label.is_empty()).then(|| Box::new(instruction.label.clone()));
-    let instruction_type = recognize_instruction_type(instruction, custom_instructions);
+    let instruction_type = recognize_instruction_type(instruction, custom_instructions)?;
     let (op, parameter_values) = match instruction_type {
         InstructionType::StandardGate => unpack_standard_gate(instruction, qpy_data)?,
         InstructionType::StandardInstruction => unpack_standard_instruction(instruction, qpy_data)?,

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -162,7 +162,7 @@ pub struct CircuitInstructionV2Pack {
     #[br(parse_with = ConditionPack::read, args(condition_register_size, extract_conditional_key(extras_key), condition_value))]
     #[bw(write_with = ConditionPack::write)]
     pub condition: ConditionPack,
-    #[br(count = num_qargs + num_cargs)]
+    #[br(count = num_qargs as usize + num_cargs as usize)]
     #[br(if(read_bits))]
     pub bit_data: Vec<CircuitInstructionArgPack>,
     #[br(count = num_parameters as usize)]

--- a/crates/qpy/src/interface.rs
+++ b/crates/qpy/src/interface.rs
@@ -250,6 +250,11 @@ pub fn read_raw_circuits(
 
     for i in 0..num_programs {
         let size = if i + 1 < circuit_table.len() {
+            if circuit_table[i] > circuit_table[i + 1] {
+                return Err(QpyError::InvalidFormat(
+                    "Circuit offset table invalid".to_string(),
+                ));
+            }
             (circuit_table[i + 1] - circuit_table[i]) as usize
         } else {
             // Last circuit: read remaining bytes


### PR DESCRIPTION
There are several places in the QPY load() rust code that could potentially overflow during arithmetic for specific payloads. This overflow was in itself not an error but when the overflowed value were interpreted this would lead to an opaque error. This commit improves the handling of these overflow cases by returning a descriptive error. The one exception is the potential overflow in the `bit_data` field's CircuitInstructionV2Pack, in practice that can't actually overflow (except on 32 bit platforms which we don't support). But the way the code was written if the sum of num_qargs and num_cargs exceeded u32::MAX it would overflow before converting it to a usize for the vec's length. This instead fixes this so it converts the u32 values to usize before the addition which will fix any potential overflow on 64 bit platforms.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
