### PR TITLE
12972. Add QuantumCircuit.count_ops_per_qubit() for per-qubit operation counts

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1816,6 +1816,22 @@ impl CircuitData {
         ops_count
     }
 
+    /// Counts the number of times each operation is used, broken down by qubit.
+    ///
+    /// # Returns
+    /// Operation counts grouped by qubit.
+    /// Multi-qubit operations contribute a count to every qubit they touch.
+    pub fn count_ops_per_qubit(&self) -> Vec<HashMap<&str, usize>> {
+        let mut ops_per_qubit = vec![HashMap::new(); self.num_qubits()];
+        for instruction in &self.data {
+            let name = instruction.op.name();
+            for qubit in self.qargs_interner.get(instruction.qubits) {
+                *ops_per_qubit[qubit.0 as usize].entry(name).or_insert(0) += 1;
+            }
+        }
+        ops_per_qubit
+    }
+
     fn clear_all(&mut self) {
         // Clear anything that could have a reference cycle.
         self.data.clear();
@@ -2923,6 +2939,15 @@ impl PyCircuitData {
     /// An IndexMap containing the operation names as keys and their respective counts as values.
     pub fn count_ops(&self) -> IndexMap<&str, usize> {
         self.inner.count_ops()
+    }
+    
+    /// Counts the number of times each operation is used, broken down by qubit.
+    ///
+    /// # Returns
+    /// Operation counts grouped by qubit.
+    /// Multi-qubit operations contribute a count to every qubit they touch.
+    pub fn count_ops_per_qubit(&self) -> Vec<HashMap<&str, usize>> {
+        self.inner.count_ops_per_qubit()
     }
 
     // Marks this pyclass as NOT hashable.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4235,6 +4235,30 @@ class QuantumCircuit:
         ops_dict = self._data.count_ops()
         return OrderedDict(ops_dict)
 
+    def count_ops_per_qubit(self) -> list[dict[str, int]]:
+        """Counts the number of times each operation is used, broken down by qubit.
+
+        Returns:
+            A list of dictionaries, one per qubit, mapping operation names to counts. Multi-qubit operations contribute a count to every qubit they touch.
+
+        Example:
+
+            .. code-block:: python
+
+                from qiskit.circuit import QuantumCircuit
+
+                qc = QuantumCircuit(3)
+                qc.h(0)
+                qc.cx(0, 1)
+                qc.x(2)
+                qc.x(2)
+                counts = qc.count_ops_per_qubit()
+                assert counts[0] == {"h": 1, "cx": 1}
+                assert counts[1] == {"cx": 1}
+                assert counts[2] == {"x": 2}
+        """
+        return self._data.count_ops_per_qubit()
+
     def num_nonlocal_gates(self) -> int:
         """Return number of non-local gates (i.e. involving 2+ qubits).
 

--- a/releasenotes/notes/count-ops-per-qubit-a1b2c3d4e5f67890.yaml
+++ b/releasenotes/notes/count-ops-per-qubit-a1b2c3d4e5f67890.yaml
@@ -1,0 +1,8 @@
+---
+features_circuits:
+  - |
+    Added :meth:`.QuantumCircuit.count_ops_per_qubit`, a per-qubit variant of
+    :meth:`~.QuantumCircuit.count_ops`. It returns a list of dictionaries, one
+    per qubit, mapping operation names to how many times that operation appears
+    on the qubit. Multi-qubit operations contribute a count to every qubit they
+    touch. The counting is performed in Rust for efficiency.

--- a/test/python/circuit/test_circuit_properties.py
+++ b/test/python/circuit/test_circuit_properties.py
@@ -506,6 +506,166 @@ class TestCircuitProperties(QiskitTestCase):
         self.assertIsInstance(result, dict)
         self.assertEqual(expected, result)
 
+    def test_count_ops_empty_circuit_returns_empty_dict(self):
+        """Test count_ops with an empty circuit."""
+        qc = QuantumCircuit(3)
+        self.assertEqual(qc.count_ops(), {})
+
+    def test_count_ops_multi_qubit_gates_counts_each_gate(self):
+        """Test count_ops with gates acting on multiple qubits."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.ccx(0, 1, 2)
+        self.assertEqual(dict(qc.count_ops()), {"ccx": 1, "cx": 1})
+
+    def test_count_ops_non_gate_instructions_counts_each_instruction(self):
+        """Test count_ops with non-gate instructions."""
+        qc = QuantumCircuit(2, 1)
+        qc.measure(0, 0)
+        qc.barrier()
+        qc.reset(1)
+        result = dict(qc.count_ops())
+        self.assertEqual(result, {"measure": 1, "barrier": 1, "reset": 1})
+
+    def test_count_ops_repeated_single_gate_accumulates_count(self):
+        """Test count_ops with repeated gates."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.x(0)
+        qc.x(0)
+        self.assertEqual(dict(qc.count_ops()), {"x": 3})
+
+    def test_count_ops_per_qubit_no_qubits_returns_empty_list(self):
+        """Test count_ops_per_qubit with a circuit containing no qubits."""
+        qc = QuantumCircuit()
+        self.assertEqual(qc.count_ops_per_qubit(), [])
+
+    def test_count_ops_per_qubit_qubits_without_gates_returns_empty_dicts(self):
+        """Test count_ops_per_qubit with qubits but no gates."""
+        qc = QuantumCircuit(3)
+        result = qc.count_ops_per_qubit()
+        self.assertEqual(result, [{}, {}, {}])
+
+    def test_count_ops_per_qubit_single_qubit_gates_counts_operations_per_qubit(
+        self,
+    ):
+        """Test count_ops_per_qubit with single-qubit gates."""
+        q = QuantumRegister(4, "q")
+        qc = QuantumCircuit(q)
+        qc.h(q)
+        qc.x(q[1:3])
+        qc.y(q[2:])
+        qc.z(q[3])
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"h": 1})
+        self.assertEqual(result[1], {"h": 1, "x": 1})
+        self.assertEqual(result[2], {"h": 1, "x": 1, "y": 1})
+        self.assertEqual(result[3], {"h": 1, "y": 1, "z": 1})
+
+    def test_count_ops_per_qubit_two_qubit_gates_counts_operations_per_qubit(self):
+        """Test count_ops_per_qubit with two-qubit gates."""
+        qc = QuantumCircuit(4)
+        qc.cx(0, 1)
+        qc.cy(1, 2)
+        qc.cz(2, 3)
+        qc.ch(0, 3)
+        qc.swap(1, 3)
+        qc.ecr(0, 2)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"cx": 1, "ch": 1, "ecr": 1})
+        self.assertEqual(result[1], {"cx": 1, "cy": 1, "swap": 1})
+        self.assertEqual(result[2], {"cy": 1, "cz": 1, "ecr": 1})
+        self.assertEqual(result[3], {"cz": 1, "ch": 1, "swap": 1})
+
+    def test_count_ops_per_qubit_three_qubit_gates_counts_operations_per_qubit(self):
+        """Test count_ops_per_qubit with three-qubit gates."""
+        qc = QuantumCircuit(5)
+        qc.ccx(0, 1, 2)
+        qc.ccz(1, 2, 3)
+        qc.cswap(2, 3, 4)
+        qc.rccx(0, 3, 4)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"ccx": 1, "rccx": 1})
+        self.assertEqual(result[1], {"ccx": 1, "ccz": 1})
+        self.assertEqual(result[2], {"ccx": 1, "ccz": 1, "cswap": 1})
+        self.assertEqual(result[3], {"ccz": 1, "cswap": 1, "rccx": 1})
+        self.assertEqual(result[4], {"cswap": 1, "rccx": 1})
+
+    def test_count_ops_per_qubit_non_gate_instructions_counts_operations_per_qubit(self):
+        """Test count_ops_per_qubit with non-gate instructions."""
+        qc = QuantumCircuit(3, 1)
+        qc.measure(0, 0)
+        qc.reset(1)
+        qc.delay(100, 2)
+        qc.barrier(0, 2)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"measure": 1, "barrier": 1})
+        self.assertEqual(result[1], {"reset": 1})
+        self.assertEqual(result[2], {"delay": 1, "barrier": 1})
+
+    def test_count_ops_per_qubit_repeated_operations_accumulates_count(self):
+        """Test count_ops_per_qubit with repeated operations."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.x(0)
+        qc.x(0)
+        qc.h(0)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"x": 3, "h": 1})
+
+    def test_count_ops_per_qubit_unused_middle_qubit_returns_empty_dict(self):
+        """Test count_ops_per_qubit with an unused qubit."""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.cx(0, 2)
+        qc.x(2)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"h": 1, "cx": 1})
+        self.assertEqual(result[1], {})
+        self.assertEqual(result[2], {"cx": 1, "x": 1})
+
+    def test_count_ops_per_qubit_custom_gate_counts_gate_on_each_target_qubit(self):
+        """Test count_ops_per_qubit with a custom gate."""
+        inner = QuantumCircuit(2, name="bill_gate")
+        inner.h(0)
+        inner.cx(0, 1)
+        custom = inner.to_gate()
+        qc = QuantumCircuit(3)
+        qc.append(custom, [0, 1])
+        qc.x(2)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"bill_gate": 1})
+        self.assertEqual(result[1], {"bill_gate": 1})
+        self.assertEqual(result[2], {"x": 1})
+
+    def test_count_ops_per_qubit_control_flow_counts_if_else_at_surface_level(self):
+        """Test count_ops_per_qubit with control-flow instructions."""
+        qc = QuantumCircuit(2, 1)
+        qc.measure(0, 0)
+
+        with qc.if_test((qc.clbits[0], True)):
+            qc.x(0)
+            qc.x(1)
+
+        result = qc.count_ops_per_qubit()
+
+        self.assertEqual(result[0], {"measure": 1, "if_else": 1})
+        self.assertEqual(result[1], {"if_else": 1})
+
     def test_circuit_nonlocal_gates(self):
         """Test num_nonlocal_gates."""
 


### PR DESCRIPTION
### Summary

Adds `QuantumCircuit.count_ops_per_qubit()`, which returns per-qubit operation counts as a `list[dict[str, int]]`. 
The list index corresponds to the qubit index, and each dictionary maps operation names to how many times that operation appears on that qubit. Multi-qubit gates contribute a count to every qubit they touch.

Fixes #12972

### Details and comments

- Rust implementation: `CircuitData::count_ops_per_qubit()` in  `crates/circuit/src/circuit_data.rs`, following the same pattern as the
  existing `count_ops()` method
- Python wrapper: `QuantumCircuit.count_ops_per_qubit()` in  `qiskit/circuit/quantumcircuit.py`
- Python method covered by unit tests, Rust code is not covered (the same as ount_ops())
- Release note added

The return type follows the guidance from the review on #13055:
`Vec<HashMap<&str, usize>>` on the Rust side (auto-converted to `list[dict[str, int]]` by PyO3), using qubit indices as the list position rather than returning qubit objects or strings.

Note: I'm aware of the existing PR #13055 which addresses the same issue.
That PR has been inactive since 2024.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: Claude (PR description formatting, release note text)
- [ ] Some submitted code was generated by:
