### PR TITLE
Fix potential panics in QPY deserialization on malformed payloads

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1061,6 +1061,20 @@ fn add_standalone_vars(
     Ok(())
 }
 
+fn get_bit<'a, T>(bits: &'a [T], index: usize, err_name: &str) -> Result<&'a T, QpyError> {
+    bits.get(index)
+        .ok_or(QpyError::InvalidBit(format!("{err_name}: {index}")))
+}
+
+fn get_bit_mut<'a, T>(
+    bits: &'a mut [T],
+    index: usize,
+    err_name: &str,
+) -> Result<&'a mut T, QpyError> {
+    bits.get_mut(index)
+        .ok_or(QpyError::InvalidBit(format!("{err_name}: {index}")))
+}
+
 fn add_registers_and_bits(
     packed_circuit: &formats::QPYCircuit,
     qpy_data: &mut QPYReadData,
@@ -1099,9 +1113,8 @@ fn add_registers_and_bits(
                             {
                                 if index >= 0 {
                                     // index can be -1, indicating this bit is not in the circuit
-                                    let circuit_qubit = qubits
-                                        .get_mut(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    let circuit_qubit =
+                                        get_bit_mut(&mut qubits, index as usize, "Qubit")?;
                                     *circuit_qubit = Some(qubit);
                                 }
                             }
@@ -1119,9 +1132,8 @@ fn add_registers_and_bits(
                             {
                                 if index >= 0 {
                                     // index can be -1, indicating this bit is not in the circuit
-                                    let circuit_clbit = clbits
-                                        .get_mut(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    let circuit_clbit =
+                                        get_bit_mut(&mut clbits, index as usize, "Clbit")?;
                                     *circuit_clbit = Some(clbit);
                                 }
                             }
@@ -1146,9 +1158,7 @@ fn add_registers_and_bits(
                                 let start = packed_register.start_index;
                                 for i in 0..packed_register.size {
                                     let index = start + i;
-                                    let qubit = qubits
-                                        .get_mut(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    let qubit = get_bit_mut(&mut qubits, index as usize, "Qubit")?;
                                     *qubit = qreg.get(i as usize);
                                 }
                             } else if packed_register.register_attachment == 0 {
@@ -1157,9 +1167,8 @@ fn add_registers_and_bits(
                                 {
                                     if index != u32::MAX {
                                         // index can be -1, indicating this bit is not in the circuit
-                                        let index_qubit = qubits.get_mut(index as usize).ok_or(
-                                            QpyError::InvalidBit(format!("Qubit: {index}")),
-                                        )?;
+                                        let index_qubit =
+                                            get_bit_mut(&mut qubits, index as usize, "Qubit")?;
                                         *index_qubit = Some(qubit);
                                     }
                                 }
@@ -1181,9 +1190,7 @@ fn add_registers_and_bits(
                                 let start = packed_register.start_index;
                                 for i in 0..packed_register.size {
                                     let index = start + i;
-                                    let clbit = clbits
-                                        .get_mut(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Clbit: {index}")))?;
+                                    let clbit = get_bit_mut(&mut clbits, index as usize, "Clbit")?;
                                     *clbit = creg.get(i as usize);
                                 }
                             } else if packed_register.register_attachment == 0 {
@@ -1192,9 +1199,8 @@ fn add_registers_and_bits(
                                 {
                                     if index != u32::MAX {
                                         // index can be -1, indicating this bit is not in the circuit
-                                        let index_clbit = clbits.get_mut(index as usize).ok_or(
-                                            QpyError::InvalidBit(format!("Clbit: {index}")),
-                                        )?;
+                                        let index_clbit =
+                                            get_bit_mut(&mut clbits, index as usize, "Clbit")?;
                                         *index_clbit = Some(clbit);
                                     }
                                 }
@@ -1238,9 +1244,7 @@ fn add_registers_and_bits(
                         .iter()
                         .filter_map(|&index| {
                             if index >= 0 {
-                                let qubit = final_qubit_list
-                                    .get(index as usize)
-                                    .ok_or(QpyError::InvalidBit(format!("Qubit {index}")));
+                                let qubit = get_bit(&final_qubit_list, index as usize, "Qubit");
                                 Some(qubit.cloned())
                             } else {
                                 None
@@ -1256,9 +1260,7 @@ fn add_registers_and_bits(
                         .iter()
                         .filter_map(|&index| {
                             if index >= 0 {
-                                let clbit = final_clbit_list
-                                    .get(index as usize)
-                                    .ok_or(QpyError::InvalidBit(format!("Clbit {index}")));
+                                let clbit = get_bit(&final_clbit_list, index as usize, "Clbit");
                                 Some(clbit.cloned())
                             } else {
                                 None
@@ -1283,9 +1285,7 @@ fn add_registers_and_bits(
                             .iter()
                             .filter_map(|&index| {
                                 if index != u32::MAX {
-                                    let qubit = final_qubit_list
-                                        .get(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Qubit {index}")));
+                                    let qubit = get_bit(&final_qubit_list, index as usize, "Qubit");
                                     Some(qubit.cloned())
                                 } else {
                                     None
@@ -1302,9 +1302,7 @@ fn add_registers_and_bits(
                             .iter()
                             .filter_map(|&index| {
                                 if index != u32::MAX {
-                                    let clbit = final_clbit_list
-                                        .get(index as usize)
-                                        .ok_or(QpyError::InvalidBit(format!("Clbit {index}")));
+                                    let clbit = get_bit(&final_clbit_list, index as usize, "Clbit");
                                     Some(clbit.cloned())
                                 } else {
                                     None

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1099,7 +1099,10 @@ fn add_registers_and_bits(
                             {
                                 if index >= 0 {
                                     // index can be -1, indicating this bit is not in the circuit
-                                    qubits[index as usize] = Some(qubit);
+                                    let circuit_qubit = qubits
+                                        .get_mut(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    *circuit_qubit = Some(qubit);
                                 }
                             }
                             if packed_register.in_circuit != 0 {
@@ -1116,7 +1119,10 @@ fn add_registers_and_bits(
                             {
                                 if index >= 0 {
                                     // index can be -1, indicating this bit is not in the circuit
-                                    clbits[index as usize] = Some(clbit);
+                                    let circuit_clbit = clbits
+                                        .get_mut(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    *circuit_clbit = Some(clbit);
                                 }
                             }
                             if packed_register.in_circuit != 0 {
@@ -1140,7 +1146,10 @@ fn add_registers_and_bits(
                                 let start = packed_register.start_index;
                                 for i in 0..packed_register.size {
                                     let index = start + i;
-                                    qubits[index as usize] = qreg.get(i as usize);
+                                    let qubit = qubits
+                                        .get_mut(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Qubit: {index}")))?;
+                                    *qubit = qreg.get(i as usize);
                                 }
                             } else if packed_register.register_attachment == 0 {
                                 for (qubit, &index) in
@@ -1148,7 +1157,10 @@ fn add_registers_and_bits(
                                 {
                                     if index != u32::MAX {
                                         // index can be -1, indicating this bit is not in the circuit
-                                        qubits[index as usize] = Some(qubit);
+                                        let index_qubit = qubits.get_mut(index as usize).ok_or(
+                                            QpyError::InvalidBit(format!("Qubit: {index}")),
+                                        )?;
+                                        *index_qubit = Some(qubit);
                                     }
                                 }
                             } else {
@@ -1169,7 +1181,10 @@ fn add_registers_and_bits(
                                 let start = packed_register.start_index;
                                 for i in 0..packed_register.size {
                                     let index = start + i;
-                                    clbits[index as usize] = creg.get(i as usize);
+                                    let clbit = clbits
+                                        .get_mut(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Clbit: {index}")))?;
+                                    *clbit = creg.get(i as usize);
                                 }
                             } else if packed_register.register_attachment == 0 {
                                 for (clbit, &index) in
@@ -1177,7 +1192,10 @@ fn add_registers_and_bits(
                                 {
                                     if index != u32::MAX {
                                         // index can be -1, indicating this bit is not in the circuit
-                                        clbits[index as usize] = Some(clbit);
+                                        let index_clbit = clbits.get_mut(index as usize).ok_or(
+                                            QpyError::InvalidBit(format!("Clbit: {index}")),
+                                        )?;
+                                        *index_clbit = Some(clbit);
                                     }
                                 }
                             } else {
@@ -1220,12 +1238,15 @@ fn add_registers_and_bits(
                         .iter()
                         .filter_map(|&index| {
                             if index >= 0 {
-                                Some(final_qubit_list[index as usize].clone())
+                                let qubit = final_qubit_list
+                                    .get(index as usize)
+                                    .ok_or(QpyError::InvalidBit(format!("Qubit {index}")));
+                                Some(qubit.cloned())
                             } else {
                                 None
                             }
                         })
-                        .collect();
+                        .collect::<Result<_, QpyError>>()?;
                     let qreg = QuantumRegister::new_alias(Some(packed_register.name.clone()), bits);
                     qregs.push(qreg);
                 }
@@ -1235,12 +1256,15 @@ fn add_registers_and_bits(
                         .iter()
                         .filter_map(|&index| {
                             if index >= 0 {
-                                Some(final_clbit_list[index as usize].clone())
+                                let clbit = final_clbit_list
+                                    .get(index as usize)
+                                    .ok_or(QpyError::InvalidBit(format!("Clbit {index}")));
+                                Some(clbit.cloned())
                             } else {
                                 None
                             }
                         })
-                        .collect();
+                        .collect::<Result<_, QpyError>>()?;
                     let creg =
                         ClassicalRegister::new_alias(Some(packed_register.name.clone()), bits);
                     cregs.push(creg);
@@ -1259,12 +1283,15 @@ fn add_registers_and_bits(
                             .iter()
                             .filter_map(|&index| {
                                 if index != u32::MAX {
-                                    Some(final_qubit_list[index as usize].clone())
+                                    let qubit = final_qubit_list
+                                        .get(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Qubit {index}")));
+                                    Some(qubit.cloned())
                                 } else {
                                     None
                                 }
                             })
-                            .collect();
+                            .collect::<Result<_, QpyError>>()?;
                         let qreg =
                             QuantumRegister::new_alias(Some(packed_register.name.clone()), bits);
                         qregs.push(qreg);
@@ -1275,12 +1302,15 @@ fn add_registers_and_bits(
                             .iter()
                             .filter_map(|&index| {
                                 if index != u32::MAX {
-                                    Some(final_clbit_list[index as usize].clone())
+                                    let clbit = final_clbit_list
+                                        .get(index as usize)
+                                        .ok_or(QpyError::InvalidBit(format!("Clbit {index}")));
+                                    Some(clbit.cloned())
                                 } else {
                                     None
                                 }
                             })
-                            .collect();
+                            .collect::<Result<_, QpyError>>()?;
                         let creg =
                             ClassicalRegister::new_alias(Some(packed_register.name.clone()), bits);
                         cregs.push(creg);

--- a/releasenotes/notes/fix-panic-on-invalid-qpy-register-f6aa214cbd1c63ac.yaml
+++ b/releasenotes/notes/fix-panic-on-invalid-qpy-register-f6aa214cbd1c63ac.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue in :func:`.qpy.load` where it would potentially panic when
+    parsing a malformed payload that contained register bit indices not defined
+    in the circuit. This will now properly return a :class:`.QpyError` instead.


### PR DESCRIPTION
When reconstructing registers during deserialization the QPY circuit reader in rust was using Vec indexing to update the circuit's bit arrays with register bits. However, this assumed the qpy payload was always correctly formed, but if the payload was malformed or corrupted the index mapping could refer to a non-existent bit index. This would cause a panic from Rust. To avoid the panic and return a meaningful error, this commit switches that indexing syntax to use the get methods and return an error if the index is not present in the vecs being accessed.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [ ] Some submitted code was generated by:

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
