### PR TITLE
fix: avoid integer overflow in ParameterExpression arithmetic

### DIFF
--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -3547,7 +3547,10 @@ impl Value {
                     if *r < 0 {
                         Value::Real(*e as f64).pow(p)
                     } else {
-                        Value::Int(e.pow(*r as u32))
+                        match u32::try_from(*r).ok().and_then(|exp| e.checked_pow(exp)) {
+                            Some(v) => Value::Int(v),
+                            None => Value::Real((*e as f64).powf(*r as f64)),
+                        }
                     }
                 }
                 Value::Complex(_) => Value::Complex(Complex64::from(*e as f64)).pow(p),
@@ -3814,7 +3817,10 @@ impl Add for Value {
             },
             Value::Int(l) => match rhs {
                 Value::Real(r) => Value::Real(l as f64 + r),
-                Value::Int(r) => Value::Int(l + r),
+                Value::Int(r) => match l.checked_add(r) {
+                    Some(v) => Value::Int(v),
+                    None => Value::Real(l as f64 + r as f64),
+                },
                 Value::Complex(r) => Value::Complex(l as f64 + r),
             },
             Value::Complex(l) => match rhs {
@@ -3848,7 +3854,10 @@ impl Sub for Value {
             },
             Value::Int(l) => match rhs {
                 Value::Real(r) => Value::Real(l as f64 - r),
-                Value::Int(r) => Value::Int(l - r),
+                Value::Int(r) => match l.checked_sub(r) {
+                    Some(v) => Value::Int(v),
+                    None => Value::Real(l as f64 - r as f64),
+                },
                 Value::Complex(r) => Value::Complex(l as f64 - r),
             },
             Value::Complex(l) => match rhs {
@@ -3882,7 +3891,10 @@ impl Mul for Value {
             },
             Value::Int(l) => match rhs {
                 Value::Real(r) => Value::Real(l as f64 * r),
-                Value::Int(r) => Value::Int(l * r),
+                Value::Int(r) => match l.checked_mul(r) {
+                    Some(v) => Value::Int(v),
+                    None => Value::Real(l as f64 * r as f64),
+                },
                 Value::Complex(r) => Value::Complex(l as f64 * r),
             },
             Value::Complex(l) => match rhs {
@@ -3957,7 +3969,10 @@ impl Neg for Value {
     fn neg(self) -> Value {
         match self {
             Value::Real(v) => Value::Real(-v),
-            Value::Int(v) => Value::Int(-v),
+            Value::Int(v) => match v.checked_neg() {
+                Some(n) => Value::Int(n),
+                None => Value::Real(-(v as f64)),
+            },
             Value::Complex(v) => Value::Complex(-v),
         }
     }
@@ -4490,5 +4505,29 @@ mod test {
             5,
         );
         assert!(!extend_rhs(left_mid, 5).eq_exact(&extend_rhs(right_mid, 5)));
+    }
+
+    /// Integer arithmetic on [Value] must not overflow (which panics in debug builds and wraps
+    /// silently in release builds); it should fall back to a float result at the `i64` boundary.
+    #[test]
+    fn test_value_int_arithmetic_saturates_to_real() {
+        let max = Value::Int(i64::MAX);
+        let min = Value::Int(i64::MIN);
+        let two = Value::Int(2);
+        assert_eq!(max + Value::Int(1), Value::Real(i64::MAX as f64 + 1.0));
+        assert_eq!(min - Value::Int(1), Value::Real(i64::MIN as f64 - 1.0));
+        assert_eq!(max * two, Value::Real(i64::MAX as f64 * 2.0));
+        assert_eq!(-min, Value::Real(-(i64::MIN as f64)));
+        // Result overflows `i64` but is finite as a float (3^40 > i64::MAX).
+        assert_eq!(
+            Value::Int(3).pow(&Value::Int(40)),
+            Value::Real(3f64.powf(40.0))
+        );
+        // Exponent too large for `u32`: must fall back rather than truncating the exponent.
+        assert_eq!(Value::Int(1).pow(&Value::Int(1 << 40)), Value::Real(1.0));
+        // Values that stay in range are unchanged.
+        assert_eq!(Value::Int(3) + Value::Int(4), Value::Int(7));
+        assert_eq!(Value::Int(3) * Value::Int(4), Value::Int(12));
+        assert_eq!(Value::Int(2).pow(&Value::Int(10)), Value::Int(1024));
     }
 }

--- a/releasenotes/notes/fix-parameter-int-overflow-89a759f9edd351dd.yaml
+++ b/releasenotes/notes/fix-parameter-int-overflow-89a759f9edd351dd.yaml
@@ -1,0 +1,19 @@
+---
+fixes:
+  - |
+    Fixed a bug where integer-valued :class:`.ParameterExpression` arithmetic
+    could overflow the internal 64-bit integer representation.  Binding a
+    parameter to a large integer and then adding, subtracting, multiplying,
+    negating or exponentiating it (for example via :meth:`.QuantumCircuit.assign_parameters`,
+    the ``global_phase`` of a circuit, or :meth:`.ParameterExpression.numeric`)
+    would panic in debug builds and silently wrap around to an incorrect value
+    in release builds.  Such operations now fall back to a floating-point result
+    when the exact integer result does not fit in a 64-bit integer, for example::
+
+        from qiskit import QuantumCircuit
+        from qiskit.circuit import Parameter
+
+        p = Parameter("p")
+        qc = QuantumCircuit(1)
+        qc.global_phase = p * 2
+        qc.assign_parameters({p: 2**62})  # previously panicked or wrapped


### PR DESCRIPTION
### Summary

Integer arithmetic on `ParameterExpression` overflows the internal `i64`, which panics in debug builds and wraps silently to a wrong value in release builds. It reproduces from the public API:

```python
from qiskit import QuantumCircuit
from qiskit.circuit import Parameter

p = Parameter("p")
qc = QuantumCircuit(1)
qc.global_phase = p * 2
qc.assign_parameters({p: 2**62})   # panics (debug) / silently wraps to a bogus phase (release)
```

Same path is hit by `(p * 2).assign(p, 2**62).numeric()`, `float(p + 2**62 ...)`, `-p` at `i64::MIN`, and `p ** 3` with a large base.

### Cause

In `crates/circuit/src/parameter/symbol_expr.rs`, the `Int`/`Int` branches of `Add`, `Sub`, `Mul`, `Neg` and `Value::pow` use raw `l + r`, `l - r`, `l * r`, `-v` and `e.pow(r as u32)`. The `as u32` also truncates a large exponent before overflowing.

### Fix

Use checked arithmetic and fall back to `Value::Real(f64)` when the exact integer result does not fit in an `i64`. This mirrors the coercion the same operators already apply when mixing `Int` and `Real`, so in-range integer math is unchanged and the boundary degrades to a finite float instead of panicking/wrapping. Values that stay in range keep their exact `Int` result.

One file changed plus a release note. Added a Rust unit test (`test_value_int_arithmetic_saturates_to_real`) covering each operator at the `i64` boundary and confirming in-range results are untouched.

### AI/LLM disclosure

- [ ] No part of this submission is LLM generated.
- [x] Some written text was generated by: Claude (Claude Code), edited and reviewed by me.
- [x] Some submitted code was generated by: Claude (Claude Code); I reviewed the diff, ran the tests, and can explain the change.