### PR TITLE
Remove typecheck from Rust `__deepcopy__` methods

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -962,7 +962,7 @@ impl DAGCircuit {
     pub fn __deepcopy__<'py>(
         &self,
         py: Python<'py>,
-        memo: Option<&Bound<'py, PyDict>>,
+        memo: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         let mut out = self.clone();
         let deepcopy = imports::DEEPCOPY.get_bound(py);

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -234,7 +234,7 @@ impl Param {
     pub fn py_deepcopy<'py>(
         &self,
         py: Python<'py>,
-        memo: Option<&Bound<'py, PyDict>>,
+        memo: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         match self {
             Param::Float(f) => Ok(Param::Float(*f)),
@@ -1267,7 +1267,7 @@ pub fn radd_param(param1: Param, param2: Param) -> Param {
 /// It contains the methods for managing the Python aspect
 pub trait PythonOperation: Sized {
     /// Copy this operation, including a Python-space deep copy
-    fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyDict>>) -> PyResult<Self>;
+    fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyAny>>) -> PyResult<Self>;
 
     /// Copy this operation, including a Python-space call to `copy` on the `Operation` subclass.
     fn py_copy(&self, py: Python) -> PyResult<Self>;
@@ -1329,7 +1329,7 @@ pub struct PyInstruction {
 }
 
 impl PythonOperation for PyInstruction {
-    fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+    fn py_deepcopy(&self, py: Python, memo: Option<&Bound<'_, PyAny>>) -> PyResult<Self> {
         let deepcopy = imports::DEEPCOPY.get_bound(py);
         Ok(PyInstruction {
             ob: deepcopy.call1((&self.ob, memo))?.unbind(),

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -30,7 +30,7 @@ use ndarray::{Array2, CowArray, Ix2};
 use num_complex::Complex64;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyType};
+use pyo3::types::PyType;
 use smallvec::SmallVec;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
@@ -627,7 +627,7 @@ impl PackedOperation {
     pub fn py_deepcopy<'py>(
         &self,
         py: Python<'py>,
-        memo: Option<&Bound<'py, PyDict>>,
+        memo: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         match self.view() {
             OperationRef::PyCustom(inst) => inst.py_deepcopy(py, memo).map(|ob| ob.into()),
@@ -991,7 +991,7 @@ impl PackedInstruction {
     pub fn py_deepcopy_inplace<'py>(
         &mut self,
         py: Python<'py>,
-        memo: Option<&Bound<'py, PyDict>>,
+        memo: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<()> {
         if let OperationRef::PyCustom(inst) = self.op.view() {
             self.op = inst.py_deepcopy(py, memo)?.into();

--- a/releasenotes/notes/deepcopy-typecheck-e26dfe8456f41921.yaml
+++ b/releasenotes/notes/deepcopy-typecheck-e26dfe8456f41921.yaml
@@ -1,0 +1,7 @@
+---
+
+fixes:
+  - |
+    Several Rust-defined Python objects, like :class:`.DAGCircuit` no longer typecheck the ``memo``
+    argument of :func:`copy.deepcopy`.  This was an unnecessary performance cost, and some
+    third-party accelerators of the :mod:`copy` module are known to pass non-:class:`dict` values.


### PR DESCRIPTION
Most of our methods already take `PyAny` in various forms.  The `DAGCircuit` one takes `PyDict`, which implies a typecheck on entry through the Python bridge to PyO3, which is a waste; we never need to know the type.

The documentation of `__deepcopy__` describes the `memo` object as a dictionary that should be treated as an opaque object, and a third-party `copy.deepcopy` accelerator (`copium`) reads this as meaning it can pass arbitrary objects there, which break unnecessarily with this type check.

Fix #16965 

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
