### PR TITLE
Preserve gate qargs in `FindCommutingPauliEvolutions`

### DIFF
--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -12,10 +12,12 @@
 
 """An analysis pass to find evolution gates in which the Paulis commute."""
 from collections import defaultdict
+from collections.abc import Sequence
 
 import numpy as np
 
 from qiskit.exceptions import QiskitError
+from qiskit.circuit import Qubit
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler import TransformationPass
@@ -58,7 +60,7 @@ class FindCommutingPauliEvolutions(TransformationPass):
                     continue
 
                 if self.summands_commute(node.op.operator):
-                    sub_dag = self._decompose_to_2q(dag, node.op)
+                    sub_dag = self._decompose_to_2q(dag, node.op, node.qargs)
 
                     block_op = Commuting2qBlock(set(sub_dag.op_nodes()))
                     wire_order = {
@@ -126,12 +128,15 @@ class FindCommutingPauliEvolutions(TransformationPass):
 
         return edge
 
-    def _decompose_to_2q(self, dag: DAGCircuit, op: PauliEvolutionGate) -> DAGCircuit:
+    def _decompose_to_2q(
+        self, dag: DAGCircuit, op: PauliEvolutionGate, qargs: Sequence[Qubit]
+    ) -> DAGCircuit:
         """Decompose the SparsePauliOp into two-qubit.
 
         Args:
-            dag: The dag needed to get access to qubits.
+            dag: The dag that the returned sub-dag is modelled on.
             op: The operator with all the Pauli terms we need to apply.
+            qargs: The qubits that ``op`` is applied to, in operand order.
 
         Returns:
             A dag made of two-qubit :class:`.PauliEvolutionGate`.
@@ -144,7 +149,7 @@ class FindCommutingPauliEvolutions(TransformationPass):
             required_paulis[(pauli, edge)] += coeff
 
         for (pauli, edge), coeff in required_paulis.items():
-            qubits = [dag.qubits[edge[0]], dag.qubits[edge[1]]]
+            qubits = [qargs[edge[0]], qargs[edge[1]]]
 
             simple_pauli = Pauli(pauli.to_label().replace("I", ""))
 

--- a/releasenotes/notes/fix-pauli-evolution-qargs-4824a3bb4c54d080.yaml
+++ b/releasenotes/notes/fix-pauli-evolution-qargs-4824a3bb4c54d080.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fixed :class:`.FindCommutingPauliEvolutions` reinterpreting the Pauli operands of a
+    :class:`.PauliEvolutionGate` as global qubit indices, which changed the gate when it was
+    applied to qubits in any other order. See
+    `#16860 <https://github.com/Qiskit/qiskit/issues/16860>`.

--- a/test/python/transpiler/test_swap_strategy_router.py
+++ b/test/python/transpiler/test_swap_strategy_router.py
@@ -516,6 +516,24 @@ class TestPauliEvolutionSwapStrategies(QiskitTestCase):
 
         self.assertEqual(circ, self.pm_.run(circ))
 
+    def test_asymmetric_pauli_evolution_reversed_qargs(self):
+        """Test that an asymmetric evolution keeps the qubit order it was applied to."""
+        op = SparsePauliOp.from_list([("XY", 1)])
+
+        circ = QuantumCircuit(2)
+        circ.append(PauliEvolutionGate(op, 0.37), [1, 0])
+
+        swap_strat = SwapStrategy.from_line([0, 1])
+        pm_ = PassManager([FindCommutingPauliEvolutions(), Commuting2qGateRouter(swap_strat)])
+
+        swapped = pm_.run(circ)
+
+        expected = QuantumCircuit(2)
+        expected.append(PauliEvolutionGate(Pauli("XY"), 0.37), (1, 0))
+
+        self.assertEqual(swapped, expected)
+        self.assertEqual(Operator(swapped), Operator(circ))
+
     @data(
         {(0, 1): 0, (2, 3): 0, (1, 2): 1},  # better coloring for the swap strategy
         {(0, 1): 1, (2, 3): 1, (1, 2): 0},  # worse, i.e., less CX cancellation.


### PR DESCRIPTION
Fixes #16860.

`_decompose_to_2q()` takes the local operand indices of each Pauli term and looks them up in `dag.qubits`. That only happens to be right when the `PauliEvolutionGate` was applied to the DAG's qubits in order — otherwise the two-qubit evolutions get rebuilt on the wrong qubits and the pass silently changes the circuit. For example `XY` applied to `[1, 0]` comes out as `XY` on `[0, 1]`, and a dense `ZZ` operator applied to permuted qargs ends up with its terms on the wrong edges.

The fix passes `node.qargs` down and indexes into that instead of `dag.qubits`.

The regression test applies an asymmetric `XY` evolution to `[1, 0]` and checks the routed circuit against the expected one; on a two-qubit line no swaps are involved, so the output should be the same gate on the same qargs. It also checks the unitary is unchanged.

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tools to understand this PR: ChatGPT and Claude
