### PR TITLE
#16974 fix TwoQubitBasisDecomposer with approximation_degree=1.0

### DIFF
--- a/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
+++ b/crates/synthesis/src/two_qubit_decompose/basis_decomposer.rs
@@ -679,8 +679,13 @@ impl TwoQubitBasisDecomposer {
         } else {
             basis_fidelity.unwrap_or(self.basis_fidelity)
         };
-        let target_decomposed =
-            TwoQubitWeylDecomposition::new_inner(unitary, Some(DEFAULT_FIDELITY), None)?;
+        // Specializing the target can discard small interactions before basis-gate selection.
+        // Disable that approximation when exact synthesis is requested.
+        let target_decomposed = TwoQubitWeylDecomposition::new_inner(
+            unitary,
+            approximate.then_some(DEFAULT_FIDELITY),
+            None,
+        )?;
         let traces = self.traces(&target_decomposed);
         let best_nbasis = _num_basis_uses.unwrap_or_else(|| {
             traces
@@ -921,8 +926,8 @@ impl TwoQubitBasisDecomposer {
     ///         representing the gate to synthesize
     ///     basis_fidelity (float): The target fidelity of the synthesis. This is a floating point
     ///         value between 1.0 and 0.0.
-    ///     approximate (bool): Whether to enable approximation. If set to false this is equivalent
-    ///         to setting basis_fidelity to 1.0.
+    ///     approximate (bool): Whether to enable approximation. If false, sets basis_fidelity
+    ///         to 1.0 and disables approximate specialization of the target Weyl decomposition.
     ///
     /// Returns:
     ///     DAGCircuit: The decomposed circuit for the given unitary.
@@ -964,8 +969,8 @@ impl TwoQubitBasisDecomposer {
     ///         representing the gate to synthesize
     ///     basis_fidelity (float): The target fidelity of the synthesis. This is a floating point
     ///         value between 1.0 and 0.0.
-    ///     approximate (bool): Whether to enable approximation. If set to false this is equivalent
-    ///         to setting basis_fidelity to 1.0.
+    ///     approximate (bool): Whether to enable approximation. If false, sets basis_fidelity
+    ///         to 1.0 and disables approximate specialization of the target Weyl decomposition.
     ///
     /// Returns:
     ///     CircuitData: The decomposed circuit for the given unitary.

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -523,7 +523,8 @@ class TwoQubitBasisDecomposer:
             unitary (Operator or ndarray): :math:`4 \times 4` unitary to synthesize.
             basis_fidelity (float or None): Fidelity to be assumed for applications of KAK Gate.
                 If given, overrides ``basis_fidelity`` given at init.
-            approximate (bool): Approximates if basis fidelities are less than 1.0.
+            approximate (bool): Whether to allow approximation. If false, ignore basis
+                infidelity and disable approximate specialization of the Weyl decomposition.
             use_dag (bool): If true a :class:`.DAGCircuit` is returned instead of a
                 :class:`QuantumCircuit` when this class is called.
             _num_basis_uses (int): force a particular approximation by passing a number in [0, 3].

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -975,6 +975,34 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
 class TestTwoQubitDecompose(CheckDecompositions):
     """Test TwoQubitBasisDecomposer() for exact/approx decompositions"""
 
+    @combine(
+        gate=[CRXGate, CRYGate, CRZGate],
+        theta=[-1e-4, 1.5e-4],
+        basis_fidelity=[1.0, 0.99],
+        use_dag=[False, True],
+    )
+    def test_exact_small_controlled_rotation(self, gate, theta, basis_fidelity, use_dag):
+        """Exact synthesis preserves small interactions despite their high identity fidelity."""
+        unitary = Operator(gate(theta)).data
+        decomposer = TwoQubitBasisDecomposer(
+            CXGate(), basis_fidelity=basis_fidelity, euler_basis="U"
+        )
+        result = decomposer(unitary, approximate=False, use_dag=use_dag)
+        if use_dag:
+            result = dag_to_circuit(result)
+        np.testing.assert_allclose(Operator(result).data, unitary, rtol=0, atol=1e-12)
+
+    def test_approximate_small_controlled_rotation(self):
+        """Approximate synthesis can still trade a small interaction for fewer basis gates."""
+        unitary = Operator(CRZGate(1e-4)).data
+        decomposer = TwoQubitBasisDecomposer(CXGate(), basis_fidelity=0.99, euler_basis="U")
+        result = decomposer(unitary, approximate=True)
+        self.assertEqual(result.count_ops().get("cx", 0), 0)
+        matrix = Operator(result).data
+        self.assertGreater(np.max(np.abs(matrix - unitary)), 1e-6)
+        fidelity = (abs(np.vdot(unitary, matrix)) ** 2 + 4) / 20
+        self.assertGreaterEqual(fidelity, 0.99)
+
     @combine(seed=range(10), name="test_exact_two_qubit_cnot_decompose_random_{seed}")
     def test_exact_two_qubit_cnot_decompose_random(self, seed):
         """Verify exact CNOT decomposition for random Haar 4x4 unitary (seed={seed})."""

--- a/test/python/transpiler/test_two_qubit_peephole.py
+++ b/test/python/transpiler/test_two_qubit_peephole.py
@@ -111,6 +111,33 @@ class TestTwoQubitPeepholeOptimization(QiskitTestCase):
     """Test TwoQubitPeepholeOptimization."""
 
     @combine(
+        gate=[CRXGate, CRYGate, CRZGate],
+        theta=[-1e-4, 1.5e-4],
+        optimization_level=[None, 2, 3],
+    )
+    def test_exact_small_controlled_rotation(self, gate, theta, optimization_level):
+        """Exact compilation preserves small controlled rotations through two-qubit synthesis."""
+        circuit = QuantumCircuit(2)
+        circuit.append(gate(theta), [0, 1])
+        if optimization_level is None:
+            translated = transpile(circuit, basis_gates=["u", "cx"], optimization_level=0)
+            target = Target.from_configuration(basis_gates=["u", "cx"], num_qubits=2)
+            result = PassManager(
+                [TwoQubitPeepholeOptimization(target, approximation_degree=1.0)]
+            ).run(translated)
+        else:
+            result = transpile(
+                circuit,
+                basis_gates=["u", "cx"],
+                optimization_level=optimization_level,
+                approximation_degree=1.0,
+                seed_transpiler=42,
+            )
+        np.testing.assert_allclose(
+            Operator(result).data, Operator(circuit).data, rtol=0, atol=1e-12
+        )
+
+    @combine(
         bidirectional=[True, False],
         dsc=(
             "test natural_direction works with transpile using a"


### PR DESCRIPTION
`TwoQubitBasisDecomposer` was silently approximating small controlled rotations at optimization levels 2 and 3 with a hardcoded fidelity threshold of 1 - 1e-9, despite `approximation_degree=1.0`.

The fix disables approximate Weyl specialization of the target when `TwoQubitBasisDecomposer` is called with `approximate=False`. Approximate mode retains its previous behavior.

Fixes #16974.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [ ] Some written text was generated by:
- [X] Some submitted code was generated by: Astra

<!-- "Text" includes commit messages, PR descriptions, documentation, comments, etc. -->
